### PR TITLE
Avoid installation failure when locale cannot be determined

### DIFF
--- a/python-packages/django/contrib/auth/management/__init__.py
+++ b/python-packages/django/contrib/auth/management/__init__.py
@@ -89,6 +89,10 @@ def get_system_username():
         # (a very restricted chroot environment, for example).
         # UnicodeDecodeError - preventive treatment for non-latin Windows.
         return u''
+    except:
+        # This is just the default;
+        # we should never error just because we can't find the default!
+        return u''
 
 
 def get_default_username(check_db=True):


### PR DESCRIPTION
Hotfix to patch our own fix for Django bug.
https://code.djangoproject.com/ticket/16017
https://code.djangoproject.com/attachment/ticket/16017/16017.diff

We have 2 reports of users hitting this, and one report of people on our side hitting this.

I've tested this manually.
