### PR TITLE
Card #406 Messages in top bar badly styled, especially on front page (needs width/margin fixes)

### DIFF
--- a/kalite/static/css/khan-lite.css
+++ b/kalite/static/css/khan-lite.css
@@ -254,7 +254,7 @@ li .progress-circle {
 }
 
 .message.error {
-    color: #330000;
+    color: #FFFFFF;
     background-color: #FF3030; 
     border-color: #330000;
 }


### PR DESCRIPTION
Card #406: Fixed, still needs full testing.
I've fixed some of the CSS to make the alerts look a little better. I haven't been able to check out some pages because of the error on securesync pages that I pulled from the develop branch.

https://trello.com/card/messages-in-top-bar-badly-styled-especially-on-front-page-needs-width-margin-fixes/507303596f46cc9a38c1c94f/406
