### PR TITLE
Tool for changing local user passwords

### DIFF
--- a/kalite/securesync/management/commands/changelocalpassword.py
+++ b/kalite/securesync/management/commands/changelocalpassword.py
@@ -1,16 +1,28 @@
 import getpass
+import os
+import random
+import string
 from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import DEFAULT_DB_ALIAS
 
+import settings
 from securesync.models import FacilityUser
 
+
+def generate_random_password(length=10, charset=(string.ascii_letters + string.digits + '!@#$%^&*()')):
+    random.seed = (os.urandom(1024))
+
+    return ''.join(random.choice(charset) for i in range(length))
+    
 
 class Command(BaseCommand):
     option_list = BaseCommand.option_list + (
         make_option('--database', action='store', dest='database',
             default=DEFAULT_DB_ALIAS, help='Specifies the database to use. Default is "default".'),
+        make_option('--noinput', action='store_true', dest='noinput',
+            default=False, help='Generate a new password (10 characters)'),
     )
     help = "Change a LOCAL KA Lite facility user's password"
 
@@ -23,33 +35,36 @@ class Command(BaseCommand):
         return p
 
     def handle(self, *args, **options):
-        if len(args) > 1:
-            raise CommandError("need exactly one or zero arguments for username")
+        if len(args) != 1:
+            raise CommandError("need exactly one argument (username)")
 
         if args:
             username, = args
-        else:
-            username = getpass.getuser()
 
         try:
             u = FacilityUser.objects.using(options.get('database')).get(username=username)
-        except User.DoesNotExist:
+        except FacilityUser.DoesNotExist:
             raise CommandError("user '%s' does not exist" % username)
 
         self.stdout.write("Changing password for user '%s'\n" % u.username)
 
-        MAX_TRIES = 3
-        count = 0
-        p1, p2 = 1, 2  # To make them initially mismatch.
-        while p1 != p2 and count < MAX_TRIES:
-            p1 = self._get_pass()
-            p2 = self._get_pass("Password (again): ")
-            if p1 != p2:
-                self.stdout.write("Passwords do not match. Please try again.\n")
-                count = count + 1
+        if options['noinput']:
+            p1 = generate_random_password()
+            self.stdout.write("Generated new password for user '%s': '%s'\n" % (username, p1))
+            
+        else:
+            MAX_TRIES = 3
+            count = 0
+            p1, p2 = 1, 2  # To make them initially mismatch.
+            while p1 != p2 and count < MAX_TRIES:
+                p1 = self._get_pass()
+                p2 = self._get_pass("Password (again): ")
+                if p1 != p2:
+                    self.stdout.write("Passwords do not match. Please try again.\n")
+                    count = count + 1
 
-        if count == MAX_TRIES:
-            raise CommandError("Aborting password change for user '%s' after %s attempts" % (username, count))
+            if count == MAX_TRIES:
+                raise CommandError("Aborting password change for user '%s' after %s attempts" % (username, count))
 
         u.set_password(p1)
         u.save()

--- a/kalite/securesync/tests.py
+++ b/kalite/securesync/tests.py
@@ -1,7 +1,59 @@
-from django.test import TestCase
+import re
 import unittest
 
+
+from django.test import TestCase
+
 import crypto
