### PR TITLE
reduce connection timeout time from 5.0 to 0.5s, for detecting offline status for admins

### DIFF
--- a/kalite/main/views.py
+++ b/kalite/main/views.py
@@ -204,7 +204,7 @@ def easy_admin(request):
     context = {
         "wiki_url" : settings.CENTRAL_WIKI_URL,
         "central_server_host" : settings.CENTRAL_SERVER_HOST,
-        "am_i_online": am_i_online(settings.CENTRAL_WIKI_URL, allow_redirects=False), 
+        "am_i_online": am_i_online(settings.CENTRAL_WIKI_URL, allow_redirects=False, timeout=0.5), 
     }
     return context
     

--- a/kalite/utils/internet.py
+++ b/kalite/utils/internet.py
@@ -26,7 +26,7 @@ class JsonResponse(HttpResponse):
         super(JsonResponse, self).__init__(content, content_type='application/json', *args, **kwargs)
 
     
-def am_i_online(url, expected_val=None, search_string=None, timeout=5, allow_redirects=True):
+def am_i_online(url, expected_val=None, search_string=None, timeout=0.5, allow_redirects=True):
     """Test whether we are online or not.
     returns True or False.  
     Eats all exceptions!

--- a/kalite/utils/videos.py
+++ b/kalite/utils/videos.py
@@ -22,9 +22,9 @@ class DownloadCancelled(Exception):
         return "Download has been cancelled"
 
 
-def video_connection_is_available():
+def video_connection_is_available(timeout=0.5):
     # In danger of failing, if amazon redirects us
-    return utils.internet.am_i_online(download_base_url, allow_redirects=False)
+    return utils.internet.am_i_online(download_base_url, allow_redirects=False, timeout=timeout)
     
 def get_video_ids(topic_tree):
     if topic_tree["kind"] == "Video":


### PR DESCRIPTION
I have no idea what the magic number "should" be, but 0.5s seemed better than 5 seconds (way too long).  Though the connection timeout is 0.5 seconds, when offline it takes longer than that to generate a timeout.

Note that in the case the connection times out, a page refresh might work.  This seems better than, on every request where the online status is checked, page load time is much longer.
