### PR TITLE
missing HttpResponseForbidden import :(

### DIFF
--- a/kalite/main/views.py
+++ b/kalite/main/views.py
@@ -10,7 +10,7 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.management import call_command
 from django.core.urlresolvers import reverse
 from django.db.models import Sum
-from django.http import HttpResponse, HttpResponseNotFound, HttpResponseRedirect, Http404, HttpResponseServerError
+from django.http import HttpResponse, HttpResponseForbidden, HttpResponseNotFound, HttpResponseRedirect, Http404, HttpResponseServerError
 from django.shortcuts import render_to_response, get_object_or_404, redirect, get_list_or_404
 from django.template import RequestContext
 from django.template.loader import render_to_string


### PR DESCRIPTION
This must have been lost during merge conflict resolution, as this was tested thoroughly before the control_panel check checkin.

Nonetheless, we have a missing import that is hit when a PermissionDenied exception is thrown.  Adding it to the import list fixed everything!
