### PR TITLE
Develop

### DIFF
--- a/kalite/serverstart.sh
+++ b/kalite/serverstart.sh
@@ -28,7 +28,7 @@ if [ "$ifconfig_path" == ""  ]; then
 fi
 if [ $ifconfig_path ]; then
     echo "To access it from another connected computer, try the following address(es):"
-    for ip in `$ifconfig_path | grep 'inet' | grep -E '\d+\.\d+\.\d+\.\d+' | grep -v "127.0.0.1" | sed 's/ /:/g' | cut -d: -f2 | awk '{print $1}'`
+    for ip in `$ifconfig_path | grep 'inet' | grep -oE '^[^0-9]+[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | grep -v "127.0.0.1"`
     do
         echo http://$ip:8008/
     done


### PR DESCRIPTION
I used to get an error message on osx when running start.sh:

```
Running the web server on port 8008.
The server should now be accessible locally at: http://127.0.0.1:8008/
To access it from another connected computer, try the following address(es):
usage: grep [-abcDEFGHhIiJLlmnOoPqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
    [-e pattern] [-f file] [--binary-files=value] [--color=when]
    [--context[=num]] [--directories=action] [--label] [--line-buffered]
    [--null] [pattern] [file ...]
```

this patch is meant to fix this without breaking it on linux
