### PR TITLE
Open external link in new window

### DIFF
--- a/kalite/templates/admin_distributed.html
+++ b/kalite/templates/admin_distributed.html
@@ -79,11 +79,11 @@ td.title {
             </td>
         </tr>
         <tr>
-            <td class="link"><a href="{{wiki_url}}" target=_blank>KA Lite Wiki</a></td>
+            <td class="link"><a href="{{wiki_url}}" target="_blank">KA Lite Wiki</a></td>
             <td class="desc"> {% trans "Contains the latest information setting up and using KA Lite." %}</td>
         </tr>
         <tr>
-            <td class="link"><a href="http://{{central_server_host}}/faq" target=_blank>FAQ</a></td>
+            <td class="link"><a href="http://{{central_server_host}}/faq" target="_blank">FAQ</a></td>
             <td class="desc">{% trans "Contains the latest FAQ for troubleshooting" %}</td>
         </tr>
         {% endif %}

--- a/kalite/templates/central/base_central.html
+++ b/kalite/templates/central/base_central.html
@@ -27,10 +27,10 @@ article {
 {% block sitewide_navigation %}
 	<span class="dropdown topic-browser-dropdown">
         <a href="{% url homepage %}" id="nav_home" class="{% block home_active %}{% endblock home_active %}">Home</a>
-        <a href="{% url wiki path='installation' %}" id="nav_install" class="{% block install_active %}{% endblock install_active %}">Install</a>
+        <a href="{% url wiki path='installation' %}" id="nav_install" class="{% block install_active %}{% endblock install_active %}" target="_blank">Install</a>
         <a href="{% url faq_topic_list %}" id="nav_faq" class="{% block faq_active %}{% endblock faq_active %}">FAQ</a>
         <a href="{% url contact_wizard %}" id="nav_contact" class="{% block contact_active %}{% endblock contact_active %}">Contact</a>
-        <a href="{% url about %}" id="nav_aboutus" class="{% block aboutus_active %}{% endblock aboutus_active %}" target=blank>About</a>
+        <a href="{% url about %}" id="nav_aboutus" class="{% block aboutus_active %}{% endblock aboutus_active %}" target="_blank">About</a>
     {% if user.is_authenticated %}
         {% if user.is_superuser %}
         <a href="{% url admin:index %}" id="nav_admin" class="{% block admin_active %}{% endblock admin_active %}">Admin</a>

--- a/kalite/templates/central/homepage.html
+++ b/kalite/templates/central/homepage.html
@@ -622,7 +622,7 @@ article {
             </div>
             <div class="button-section">
 
-                <a href="{{ wiki_url }}installation">
+                <a href="{{ wiki_url }}installation" target="_blank">
 
                     <button id="get-started-button">
                        Install now!


### PR DESCRIPTION
This fix the issue for https://github.com/learningequality/ka-lite/issues/382
I didn't make install button to be external link, because we had a branch of install_wizard that doesn't use wiki. I think install page shouldn't fully rely on wiki, If we can't get install wizard pull in 0.10, we can probably copy those installation wiki content in KA-Lite tamplate
