### PR TITLE
Don't ask at install whether user wants to create a superuser; just do it.

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -63,7 +63,8 @@ echo Please choose a username and password for the admin account on this device.
 echo You must remember this login information, as you will need to enter it to
 echo administer this installation of KA Lite.
 echo.
-python manage.py createsuperuser
+python manage.py createsuperuser --email=dummy@learningequality.org
+echo.
 
 set /p name=Please enter a name for this server (or, press Enter to use the default): 
 set /p description=Please enter a description for this server (or, press Enter to leave blank): 

--- a/install.sh
+++ b/install.sh
@@ -106,7 +106,8 @@ echo "Please choose a username and password for the admin account on this device
 echo "You must remember this login information, as you will need to enter it to"
 echo "administer this installation of KA Lite."
 echo
-$pyexec manage.py createsuperuser
+$pyexec manage.py createsuperuser --email=dummy@learningequality.org
+echo
 
 hostname=`uname -n`
 echo -n "Please enter a name for this server (or, press Enter to use '$hostname'): "


### PR DESCRIPTION
Addresses issue #205, to make sure we always end up with a superuser after every installation.

Tested on Linux; @ruimalheiro, can you test on Windows?
