### PR TITLE
fixing __file__ reference in cronserver.py

### DIFF
--- a/kalite/cronserver.py
+++ b/kalite/cronserver.py
@@ -12,7 +12,7 @@ def cron():
     if get_count():
         # Use sys to get the same executable running as is running this process.
         # Make sure to call the manage.py from this project.
-        subprocess.call([sys.executable, os.path.join(os.path.dirname(__file__), "manage.py"), "cron"])
+        subprocess.call([sys.executable, os.path.join(settings.PROJECT_PATH, "manage.py"), "cron"])
 
     # This is the pause between executions.  If the above hangs for a long time,
     #   we won't check again until it has returned / completed.


### PR DESCRIPTION
Aimed to fix the following intermittent exception (first reported by @gimick):

```
[13/Aug/2013 18:43:50] "GET /securesync/api/status?_=1376444630348 HTTP/1.1" 200 134
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 808, in __bootstrap_inner
    self.run()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 1080, in run
    self.function(*self.args, **self.kwargs)
  File "cronserver.py", line 15, in cron
    subprocess.call([sys.executable, os.path.join(os.path.dirname(__file__), "manage.py"), "cron"])
NameError: global name '__file__' is not defined
```
