### PR TITLE
local_settings check for all settings

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -34,7 +34,7 @@ DATABASES      = localor("DATABASES", {
             "timeout": 60,
         },
     }
-}
+})
 
 DATA_PATH      = localor("DATA_PATH", PROJECT_PATH + "/static/data/")
 


### PR DESCRIPTION
shortening use of local_settings into function, applying to all settings.

This was necessary for cleanly debugging the registration / activation process.

makes for a nice local_settings.py / settings.py interaction, while keeping settings.py relatively clean

Note that these changes couldn't be exhaustively tested.  The syntax is correct, and am using this code in another branch for testing local and central servers.
