### PR TITLE
making UserLog-related admin conditionally available

### DIFF
--- a/kalite/main/admin.py
+++ b/kalite/main/admin.py
@@ -1,12 +1,12 @@
 from django.contrib import admin
-from models import *
 
+import settings
+from models import *
 
 class VideoLogAdmin(admin.ModelAdmin):
     list_display = ("youtube_id", "user", "points", "total_seconds_watched", "complete",)
     list_filter = ("youtube_id", "user", "complete",)
 admin.site.register(VideoLog, VideoLogAdmin)
-
 
 class ExerciseLogAdmin(admin.ModelAdmin):
     list_display = ("exercise_id", "user", "streak_progress", "complete",)
@@ -15,17 +15,20 @@ admin.site.register(ExerciseLog, ExerciseLogAdmin)
 
 class UserLogAdmin(admin.ModelAdmin):
     pass
-admin.site.register(UserLog, UserLogAdmin)
-    
+if settings.USER_LOG_MAX_RECORDS:  # only enable admin if the feature is enabled.
+    admin.site.register(UserLog, UserLogAdmin)
+
+class UserLogSummaryAdmin(admin.ModelAdmin):
+    pass
+if settings.USER_LOG_MAX_RECORDS:  # only enable admin if the feature is enabled.
+    admin.site.register(UserLogSummary, UserLogSummaryAdmin)
+
 class VideoFileAdmin(admin.ModelAdmin):
     list_display = ("youtube_id", "flagged_for_download", "download_in_progress", "cancel_download", "percent_complete",)
     list_filter = ("flagged_for_download", "download_in_progress", "flagged_for_subtitle_download", "subtitle_download_in_progress",)
 admin.site.register(VideoFile, VideoFileAdmin)
 
 class LanguagePackAdmin(admin.ModelAdmin):
-	list_display = ("lang_id", "lang_name")
-	list_filter = ("lang_id", "lang_name")
+    list_display = ("lang_id", "lang_name")
+    list_filter = ("lang_id", "lang_name")
 admin.site.register(LanguagePack, LanguagePackAdmin)
-
-
-


### PR DESCRIPTION
UserLog is disabled by default, but one objects' admin was available by default, and the other not at all.

Make both available any time the functionality is enabled.
