### PR TITLE
Only expose the "Admin" link on distributed servers when DEBUG=True

### DIFF
--- a/kalite/templates/base_distributed.html
+++ b/kalite/templates/base_distributed.html
@@ -42,8 +42,10 @@
     <a href="{% url add_facility_student %}" id="nav_addstudent" class="admin-only {% block addstudent_active %}{% endblock addstudent_active %}" title="Add a student">{% trans "Add Student" %}</a>
     {% comment %}Translators: this will appear in the navigation bar. Please try to keep it a short as possible.{% endcomment %}
     <a href="{% url add_facility_teacher %}" id="nav_addteacher" class="admin-only {% block addteacher_active %}{% endblock addteacher_active %}" title="Add a teacher">{% trans "Add Teacher" %}</a>
+{% if debug %}
     {% comment %}Translators: this will appear in the navigation bar. Please try to keep it a short as possible.{% endcomment %}
     <a href="/admin" id="nav_admin" class="django-user-only {% block admin_active %}{% endblock admin_active %}" title="Visit the admin panel">{% trans "Admin" %}</a>
+{% endif %}
     {% comment %}Translators: this will appear in the navigation bar. Please try to keep it a short as possible.{% endcomment %}
     <a href="{% url update %}" id="nav_update" class="admin-only {% block update_active %}{% endblock update_active %}" title="Update this server with new videos and subtitles">{% trans "Update" %}</a>
     {% comment %}Translators: this will appear in the navigation bar. Please try to keep it a short as possible.{% endcomment %}


### PR DESCRIPTION
Title says it all.  Django admin still accessible via /admin/, for advanced users.  

Threw together some initial documentation to reflect this:
http://kalitewiki.learningequality.org/development/code-documentation/debug-mode
