### PR TITLE
Wrap call to console.log, to avoid errors in browsers without a console object.

### DIFF
--- a/kalite/static/js/kmap-editor.js
+++ b/kalite/static/js/kmap-editor.js
@@ -233,7 +233,9 @@ $(document).ready(function() {
 
     if (vars["topic"]) {
         $.getJSON("/static/data/topicdata/" + vars["topic"] + ".json", function(exerciseLayout) {
-            console.log(exerciseLayout);
+            if (typeof console !== "undefined") {
+                console.log(exerciseLayout);
+            }
             var exercise_ids = $.map(exerciseLayout, function(exercise) { return exercise.name });
             doRequest("/api/get_exercise_logs", exercise_ids).success(function(data) {
                 var exercisesCompleted = {};


### PR DESCRIPTION
This broke Firefox 3.6.16, which is used in the IDOC system for it's browser profile / lock-out features.  It probably broke other browsers that we're not aware of; it caused the second layer of the exercise tree to fail to be rendered.
