### PR TITLE
improving user experience when failing to sign up due to no facility.

### DIFF
--- a/kalite/securesync/views.py
+++ b/kalite/securesync/views.py
@@ -53,14 +53,19 @@ def facility_required(handler):
                     request,
                     _("To continue, you must first add a facility (e.g. for your school). ")
                     + _("Please use the form below to add a facility."))
+                
+                # Redirect admins to add a facility
+                redir_url = reverse("add_facility")
+                redir_url = set_query_params(redir_url, {"prev": request.META.get("HTTP_REFERER", "")})
+                return HttpResponseRedirect(redir_url)
+
             else:
                 messages.error(
                     request,
                     _("You must first have the administrator of this server log in below to add a facility.")
                 )
-            redir_url = reverse("add_facility")
-            redir_url = set_query_params(redir_url, {"prev": request.META.get("HTTP_REFERER", "")})
-            return HttpResponseRedirect(redir_url)
+                # Nothing students can do, except to watch videos without a login.
+                return HttpResponseRedirect(reverse("homepage"))
 
         else:
             facility = get_facility_from_request(request)


### PR DESCRIPTION
Current UX when clicking "sign up" before an admin has added a facility assumes that it's an admin trying to sign up.  However, I think (a) that's not necessary, (b) that's not likely, and (c) we should support the case where no facility is ever created.

To do that, instead of emitting admin-focused errors and redirects, do something that makes sense for both.  See "before" (old behavior) and "after" (new behavior) screen shots below.  I think this makes more sense for end-users.

Before (Clicked on "Sign up"):
![screen shot 2013-06-29 at 12 07 06 pm](https://f.cloud.github.com/assets/4072455/726367/e8963064-e0ef-11e2-92a6-bec33e7f9e33.png)

Afte (clicked on "Sign up")r:
![screen shot 2013-06-29 at 12 07 43 pm](https://f.cloud.github.com/assets/4072455/726368/f036cef0-e0ef-11e2-85f9-7d59c6fb80f6.png)
