### PR TITLE
Sandboxing admin of "headless zones" dummy organization

### DIFF
--- a/kalite/templates/central/org_management.html
+++ b/kalite/templates/central/org_management.html
@@ -189,11 +189,14 @@
 								<div class="clearfix"></div>
 							{% endfor %}
 							<div class="clearfix"></div>
+                            {% if org.name != HEADLESS_ORG_NAME %}
 							<form method="link" action="{% url zone_form org_id=org.id zone_id='new' %}">
 								<input class="add" type="submit" value="Create a new zone">
 							</form>
+						    {% endif %}
 						</div>
 						<div class="members">
+                            {% if org.name != HEADLESS_ORG_NAME %}
 							<h4 class="title floatleft">Organization Admins</h4><span class="glossary-link nudge-left" title="An Organization Admin is a user responsible for overseeing an organization."></span>
 							<div class="clearfix"></div>
 							{% for member in org.get_members %}
@@ -240,6 +243,7 @@
 									{% endfor %}
 								</form>
 							</div>
+							{% endif %}
 					</div>
 					<div class="clearfix"></div>
 					</div>


### PR DESCRIPTION
This pull request addresses issue #303.

Sandbox organization actions in the headless zones:
- Don't allow the creation of new headless zones (what would be the purpose??)
- Don't allow inviting or revoking access (just superusers)
