### PR TITLE
Fixed running .sh scripts from different directories

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,8 @@ if [ ! -w `dirname "${BASH_SOURCE[0]}"`/kalite ]; then
 	exit 1
 fi
 
-pyexec=`./python.sh`
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+pyexec=`$SCRIPT_DIR/python.sh`
 cd `dirname "${BASH_SOURCE[0]}"`/kalite
 
 if [ -f "database/data.sqlite" ]; then

--- a/kalite/cronstart.sh
+++ b/kalite/cronstart.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-pyexec=`../python.sh`
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+pyexec=`$SCRIPT_DIR/../python.sh`
 
 cd `dirname "${BASH_SOURCE[0]}"`
 pids=`ps aux | grep cronserver.py | grep -v "grep" | awk '{print $2}'`

--- a/kalite/graph_models.sh
+++ b/kalite/graph_models.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-pyexec=`../python.sh`
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+pyexec=`$SCRIPT_DIR/../python.sh`
 
 cd `dirname "${BASH_SOURCE[0]}"`
 $pyexec manage.py graph_models securesync main -g -o model_graph.png

--- a/kalite/runatboot.sh
+++ b/kalite/runatboot.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-pyexec=`../python.sh`
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+pyexec=`$SCRIPT_DIR/../python.sh`
 
 $pyexec manage.py initdconfig > /etc/init.d/kalite
 chmod 755 /etc/init.d/kalite

--- a/kalite/serverstart.sh
+++ b/kalite/serverstart.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-pyexec=`../python.sh`
+SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
+pyexec=`$SCRIPT_DIR/../python.sh`
 
 cd `dirname "${BASH_SOURCE[0]}"`
 if [ -f "runwsgiserver.pid" ];


### PR DESCRIPTION
This should fix the problem described in the following card:

https://trello.com/card/running-install-sh-from-within-another-folder-e-g-install-sh-from-inside-kalite-means-it-can-t-find-the-python-sh-script/507303596f46cc9a38c1c94f/883
