### PR TITLE
putting @api_handle_error_with_json decorator closest to function body.

### DIFF
--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -258,11 +258,13 @@ def convert_topic_tree_for_dynatree(node, level=0):
 
 ####### view endpoints #######
 
+@api_handle_error_with_json
 def get_topic_tree(request, topic_path):
     return JsonResponse(convert_topic_tree_for_dynatree(get_topic_by_path(topic_path)));
 
 
 @csrf_exempt
+@api_handle_error_with_json
 def api_data(request, xaxis="", yaxis=""):
     """Request contains information about what data are requested (who, what, and how).
 

--- a/kalite/securesync/api_views.py
+++ b/kalite/securesync/api_views.py
@@ -46,8 +46,8 @@ def require_sync_session(handler):
     return wrapper_fn
 
 
-@api_handle_error_with_json
 @csrf_exempt
+@api_handle_error_with_json
 def register_device(request):
     data = simplejson.loads(request.raw_post_data or "{}")
 
@@ -116,8 +116,8 @@ def register_device(request):
     )
 
 
-@api_handle_error_with_json
 @csrf_exempt
+@api_handle_error_with_json
 def create_session(request):
     data = simplejson.loads(request.raw_post_data or "{}")
     if "client_nonce" not in data:
@@ -165,18 +165,18 @@ def create_session(request):
     })
 
 
-@api_handle_error_with_json
 @csrf_exempt
 @require_sync_session
+@api_handle_error_with_json
 def destroy_session(data, session):
     session.closed = True
     return JsonResponse({})
 
 
-@api_handle_error_with_json
 @csrf_exempt
 @gzip_page
 @require_sync_session
+@api_handle_error_with_json
 def device_download(data, session):
     """This device is having its own devices downloaded"""
     zone = session.client_device.get_zone()
@@ -188,9 +188,9 @@ def device_download(data, session):
     return JsonResponse({"devices": serializers.serialize("versioned-json", devices + devicezones, dest_version=session.client_version, ensure_ascii=False)})
 
 
-@api_handle_error_with_json
 @csrf_exempt
 @require_sync_session
+@api_handle_error_with_json
 def device_upload(data, session):
     """This device is getting device-related objects from another device"""
     # TODO(jamalex): check that the uploaded devices belong to the client device's zone and whatnot
@@ -207,10 +207,10 @@ def device_upload(data, session):
     return JsonResponse(result)
 
 
-@api_handle_error_with_json
 @csrf_exempt
 @gzip_page
 @require_sync_session
+@api_handle_error_with_json
 def device_counters(data, session):
     device_counters = Device.get_device_counters(session.client_device.get_zone())
     return JsonResponse({
@@ -218,9 +218,9 @@ def device_counters(data, session):
     })
 
 
-@api_handle_error_with_json
 @csrf_exempt
 @require_sync_session
+@api_handle_error_with_json
 def model_upload(data, session):
     """This device is getting data-related objects from another device."""
     if "models" not in data:
@@ -237,10 +237,10 @@ def model_upload(data, session):
     return JsonResponse(result)
 
 
-@api_handle_error_with_json
 @csrf_exempt
 @gzip_page
 @require_sync_session
+@api_handle_error_with_json
 def model_download(data, session):
     """This device is having its own data downloaded"""
     if "device_counters" not in data:
@@ -256,17 +256,17 @@ def model_download(data, session):
     return JsonResponse(result)
 
 
-@api_handle_error_with_json
 @csrf_exempt
+@api_handle_error_with_json
 def test_connection(request):
     return HttpResponse("OK")
 
 
 # On pages with no forms, we want to ensure that the CSRF cookie is set, so that AJAX POST
 # requests will be possible. Since `status` is always loaded, it's a good place for this.
-@api_handle_error_with_json
 @ensure_csrf_cookie
 @distributed_server_only
+@api_handle_error_with_json
 def status(request):
     """In order to promote (efficient) caching on (low-powered)
     distributed devices, we do not include ANY user data in our


### PR DESCRIPTION
Regression bugs from #439

Apparently decorator order matters.  The current order of decorations prevents registration from happening.
In addition, some decorators were missing from the coach reports API.  added those in.

Testing:
- Tested that registration works, login works.