+from securesync.models import Facility, FacilityUser, FacilityGroup
+from utils.django_utils import call_command_with_output
+
+
+class ChangeLocalUserPassword(unittest.TestCase):
+    def setUp(self):
+        self.facility = Facility(name="Test Facility")
+        self.facility.save()
+        self.group = FacilityGroup(facility=self.facility, name="Test Class")
+        self.group.full_clean()
+        self.group.save()
+        self.user = FacilityUser(facility=self.facility, username="testuser", first_name="Firstname", last_name="Lastname", group=self.group)
+        self.user.clear_text_password = "testpass" # not used anywhere but by us, for testing purposes
+        self.user.set_password(self.user.clear_text_password)
+        self.user.full_clean()
+        self.user.save()
+    
+    
+    def test_change_password(self):
+        
+        # Now, re-retrieve the user, to check.
+        (out,err,val) = call_command_with_output("changelocalpassword", self.user.username, noinput=True)
+        self.assertEquals(err, "", "no output on stderr")
+        self.assertNotEquals(out, "", "some output on stderr")
+        self.assertEquals(val, 0, "Exit code is zero")
+        
+        match = re.match(r"^.*Generated new password for user '([^']+)': '([^']+)'", out.replace("\n",""), re.MULTILINE)
+        self.assertFalse(match is None, "could not parse stdout")
+
+        user = FacilityUser.objects.get(facility=self.facility, username=self.user.username)
+        self.assertEquals(user.username, match.groups()[0], "Username reported correctly")
+
+        self.assertTrue(user.check_password(match.groups()[1]), "New password works")
+        self.assertFalse(user.check_password(self.user.clear_text_password), "NOT the old password")
+        
+
+    def test_no_user(self):
+        fake_username = self.user.username + "xxxxx"
+        
+        #with self.assertRaises(FacilityUser.DoesNotExist):
+        (out,err,val) = call_command_with_output("changelocalpassword", fake_username, noinput=True)
+
+        self.assertNotIn("Generated new password for user", out, "Did not set password")
+        self.assertNotEquals(err, "", "some output on stderr")
+
+        match = re.match(r"^.*Error: user '([^']+)' does not exist$", err.replace("\n",""), re.M)
+        self.assertFalse(match is None, "could not parse stderr")
+        self.assertEquals(match.groups()[0], fake_username, "Verify printed fake username")
+        self.assertNotEquals(val, 0, "Verify exit code is non-zero")
 
 @unittest.skipIf(not crypto.M2CRYPTO_EXISTS, "Skipping M2Crypto tests as it does not appear to be installed.")
 class TestM2Crypto(unittest.TestCase):

--- a/kalite/utils/django_utils.py
+++ b/kalite/utils/django_utils.py
@@ -1,0 +1,39 @@
+import re
+import sys
+from cStringIO import StringIO
+
+from django.core.management import call_command
+
+
+def call_command_with_output(cmd, *args, **kwargs): 
+    """Run call_command while capturing stdout/stderr and calls to sys.exit"""
+    
+    backups = [sys.stdout, sys.stderr, sys.exit]
+    try:
+        sys.stdout = StringIO()     # capture output
+        sys.stderr = StringIO()
+        sys.exit = lambda exit_code: sys.stderr.write("Exit code: %d" % exit_code) if exit_code else ""
+
+        call_command(cmd, *args, **kwargs)
+
+        out = sys.stdout.getvalue() # release output
+        err = sys.stderr.getvalue() # release err
+        
+        # parse off exit code from stderr
+        match = re.match(r".*Exit code: ([0-9]+)$", err.replace("\n",""), re.M)
+        if match is None:
+            val = 0
+        else:
+            val = int(match.groups()[0])
+            
+            # Having trouble regexp-ing with newlines :(  Here's my hacky solution
+            match = re.match(r"^(.*)__newline__Exit code: [0-9]+$", err.replace("\n", "__newline__"), re.M)
+            assert match is not None
+            err = match.groups()[0].replace("__newline__", "\n")
+
+        return (out,err, val)
+        
+    finally:
+        sys.stdout = backups[0]
+        sys.stderr = backups[1]
+        sys.exit   = backups[2]


### PR DESCRIPTION
I don't think there's any way to do this.  Here's an easy hotfix for supporting that.

I simply copied the code from django's changepassword command, and changed User to FacilityUser.  The interfaces are similar enough that this worked just fine.

See this URL for info about Django's command.
https://docs.djangoproject.com/en/1.4/topics/auth/

@jamalex , could we merge this in as a hotfix on master, to support the dev request?
