### PR TITLE
ignore validation errors in UserLog

### DIFF
--- a/kalite/main/models.py
+++ b/kalite/main/models.py
@@ -4,6 +4,7 @@ from annoying.functions import get_object_or_None
 from dateutil import relativedelta
 
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import Sum
 
@@ -34,9 +35,12 @@ class VideoLog(SyncedModel):
                 self.completion_timestamp = datetime.now()
                 self.completion_counter = Device.get_own_device().get_counter()
 
-            # Tell logins that they are still active.
+            # Tell logins that they are still active (ignoring validation failures).
             #   TODO(bcipolli): Could log video information in the future.
-            UserLog.update_user_activity(self.user, activity_type="login", update_datetime=(self.completion_timestamp or datetime.now()))
+            try:
+                UserLog.update_user_activity(self.user, activity_type="login", update_datetime=(self.completion_timestamp or datetime.now()))
+            except ValidationError as e:
+                logging.debug("Failed to update userlog during video: %s" % e)
 
         super(VideoLog, self).save(*args, **kwargs)
 
@@ -76,11 +80,13 @@ class ExerciseLog(SyncedModel):
                 self.completion_counter = Device.get_own_device().get_counter()
                 self.attempts_before_completion = self.attempts
 
-            # Tell logins that they are still active.
+            # Tell logins that they are still active (ignoring validation failures).
             #   TODO(bcipolli): Could log exercise information in the future.
-            UserLog.update_user_activity(self.user, activity_type="login", update_datetime=(self.completion_timestamp or datetime.now()))
-
-        super(ExerciseLog, self).save(*args, **kwargs)
+            try:
+                UserLog.update_user_activity(self.user, activity_type="login", update_datetime=(self.completion_timestamp or datetime.now()))
+            except ValidationError as e:
+                logging.debug("Failed to update userlog during exercise: %s" % e)
+            super(ExerciseLog, self).save(*args, **kwargs)
 
     def get_uuid(self, *args, **kwargs):
         namespace = uuid.UUID(self.user.id)
@@ -305,8 +311,8 @@ class UserLog(models.Model):  # Not sync'd, only summaries are
 
         # Create a new entry
         cur_user_log_entry = cls(user=user, activity_type=activity_type, start_datetime=start_datetime, last_active_datetime=start_datetime)
-        cur_user_log_entry.save()
 
+        cur_user_log_entry.save()
         return cur_user_log_entry
 
 
@@ -333,6 +339,7 @@ class UserLog(models.Model):  # Not sync'd, only summaries are
 
         logging.debug("%s: UPDATE activity (%d) @ %s"%(user.username,activity_type,update_datetime))
         cur_user_log_entry.last_active_datetime = update_datetime
+
         cur_user_log_entry.save()
 
 

--- a/kalite/securesync/views.py
+++ b/kalite/securesync/views.py
@@ -8,7 +8,9 @@ from django.contrib import messages
 from django.contrib.auth import authenticate, login as auth_login, logout as auth_logout
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
+from django.db import models
 from django.http import HttpResponse, HttpResponseNotFound, HttpResponseRedirect, HttpResponseServerError
 from django.shortcuts import get_object_or_404
 from django.utils.html import strip_tags
@@ -21,6 +23,7 @@ from securesync import crypto
 from securesync.api_client import SyncClient
 from securesync.forms import RegisteredDevicePublicKeyForm, FacilityUserForm, LoginForm, FacilityForm, FacilityGroupForm
 from securesync.models import SyncSession, Device, Facility, FacilityGroup, Zone
+from settings import LOG as logging
 from utils.jobs import force_job
 from utils.decorators import require_admin, central_server_only, distributed_server_only, facility_required, facility_from_request
 from utils.internet import set_query_params
@@ -296,7 +299,10 @@ def login(request, facility):
         if form.is_valid():
             user = form.get_user()
 
-            UserLog.begin_user_activity(user, activity_type="login")  # Success! Log the event
+            try:
+                UserLog.begin_user_activity(user, activity_type="login")  # Success! Log the event (ignoring validation failures)
+            except ValidationError as e:
+                logging.debug("Failed to end_user_activity upon logout: %s" % e)
             request.session["facility_user"] = user
             messages.success(request, _("You've been logged in! We hope you enjoy your time with KA Lite ") +
                                         _("-- be sure to log out when you finish."))
@@ -324,7 +330,12 @@ def login(request, facility):
 @distributed_server_only
 def logout(request):
     if "facility_user" in request.session:
-        UserLog.end_user_activity(request.session["facility_user"], activity_type="login")
+        # Logout, ignore any errors.
+        try:
+            UserLog.end_user_activity(request.session["facility_user"], activity_type="login")
+        except ValidationError as e:
+            logging.debug("Failed to end_user_activity upon logout: %s" % e)
+
         del request.session["facility_user"]
     auth_logout(request)
     next = request.GET.get("next", reverse("homepage"))


### PR DESCRIPTION
Issue:
UserLog updates can throw errors--particularly if a user is deleted while logged in.

This code can be made more robust by catching these validation errors.  Since nothing can be done, just catching them and logging a console error is best--let the procedure complete (for example, logout) rather than fail due to in-process logging.

Changes:
- Wrap all calls into UserLog with try...catch for Django validation errors.  Ignore the errors (logging to console.

Potential Impact:
Extremely low.  THis feature is off by default (and so would never throw), and these types of errors are rare anyway.
