### PR TITLE
Smoother navigation across facility selection / coach report pages

### DIFF
--- a/kalite/coachreports/forms.py
+++ b/kalite/coachreports/forms.py
@@ -5,9 +5,9 @@ class DataForm(forms.Form):
     """Form that represents the schema for data API requests"""
     
     # who?
-    facility_id = forms.CharField(max_length=40),
-    group_id = forms.CharField(max_length=40),
-    user_id = forms.CharField(max_length=40),
+    facility = forms.CharField(max_length=40),
+    group = forms.CharField(max_length=40),
+    user = forms.CharField(max_length=40),
 
     # where?
     topic_path = forms.CharField(max_length=500),

--- a/kalite/coachreports/views.py
+++ b/kalite/coachreports/views.py
@@ -93,7 +93,7 @@ def student_view(request, facility, xaxis="pct_mastery", yaxis="ex:attempts"):
     Student view lists a by-topic-summary of their activity logs.
     """
     
-    user = get_object_or_None(FacilityUser, id=request.REQUEST.get("user_id"))
+    user = get_object_or_None(FacilityUser, id=request.REQUEST.get("user"))
     user = user or request.session.get("facility_user",None)
 
     topics = get_all_midlevel_topics()
@@ -196,14 +196,15 @@ def tabular_view(request, facility, report_type="exercise"):
 
     # get querystring info
     topic_id = request.GET.get("topic", "")
-    group_id = request.GET.get("group_id", "")
-    
     # No valid data; just show generic
-    if not group_id or not topic_id or not re.match("^[\w\-]+$", topic_id):
+    if not topic_id or not re.match("^[\w\-]+$", topic_id):
         return context
 
-    group = get_object_or_404(FacilityGroup, pk=group_id)
-    users = FacilityUser.objects.filter(group=group, is_teacher=False).order_by("last_name", "first_name")
+    group_id = request.GET.get("group", "")
+    if group_id:
+        users = FacilityUser.objects.filter(group=group, is_teacher=False).order_by("last_name", "first_name")
+    else:
+        users = FacilityUser.objects.filter(group__in=groups, is_teacher=False).order_by("last_name", "first_name")
 
     # We have enough data to render over a group of students
     # Get type-specific information

--- a/kalite/static/js/distributed-server.js
+++ b/kalite/static/js/distributed-server.js
@@ -34,5 +34,28 @@ $(function(){
             }
         }
         show_messages(data.messages);
-    });        
+    });
+
+    // load progress data for all videos linked on page, and render progress circles
+    var youtube_ids = $.map($(".progress-circle[data-youtube-id]"), function(el) { return $(el).data("youtube-id") });
+    if (youtube_ids.length > 0) {
+        doRequest("/api/get_video_logs", youtube_ids).success(function(data) {
+            $.each(data, function(ind, video) {
+                var newClass = video.complete ? "complete" : "partial";
+                $("[data-youtube-id='" + video.youtube_id + "']").addClass(newClass);
+            });
+        });
+    }
+
+    // load progress data for all exercises linked on page, and render progress circles
+    var exercise_ids = $.map($(".progress-circle[data-exercise-id]"), function(el) { return $(el).data("exercise-id") });
+    if (exercise_ids.length > 0) {
+        doRequest("/api/get_exercise_logs", exercise_ids).success(function(data) {
+            $.each(data, function(ind, exercise) {
+                var newClass = exercise.complete ? "complete" : "partial";
+                $("[data-exercise-id='" + exercise.exercise_id + "']").addClass(newClass);
+            });
+        });
+    }
+
 });

--- a/kalite/static/js/khan-lite.js
+++ b/kalite/static/js/khan-lite.js
@@ -70,29 +70,30 @@ function clear_messages() {
     return $("#message_container");
 }
 
-$(function() {
+function setGetParam(href, name, val) {
+    // Generic function for changing a querystring parameter in a url
+    var vars = {};
+    var base = href.replace(/([?].*)$/gi, ""); // no querystring
+    var parts = href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
+        vars[key] = value;
+    });
 
-    // load progress data for all videos linked on page, and render progress circles
-    var youtube_ids = $.map($(".progress-circle[data-youtube-id]"), function(el) { return $(el).data("youtube-id") });
-    if (youtube_ids.length > 0) {
-        doRequest("/api/get_video_logs", youtube_ids).success(function(data) {
-            $.each(data, function(ind, video) {
-                var newClass = video.complete ? "complete" : "partial";
-                $("[data-youtube-id='" + video.youtube_id + "']").addClass(newClass);
-            });
-        });
+    if (val == "" || val == "----" || val === undefined) {
+        delete vars[name];
+    } else {
+        vars[name] = val;
     }
 
-    // load progress data for all exercises linked on page, and render progress circles
-    var exercise_ids = $.map($(".progress-circle[data-exercise-id]"), function(el) { return $(el).data("exercise-id") });
-    if (exercise_ids.length > 0) {
-        doRequest("/api/get_exercise_logs", exercise_ids).success(function(data) {
-            $.each(data, function(ind, exercise) {
-                var newClass = exercise.complete ? "complete" : "partial";
-                $("[data-exercise-id='" + exercise.exercise_id + "']").addClass(newClass);
-            });
-        });
+    var url = base + "?";
+    for (key in vars) {
+        url += "&" + key + "=" + vars[key];//         + $.param(vars);
     }
+    return url
+}
 
-
-});
+function setGetParamDict(href, dict) {
+    for (key in dict) {
+         href = setGetParam(href, key, dict[key]);
+    }
+    return href;
+}

--- a/kalite/static/js/purl.js
+++ b/kalite/static/js/purl.js
@@ -1,0 +1,265 @@
+/*
+ * Purl (A JavaScript URL parser) v2.3.1
+ * Developed and maintanined by Mark Perkins, mark@allmarkedup.com
+ * Source repository: https://github.com/allmarkedup/jQuery-URL-Parser
+ * Licensed under an MIT-style license. See https://github.com/allmarkedup/jQuery-URL-Parser/blob/master/LICENSE for details.
+ */
+
+;(function(factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(factory);
+    } else {
+        window.purl = factory();
+    }
+})(function() {
+
+    var tag2attr = {
+            a       : 'href',
+            img     : 'src',
+            form    : 'action',
+            base    : 'href',
+            script  : 'src',
+            iframe  : 'src',
+            link    : 'href'
+        },
+
+        key = ['source', 'protocol', 'authority', 'userInfo', 'user', 'password', 'host', 'port', 'relative', 'path', 'directory', 'file', 'query', 'fragment'], // keys available to query
+
+        aliases = { 'anchor' : 'fragment' }, // aliases for backwards compatability
+
+        parser = {
+            strict : /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,  //less intuitive, more accurate to the specs
+            loose :  /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/ // more intuitive, fails on relative paths and deviates from specs
+        },
+
+        isint = /^[0-9]+$/;
+
+    function parseUri( url, strictMode ) {
+        var str = decodeURI( url ),
+        res   = parser[ strictMode || false ? 'strict' : 'loose' ].exec( str ),
+        uri = { attr : {}, param : {}, seg : {} },
+        i   = 14;
+
+        while ( i-- ) {
+            uri.attr[ key[i] ] = res[i] || '';
+        }
+
+        // build query and fragment parameters
+        uri.param['query'] = parseString(uri.attr['query']);
+        uri.param['fragment'] = parseString(uri.attr['fragment']);
+
+        // split path and fragement into segments
+        uri.seg['path'] = uri.attr.path.replace(/^\/+|\/+$/g,'').split('/');
+        uri.seg['fragment'] = uri.attr.fragment.replace(/^\/+|\/+$/g,'').split('/');
+
+        // compile a 'base' domain attribute
+        uri.attr['base'] = uri.attr.host ? (uri.attr.protocol ?  uri.attr.protocol+'://'+uri.attr.host : uri.attr.host) + (uri.attr.port ? ':'+uri.attr.port : '') : '';
+
+        return uri;
+    }
+
+    function getAttrName( elm ) {
+        var tn = elm.tagName;
+        if ( typeof tn !== 'undefined' ) return tag2attr[tn.toLowerCase()];
+        return tn;
+    }
+
+    function promote(parent, key) {
+        if (parent[key].length === 0) return parent[key] = {};
+        var t = {};
+        for (var i in parent[key]) t[i] = parent[key][i];
+        parent[key] = t;
+        return t;
+    }
+
+    function parse(parts, parent, key, val) {
+        var part = parts.shift();
+        if (!part) {
+            if (isArray(parent[key])) {
+                parent[key].push(val);
+            } else if ('object' == typeof parent[key]) {
+                parent[key] = val;
+            } else if ('undefined' == typeof parent[key]) {
+                parent[key] = val;
+            } else {
+                parent[key] = [parent[key], val];
+            }
+        } else {
+            var obj = parent[key] = parent[key] || [];
+            if (']' == part) {
+                if (isArray(obj)) {
+                    if ('' !== val) obj.push(val);
+                } else if ('object' == typeof obj) {
+                    obj[keys(obj).length] = val;
+                } else {
+                    obj = parent[key] = [parent[key], val];
+                }
+            } else if (~part.indexOf(']')) {
+                part = part.substr(0, part.length - 1);
+                if (!isint.test(part) && isArray(obj)) obj = promote(parent, key);
+                parse(parts, obj, part, val);
+                // key
+            } else {
+                if (!isint.test(part) && isArray(obj)) obj = promote(parent, key);
+                parse(parts, obj, part, val);
+            }
+        }
+    }
+
+    function merge(parent, key, val) {
+        if (~key.indexOf(']')) {
+            var parts = key.split('[');
+            parse(parts, parent, 'base', val);
+        } else {
+            if (!isint.test(key) && isArray(parent.base)) {
+                var t = {};
+                for (var k in parent.base) t[k] = parent.base[k];
+                parent.base = t;
+            }
+            if (key !== '') {
+                set(parent.base, key, val);
+            }
+        }
+        return parent;
+    }
+
+    function parseString(str) {
+        return reduce(String(str).split(/&|;/), function(ret, pair) {
+            try {
+                pair = decodeURIComponent(pair.replace(/\+/g, ' '));
+            } catch(e) {
+                // ignore
+            }
+            var eql = pair.indexOf('='),
+                brace = lastBraceInKey(pair),
+                key = pair.substr(0, brace || eql),
+                val = pair.substr(brace || eql, pair.length);
+
+            val = val.substr(val.indexOf('=') + 1, val.length);
+
+            if (key === '') {
+                key = pair;
+                val = '';
+            }
+
+            return merge(ret, key, val);
+        }, { base: {} }).base;
+    }
+
+    function set(obj, key, val) {
+        var v = obj[key];
+        if (typeof v === 'undefined') {
+            obj[key] = val;
+        } else if (isArray(v)) {
+            v.push(val);
+        } else {
+            obj[key] = [v, val];
+        }
+    }
+
+    function lastBraceInKey(str) {
+        var len = str.length,
+            brace,
+            c;
+        for (var i = 0; i < len; ++i) {
+            c = str[i];
+            if (']' == c) brace = false;
+            if ('[' == c) brace = true;
+            if ('=' == c && !brace) return i;
+        }
+    }
+
+    function reduce(obj, accumulator){
+        var i = 0,
+            l = obj.length >> 0,
+            curr = arguments[2];
+        while (i < l) {
+            if (i in obj) curr = accumulator.call(undefined, curr, obj[i], i, obj);
+            ++i;
+        }
+        return curr;
+    }
+
+    function isArray(vArg) {
+        return Object.prototype.toString.call(vArg) === "[object Array]";
+    }
+
+    function keys(obj) {
+        var key_array = [];
+        for ( var prop in obj ) {
+            if ( obj.hasOwnProperty(prop) ) key_array.push(prop);
+        }
+        return key_array;
+    }
+
+    function purl( url, strictMode ) {
+        if ( arguments.length === 1 && url === true ) {
+            strictMode = true;
+            url = undefined;
+        }
+        strictMode = strictMode || false;
+        url = url || window.location.toString();
+
+        return {
+
+            data : parseUri(url, strictMode),
+
+            // get various attributes from the URI
+            attr : function( attr ) {
+                attr = aliases[attr] || attr;
+                return typeof attr !== 'undefined' ? this.data.attr[attr] : this.data.attr;
+            },
+
+            // return query string parameters
+            param : function( param ) {
+                return typeof param !== 'undefined' ? this.data.param.query[param] : this.data.param.query;
+            },
+
+            // return fragment parameters
+            fparam : function( param ) {
+                return typeof param !== 'undefined' ? this.data.param.fragment[param] : this.data.param.fragment;
+            },
+
+            // return path segments
+            segment : function( seg ) {
+                if ( typeof seg === 'undefined' ) {
+                    return this.data.seg.path;
+                } else {
+                    seg = seg < 0 ? this.data.seg.path.length + seg : seg - 1; // negative segments count from the end
+                    return this.data.seg.path[seg];
+                }
+            },
+
+            // return fragment segments
+            fsegment : function( seg ) {
+                if ( typeof seg === 'undefined' ) {
+                    return this.data.seg.fragment;
+                } else {
+                    seg = seg < 0 ? this.data.seg.fragment.length + seg : seg - 1; // negative segments count from the end
+                    return this.data.seg.fragment[seg];
+                }
+            }
+
+        };
+
+    }
+    
+    purl.jQuery = function($){
+        if ($ != null) {
+            $.fn.url = function( strictMode ) {
+                var url = '';
+                if ( this.length ) {
+                    url = $(this).attr( getAttrName(this[0]) ) || '';
+                }
+                return purl( url, strictMode );
+            };
+
+            $.url = purl;
+        }
+    };
+
+    purl.jQuery(window.jQuery);
+
+    return purl;
+
+});

--- a/kalite/templates/base_distributed.html
+++ b/kalite/templates/base_distributed.html
@@ -5,6 +5,7 @@
 
 {% block basejs %}{{ block.super }}
     <script type="text/javascript" src="{% static 'js/distributed-server.js' %}"></script>
+    <script type="text/javascript" src="{% static 'js/purl.js' %}"></script>
 {% endblock basejs %}
 
 
@@ -74,4 +75,16 @@
         });
     </script>
 {% endif %}
+{% block endjs %}
+<script>
+
+$(function() {
+    // Propagate any facility and group info to the coach reports link
+    var params_dict = { "facility": $.url().param('facility'), "group": $.url().param('group'), }
+    var new_href =  setGetParamDict($("#nav_coachreports").attr("href"), params_dict);
+//    $("#nav_coachreports").attr("href", new_href);
+});
+</script>
+{% endblock endjs %}
+
 {% endblock footerleft %}

--- a/kalite/templates/coachreports/base.html
+++ b/kalite/templates/coachreports/base.html
@@ -34,27 +34,6 @@ h3 {
 
 {% block headjs %}{{ block.super }}
 <script>
-
-function setGetParam(href, name, val) {
-    var vars = {};
-    var base = href.replace(/([?].*)$/gi, ""); // no querystring
-    var parts = href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m, key, value) {
-        vars[key] = value;
-    });
-
-    if (val == "" || val == "----") {
-        delete vars[name];
-    } else {
-        vars[name] = val;
-    }
-
-    var url = base + "?";
-    for (key in vars) {
-        url += "&" + key + "=" + vars[key];//         + $.param(vars);
-    }
-    return url
-}
-
 function generate_current_link() {
     var url = window.location.href + (window.location.search ? window.location.search : "?");
 
@@ -106,7 +85,7 @@ function make_editable(type) {
             <select id="facility">
             {% if facilities %}
                 {% for facility in facilities %}
-                <option value="{{ facility.id }}" {% if form.facility_id == facility.id %}selected{% endif %}>{{ facility }}</option>
+                <option value="{{ facility.id }}" {% if form.facility == facility.id %}selected{% endif %}>{{ facility }}</option>
                 {% endfor %}
             {% else %}
                 <option value="" selected>[{% trans "this device" %}]</option>
@@ -161,7 +140,7 @@ function make_editable(type) {
 </div>
 {% endblock navbar %}
 
-{% block endjs %}
+{% block endjs %}{{ block.super }}
 <script type="text/javascript">
     $(function() {        
         // Make sure that each dropdown has a callback 
@@ -169,9 +148,9 @@ function make_editable(type) {
         $("#group").change(   function() { changeData("group"); });
         $("#facility").change(function() { changeData("facility"); });
 
-        // Select the values in the 
-        $("#group").val("{{ form.group_id }}").change();
-        $("#facility").val("{{ form.facility_id }}").change();
+        // Select the values in the dropdowns
+        $("#group").val("{{ form.group }}").change();
+        $("#facility").val("{{ form.facility }}").change();
     });
 </script>
 {% endblock endjs %}

--- a/kalite/templates/coachreports/base_google_visualization.html
+++ b/kalite/templates/coachreports/base_google_visualization.html
@@ -91,9 +91,9 @@ function plotJsonData(chart_div, base_url, props) {
        NOTE: you have to implement drawJsonChart(chart_div, json, xaxis, yaxis); */
     
     // Scrub data
-    if (!props["facility_id"]) { props["facility_id"] = "{{ form.facility_id }}"; }
-    if (!props["group_id"])    { props["group_id"]    = "{{ form.group_id }}"; }
-    if (!props["user_id"])     { props["user_id"]     = "{{ form.user_id }}"; }
+    if (!props["facility"]) { props["facility"] = "{{ form.facility }}"; }
+    if (!props["group"])    { props["group"]    = "{{ form.group }}"; }
+    if (!props["user"])     { props["user"]     = "{{ form.user }}"; }
     if (!props["topic_path"])  { props["topic_path"]  = {{ form.topic_path|jsonify }}; }
 
     if (!props["xaxis"] || !props["yaxis"] || !props["topic_path"] || props["topic_path"].length==0) { // one of the ---- is selected
@@ -144,9 +144,9 @@ function plotTopics(topic_paths) {
         {
             "xaxis":       $("#xaxis option:selected").val(),
             "yaxis":       $("#yaxis option:selected").val(),
-            "user_id":     "",
-            "group_id":    $("#group option:selected").val(), 
-            "facility_id": $("#facility option:selected").val(),
+            "user":     "",
+            "group":    $("#group option:selected").val(), 
+            "facility": $("#facility option:selected").val(),
             "topic_path":  topic_paths,
         }
     );
@@ -206,8 +206,8 @@ function plotTopics(topic_paths) {
         // Select the values in the 
         $("#xaxis").val("{{ form.xaxis }}").change();
         $("#yaxis").val("{{ form.yaxis }}").change();
-        $("#group").val("{{ form.group_id }}").change();
-        $("#facility").val("{{ form.facility_id }}").change();
+        $("#group").val("{{ form.group }}").change();
+        $("#facility").val("{{ form.facility }}").change();
         
         
         setTimeout(function() {

--- a/kalite/templates/coachreports/landing_page.html
+++ b/kalite/templates/coachreports/landing_page.html
@@ -9,59 +9,49 @@
 {% block headcss %}{{ block.super }}
 <link rel="stylesheet" type="text/css" href="{% static 'css/landing-page.css' %}" />
 <style>
-#options {
-    width:100%;
-}
-.suggested-action {
-    margin: 0 auto;
-    width: 80%;
-}
-.separate {
+    #options {
+        width:100%;
+    }
+    .suggested-action {
+        margin: 0 auto;
+        width: 80%;
+    }
+    .separate {
 
-    display: block;
-    margin-bottom: 0;
-    position: relative;
-    width:30.245746691%;
-    /*width: 320px/1058;*/
-    float: left;
-    padding-bottom: 10px;
-    margin-left:2.835538752%;
-   /* margin-left: 30/1058px;*/
-    min-height: 225px;
-}
-
-.wrapit {
-    max-width: 1058px;
-/*   margin-left: auto;
-    margin-right: auto;*/
-}
-
-.suggested-action-image-link{
-    max-width: 280px;
-}
-
-.suggested-action-title{
-    height: 35px;
-    padding-bottom: 8px;
-    text-align: center;
-}
-
-
-.other {
-    margin-top: 10px;
-    font-size:18px;
-    float:left;
-}
-
-
-.changeable-link{
-    clear:both;
-    font-size: 16px;
-    float:left;
-
-}
-
-
+        display: block;
+        margin-bottom: 0;
+        position: relative;
+        width:30.245746691%;
+        /*width: 320px/1058;*/
+        float: left;
+        padding-bottom: 10px;
+        margin-left:2.835538752%;
+       /* margin-left: 30/1058px;*/
+        min-height: 225px;
+    }
+    .wrapit {
+        max-width: 1058px;
+    /*   margin-left: auto;
+        margin-right: auto;*/
+    }
+    .suggested-action-image-link{
+        max-width: 280px;
+    }
+    .suggested-action-title{
+        height: 35px;
+        padding-bottom: 8px;
+        text-align: center;
+    }
+    .other {
+        margin-top: 10px;
+        font-size:18px;
+        float:left;
+    }
+    .changeable-link{
+        clear:both;
+        font-size: 16px;
+        float:left;
+    }
 </style>
 {% endblock headcss %}
 

--- a/kalite/templates/coachreports/tabular_view.html
+++ b/kalite/templates/coachreports/tabular_view.html
@@ -92,9 +92,9 @@
     {% if users and request_report_type == "student" %}
         <div class="selection">
             <div class="subtitle">{% trans "Select Student" %}</div><select id="student">
-                <option {% if not request.GET.user_id %}selected{% endif %}>----</option>
+                <option {% if not request.GET.user %}selected{% endif %}>----</option>
                 {% for user in users %}
-                    <option value="{{ user.pk }}"{% if request.GET.user_id == user.pk %}selected{% endif %}>{{ user.last_name }} {{ user.first_name }}</option>
+                    <option value="{{ user.pk }}"{% if request.GET.user == user.pk %}selected{% endif %}>{{ user.last_name }} {{ user.first_name }}</option>
                 {% endfor %}
             </select>
         </div>
@@ -150,7 +150,7 @@
                             <tr>
                                 <th class="username">
                                     <span title="{{ student.first_name }} {{ student.last_name }} ({{ student.username }})">
-                                        <div class="student-name"><a href="{% url student_view %}?user_id={{ student.id }}">{{ student.first_name }} {{ student.last_name }}</a></div>
+                                        <div class="student-name"><a href="{% url student_view %}?user={{ student.id }}">{{ student.first_name }} {{ student.last_name }}</a></div>
                                     </span>
                                 </th>
                             </tr>
@@ -245,13 +245,8 @@
     {% endif %}
 </div> 
 
-{% block endjs %}
-{{ block.super }}
-{% endblock endjs %}
-
+{% block endjs %}{{ block.super }}
 <script>
-
-
 $(function() {
 
     $("#report_type").change(function(){
@@ -259,17 +254,13 @@ $(function() {
     });
 
     $("#student").change(function(){
-        window.location.href = setGetParam(window.location.href, "user_id", $("#student option:selected").val());
+        window.location.href = setGetParam(window.location.href, "user", $("#student option:selected").val());
     });
 
     $("#topic").change(function(){
         window.location.href = setGetParam(window.location.href, "topic", $("#topic option:selected").val());
     });
 
-    $("#group").change(function(){
-        window.location.href = setGetParam(window.location.href, "group_id", $("#group option:selected").val()); 
-    });
-    
     // Selector to toggle visible elements is stored in each option value
     cell_height = 27;
     $("#disp_options").change(function(){
@@ -302,6 +293,7 @@ $(function() {
     
 });
 </script>
+{% endblock endjs %}
 {% endblock content %}
 
   

--- a/kalite/utils/decorators.py
+++ b/kalite/utils/decorators.py
@@ -85,10 +85,10 @@ def authorized_login_required(handler):
         if user.is_superuser:
             return handler(request, *args, **kwargs)
         
-        org = None; org_id      = kwargs.get("org_id", None)
-        zone = None; zone_id     = kwargs.get("zone_id", None)
-        device = None; device_id   = kwargs.get("device_id", None)
-        facility = None; facility_id = kwargs.get("facility_id", None)
+        org = None; org_id      = kwargs.get("org", None)
+        zone = None; zone_id     = kwargs.get("zone", None)
+        device = None; device_id   = kwargs.get("device", None)
+        facility = None; facility_id = kwargs.get("facility", None)
         
         # Validate device through zone
         if device_id:


### PR DESCRIPTION
Our coach report pages used querystring params facility_id/group_id/user_id.  However, the standard for the app is facility/group/user.  I've migrated the coachreports app to follow this pre-existing convention, which makes the interaction between require_facility and coachreports work more smoothly.

I've also dabbled in a few other things along the way:
- Make the coach reports header link add the relevant querystring args dynamically, if they exist
- Make the tabular view work when no group is specified
- Probably some other good stuff.
