### PR TITLE
raise Http404, not return

### DIFF
--- a/kalite/utils/decorators.py
+++ b/kalite/utils/decorators.py
@@ -21,7 +21,7 @@ def central_server_only(handler):
     """
     def wrapper_fn(*args, **kwargs):
         if not settings.CENTRAL_SERVER:
-            return Http404("This path is only available on the central server.")
+            raise Http404("This path is only available on the central server.")
         return handler(*args, **kwargs)
     return wrapper_fn
 
@@ -32,7 +32,7 @@ def distributed_server_only(handler):
     """
     def wrapper_fn(*args, **kwargs):
         if settings.CENTRAL_SERVER:
-            return Http404(_("This path is only available on distributed servers."))
+            raise Http404(_("This path is only available on distributed servers."))
         return handler(*args, **kwargs)
     return wrapper_fn
 


### PR DESCRIPTION
This was introduced in a previous checkin, migrating from HttpResponseNotFound (response) to Http404 (exception), in order to return API responses properly:
https://github.com/learningequality/ka-lite/commit/97d4de14ac16a5a9b2ff2d82aaee7bc748416cc5

Exceptions are raised, not returned.  Fixed here.

2 word change, very simple!
