### PR TITLE
fixing misspelling of caching library function

### DIFF
--- a/kalite/main/management/commands/videodownload.py
+++ b/kalite/main/management/commands/videodownload.py
@@ -78,5 +78,5 @@ class Command(BaseCommand):
     
         # Regenerate all pages, efficiently
         if hasattr(settings, "CACHES"):
-            caching.regenereate_cached_topic_hierarchies(handled_video_ids)
+            caching.regenerate_cached_topic_hierarchies(handled_video_ids)
         


### PR DESCRIPTION
Issue #161 was partially fixed by #163, but missed one function call.  I fix that here.
