### PR TITLE
Add font mimetype to avoid warnings on exercise pages.

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -224,3 +224,7 @@ MESSAGE_STORAGE = 'utils.django_utils.NoDuplicateMessagesSessionStorage'
 TEST_RUNNER = 'kalite.utils.testing.testrunner.KALiteTestRunner'
 
 CRONSERVER_FREQUENCY = getattr(local_settings, "CRONSERVER_FREQUENCY", 600) # 10 mins (in seconds)
+
+# Add additional mimetypes to avoid errors/warnings
+import mimetypes
+mimetypes.add_type("font/opentype", ".otf", True)


### PR DESCRIPTION
Added a mimetype for OTF fonts, to avoid warnings like:

```
Resource interpreted as Font but transferred with MIME type application/octet-stream:     
"http://localhost:1234/static/js/khan-exercises/utils/MathJax/1.1a/fonts/HTML-CSS/TeX/otf/MathJax_Math-Italic.otf". 
```
