### PR TITLE
Quick fix to prevent a nav bar display error on Android browsers.

### DIFF
--- a/kalite/templates/base_distributed.html
+++ b/kalite/templates/base_distributed.html
@@ -37,7 +37,7 @@
 </span>
 <span class="dropdown topic-browser-dropdown logged-in-only">
     {% comment %}Translators: this will appear in the navigation bar. Please try to keep it a short as possible.{% endcomment %}
-    <a href="{% url student_view %}" id="logged-in-name" class="not-admin-only {% block selfreports_active %}{% endblock selfreports_active %}"></a>
+    <a href="{% url student_view %}" id="logged-in-name" class="not-admin-only {% block selfreports_active %}{% endblock selfreports_active %}">&nbsp;</a>
     <a href="{% url logout %}" id="logout" title="Logout">&nbsp;{% trans "Logout" %}</a></span>
 
 {% endblock sitewide_navigation %}


### PR DESCRIPTION
This addresses issue #371.

Low-risk, high-impact on Android deployments, which is why I'm targeting 0.10
