### PR TITLE
moving slug_key and title_key out of settings.py

### DIFF
--- a/kalite/main/api_views.py
+++ b/kalite/main/api_views.py
@@ -5,7 +5,7 @@ from django.utils import simplejson
 from django.db.models import Q
 from annoying.functions import get_object_or_None
 import settings
-from settings import slug_key, title_key
+from utils.topics import slug_key, title_key
 from main import topicdata
 from utils.jobs import force_job, job_status
 from utils.videos import delete_downloaded_files

--- a/kalite/main/views.py
+++ b/kalite/main/views.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import reverse
 from annoying.decorators import render_to
 from annoying.functions import get_object_or_None
 import settings
-from settings import slug_key, title_key
+from utils.topics import slug_key, title_key
 from main import topicdata
 from django.contrib import messages
 from securesync.views import require_admin, facility_required

--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -149,15 +149,3 @@ def add_syncing_models(models):
     for model in models:
         if model not in syncing_models:
             syncing_models.append(model)
-
-slug_key = {
-    "Topic": "id",
-    "Video": "readable_id",
-    "Exercise": "name",
-}
-
-title_key = {
-    "Topic": "title",
-    "Video": "title",
-    "Exercise": "display_name",
-}


### PR DESCRIPTION
Finally found the place where slug_key and title_key belong: utils/topics.py, where they already are! :D

Only required 2 import changes outside of settings.py.  Great! :D
