### PR TITLE
Workaround for AJAX-based messages

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -183,6 +183,8 @@ if CACHE_TIME or CACHE_TIME is None: # None can mean infinite caching to some fu
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
+# This setting is required for AJAX-based messaging to work in Django 1.4,
+#   due to this bug: https://code.djangoproject.com/ticket/19387
 MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 
 # import these one extra time to overwrite any settings not explicitly looking for local settings


### PR DESCRIPTION
Due to a Django bug, we can't use CookieStorage (nor FallbackStorage, which defaults to CookieStorage) for persisting messages across requests (necessary for AJAX-based messaging).

Fix is simple: use SessionStorage.

See here for details on the bug (fixed in Django 1.5)
https://code.djangoproject.com/ticket/19387
