### PR TITLE
normalizing all paths, to make sure anything from local_settings doesn't...

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -31,9 +31,10 @@ ADMINS         = getattr(local_settings, "ADMINS", ( ("KA Lite Team", CENTRAL_AD
 
 MANAGERS       = getattr(local_settings, "MANAGERS", ADMINS)
 
-PROJECT_PATH   = getattr(local_settings, "PROJECT_PATH", os.path.dirname(os.path.realpath(__file__)))
+PROJECT_PATH   = os.path.realpath(getattr(local_settings, "PROJECT_PATH", os.path.dirname(os.path.realpath(__file__)))) + "/"
 
 LOCALE_PATHS   = getattr(local_settings, "LOCALE_PATHS", (PROJECT_PATH + "/../locale",))
+LOCALE_PATHS   = tuple([os.path.realpath(lp) + "/" for lp in LOCALE_PATHS])
 
 DATABASES      = getattr(local_settings, "DATABASES", {
     "default": {
@@ -45,9 +46,9 @@ DATABASES      = getattr(local_settings, "DATABASES", {
     }
 })
 
-DATA_PATH      = getattr(local_settings, "DATA_PATH", PROJECT_PATH + "/static/data/")
+DATA_PATH      = os.path.realpath(getattr(local_settings, "DATA_PATH", PROJECT_PATH + "/static/data/")) + "/"
 
-CONTENT_ROOT   = getattr(local_settings, "CONTENT_ROOT", PROJECT_PATH + "/../content/")
+CONTENT_ROOT   = os.path.realpath(getattr(local_settings, "CONTENT_ROOT", PROJECT_PATH + "/../content/")) + "/"
 CONTENT_URL    = getattr(local_settings, "CONTENT_URL", "/content/")
 
 # Local time zone for this installation. Choices can be found here:
@@ -66,7 +67,7 @@ USE_I18N       = getattr(local_settings, "USE_I18N", True)
 # calendars according to the current locale
 USE_L10N       = getattr(local_settings, "USE_L10N", False)
 
-MEDIA_ROOT     = getattr(local_settings, "MEDIA_ROOT", PROJECT_PATH + "/static/")
+MEDIA_ROOT     = os.path.realpath(getattr(local_settings, "MEDIA_ROOT", PROJECT_PATH + "/static/")) + "/"
 MEDIA_URL      = getattr(local_settings, "MEDIA_URL", "/static/")
 STATIC_URL     = getattr(local_settings, "STATIC_URL", "/static/")
 
@@ -74,7 +75,7 @@ STATIC_URL     = getattr(local_settings, "STATIC_URL", "/static/")
 SECRET_KEY     = getattr(local_settings, "SECRET_KEY", "8qq-!fa$92i=s1gjjitd&%s@4%ka9lj+=@n7a&fzjpwu%3kd#u")
 
 TEMPLATE_DIRS  = getattr(local_settings, "TEMPLATE_DIRS", (PROJECT_PATH + "/templates",))
-
+TEMPLATE_DIRS  = tuple([os.path.realpath(td) + "/" for td in TEMPLATE_DIRS])
 
 TEMPLATE_CONTEXT_PROCESSORS = (
     "django.contrib.auth.context_processors.auth",


### PR DESCRIPTION
Some of our code depends on having a trailing slash on paths set in settings.py.  However, some of those paths can be overriden by users (e.g. CONTENT_ROOT).

Rather than check for trailing slashes in many places, let's just enforce the trailing slash within settings.py.
