### PR TITLE
full clean before signing (to make sure what we sign is the data that we'll keep)

### DIFF
--- a/kalite/securesync/models.py
+++ b/kalite/securesync/models.py
@@ -125,10 +125,11 @@ class SyncedModel(models.Model):
         Get all of the relevant fields of this model into a single string (self._hashable_representation()),
         then sign it with the specified device (if specified), or the current device.
         """
-        self.full_clean()  # make sure the model data is of the appropriate types
         if not self.id:
             self.id = self.get_uuid()
         self.signed_by = device or Device.get_own_device()
+
+        self.full_clean()  # make sure the model data is of the appropriate types
         self.signature = self.signed_by.get_key().sign(self._hashable_representation())
 
     def verify(self):


### PR DESCRIPTION
When we sign, we need to sign a hashable_representation of the data that reflects what will be stored in the database.  To ensure that, we need to call full_clean on the model before signing it.

This bug is a general concern.  The current behavior was causing UserLogSummary objects to fail under certain scenarios, where total_seconds (an integer) was set to a float (and then converted to an int during full_clean / save).

To reproduce the bug:
- Set up syncing central and distributed servers
- on the distributed server, run `python manage.py generaterealdata` (you don't have to wait for the full data to generate, just until at least one exercise log is created)
- on the distributed server, run `python syncmodels`
- You will see failures (for UserLogSummary objects)

An alternate way to reproduce (not requiring a central server)
- on the distributed server, run `python manage.py generaterealdata` (you don't have to wait for the full data to generate, just until at least one exercise log is created)
- run `python manage.py shell_plus`
- enter command `[uls.verify() for uls in UserLogSummary.objects.all()]
- This should return an array of False.

Testing done:
- I reproduced both scenarios above, and verified that they are fixed here.  I will do a separate pull request to address the (independent, but interacting) UserLogSummary issue.
