### PR TITLE
using python2 wherever possible

### DIFF
--- a/kalite/cronstart.sh
+++ b/kalite/cronstart.sh
@@ -1,3 +1,8 @@
+pyexec=`command -v python2`
+if [[ ! -e $pyexec ]]; then
+    pyexec=`command -v python` 
+fi
+
 cd `dirname "${BASH_SOURCE[0]}"`
 pids=`ps aux | grep cronserver.py | grep -v "grep" | awk '{print $2}'`
 
@@ -8,4 +13,4 @@ fi
 
 echo "Starting the cron server in the background."
 
-python cronserver.py &
+$pyexec cronserver.py &

--- a/kalite/graph_models.sh
+++ b/kalite/graph_models.sh
@@ -1,4 +1,9 @@
+pyexec=`command -v python2`
+if [[ ! -e $pyexec ]]; then
+    pyexec=`command -v python` 
+f
+
 cd `dirname "${BASH_SOURCE[0]}"`
-python manage.py graph_models securesync main -g -o model_graph.png
+$pyexec manage.py graph_models securesync main -g -o model_graph.png
 eog model_graph.png
 rm model_graph.png

--- a/kalite/serverstart.sh
+++ b/kalite/serverstart.sh
@@ -1,3 +1,8 @@
+pyexec=`command -v python2`
+if [[ ! -e $pyexec ]]; then
+    pyexec=`command -v python` 
+fi
+
 cd `dirname "${BASH_SOURCE[0]}"`
 if [ -f "runwsgiserver.pid" ];
 then
@@ -14,7 +19,7 @@ if [ "$pids" ]; then
 fi
 
 echo "Running the web server on port 8008."
-python manage.py runwsgiserver host=0.0.0.0 port=8008 threads=50 daemonize=true pidfile=runwsgiserver.pid
+$pyexec manage.py runwsgiserver host=0.0.0.0 port=8008 threads=50 daemonize=true pidfile=runwsgiserver.pid
 echo "The server should now be accessible locally at: http://127.0.0.1:8008/"
 
 ifconfig_path=`command -v ifconfig`


### PR DESCRIPTION
Similarly to #7 I noticed while using ka-lite that there are other places which should use python2. 

With this request ka-lite should always use the correct version of the Python executable.
