### PR TITLE
Central server production port

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -29,7 +29,7 @@ LOG.setLevel(logging.DEBUG*DEBUG + logging.INFO*(1-DEBUG))
 INTERNAL_IPS   = getattr(local_settings, "INTERNAL_IPS", ("127.0.0.1",))
 
 # TODO(jamalex): currently this only has an effect on Linux/OSX
-PRODUCTION_PORT = getattr(local_settings, "PRODUCTION_PORT", 8008)
+PRODUCTION_PORT = getattr(local_settings, "PRODUCTION_PORT", 8008 if not CENTRAL_SERVER else 8001)
 
 CENTRAL_SERVER = getattr(local_settings, "CENTRAL_SERVER", False)
 


### PR DESCRIPTION
PRODUCTION_PORT setting is the default port used when starting the server.  It doesn't check whether CENTRAL_SERVER is True or not.

Now, default PRODUCTION_PORT = 8008 for distributed servers, 8001 for central servers.  

Note: 8001 instead of 80 for central servers, so that this fits our most common scenario (testing) and since our ACTUAL central server doesn't start using Python.

To test:
- Pull onto a central server test server, then run ./start.sh--see that it starts on port 8001.
