### PR TITLE
To decorate a decorator, decorate the inner function.

### DIFF
--- a/kalite/utils/decorators.py
+++ b/kalite/utils/decorators.py
@@ -121,11 +121,11 @@ def get_user_from_request(handler=None, request=None, *args, **kwargs):
     return wrapper_fn if not request else wrapper_fn(request=request, *args, **kwargs)
 
 
-@distributed_server_only
 def require_login(handler):
     """
    (Level 1) Make sure that a user is logged in to the distributed server.
     """
+    @distributed_server_only
     def wrapper_fn(request, *args, **kwargs):
         if request.user.is_authenticated() or "facility_user" in request.session:
             return handler(request, *args, **kwargs)


### PR DESCRIPTION
Spent a couple of hours debugging why every URL on the central server (homepage, etc) was returning the following error:

![central-server-broken](https://f.cloud.github.com/assets/618416/959586/4b40f16a-048e-11e3-8f23-62cdbff57e2e.png)

Turns out it was just a mis-placed meta-decorator.

Has the central server really been completely broken for a month? I haven't run it for a while. But I guess it was probably on a branch that was only recently merged.
