### PR TITLE
Added management command to display Nginx frontend proxy config.

### DIFF
--- a/kalite/main/management/commands/nginxconfig.py
+++ b/kalite/main/management/commands/nginxconfig.py
@@ -5,8 +5,8 @@ import settings
 
 config_template = """
 
-// In your local_settings.py file, set PRODUCTION_PORT = 7007
-// Then, add the following to /etc/nginx/sites-enabled/kalite:
+# In your local_settings.py file, set PRODUCTION_PORT = 7007
+# Then, add the following to /etc/nginx/sites-enabled/kalite:
 
 upstream kalite {
     server 127.0.0.1:7007;
@@ -17,8 +17,8 @@ proxy_temp_path /var/cache/nginx/tmp;
 
 server {
 
-    // You may change the following port (8008) to something else,
-    // if you want the website to be accessible at a different port:
+    # You may change the following port (8008) to something else,
+    # if you want the website to be accessible at a different port:
     listen 8008;
 
     location /static {
@@ -43,7 +43,6 @@ server {
     }
 
 }
-
 
 """
 


### PR DESCRIPTION
This is a utility management command that doesn't touch any other code, so I wanted to get it into 0.10.

Basically, it just outputs the recommended Nginx config, filling in the paths to point to wherever this copy of KA Lite was actually installed.
