### PR TITLE
Only show links to the Django admin interface if we're in debug mode.

### DIFF
--- a/kalite/main/views.py
+++ b/kalite/main/views.py
@@ -20,7 +20,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
 import settings
-import local_settings
 from config.models import Settings
 from main import topicdata
 from main.models import VideoLog, ExerciseLog, VideoFile
@@ -215,7 +214,6 @@ def easy_admin(request):
         "wiki_url" : settings.CENTRAL_WIKI_URL,
         "central_server_host" : settings.CENTRAL_SERVER_HOST,
         "am_i_online": am_i_online(settings.CENTRAL_WIKI_URL, allow_redirects=False), 
-        "check_debug_mode" : local_settings.DEBUG,
     }
     return context
     

--- a/kalite/templates/admin_distributed.html
+++ b/kalite/templates/admin_distributed.html
@@ -75,8 +75,8 @@ td.title {
         </tr>
         {% endif %}
 
-        {% if user.is_superuser %}{% comment "Django-admins only" %}{% endcomment %}
-        {% if check_debug_mode %}
+        {% if user.is_superuser and settings.DEBUG %}{% comment "Django-admins and in debug mode" %}{% endcomment %}
+        
         <tr>
             <td class="title" colspan="2">
                 <h2>{% trans "Advanced User Tools" %}</h2>
@@ -92,7 +92,6 @@ td.title {
                 <span class="warn">({% trans "Warning: changing database values can break your KA Lite installation!" %})</span>
             </td>
         </tr>
-        {% endif %}
         {% endif %}
     </table>
 </div>


### PR DESCRIPTION
This would solve https://github.com/learningequality/ka-lite/issues/230. Thanks @ruimalheiro  to help me. 
