### PR TITLE
Efficient querying of tabular view data

### DIFF
--- a/kalite/coachreports/views.py
+++ b/kalite/coachreports/views.py
@@ -243,8 +243,6 @@ def tabular_view(request, facility, report_type="exercise"):
             .filter(user__in=users, exercise_id__in=exercise_names) \
             .order_by("user__last_name", "user__first_name")\
             .values("user__id", "struggling", "complete", "exercise_id")
-        log_ids = [log["exercise_id"] for log in exlogs]
-        log_table = {}
 
         exlog_idx = 0
         for user in users:
@@ -269,22 +267,26 @@ def tabular_view(request, facility, report_type="exercise"):
         video_ids = [vid["youtube_id"] for vid in context["videos"]]
         # Get students
         context["students"] = []
+        vidlogs = VideoLog.objects \
+            .filter(user__in=users, youtube_id__in=video_ids) \
+            .order_by("user__last_name", "user__first_name")\
+            .values("user__id", "complete", "youtube_id", "total_seconds_watched", "points")
+
+        vidlog_idx = 0
         for user in users:
-            vidlogs = VideoLog.objects.filter(user=user, youtube_id__in=video_ids)
-            log_ids = [log.youtube_id for log in vidlogs]
-            log_table = []
-            for yid in video_ids:
-                if yid in log_ids:
-                    log_table.append(vidlogs[log_ids.index(yid)])
-                else:
-                    log_table.append(None)
+            log_table = {}
+            while vidlog_idx < vidlogs.count() and vidlogs[vidlog_idx]["user__id"] == user.id:
+                log_table[vidlogs[vidlog_idx]["youtube_id"]] = vidlogs[vidlog_idx]
+                vidlog_idx += 1
 
             context["students"].append({
                 "first_name": user.first_name,
                 "last_name": user.last_name,
                 "username": user.username,
+                "id": user.id,
                 "video_logs": log_table,
             })
+
     else:
         raise Http404("Unknown report_type: %s" % report_type)
 

--- a/kalite/templates/coachreports/tabular_view.html
+++ b/kalite/templates/coachreports/tabular_view.html
@@ -221,21 +221,21 @@
                         </tr>
                         {% for student in students %}
                             <tr>
-                                {% for log in student.video_logs %}
-                                    {% if not log %}
+                                {% for video in videos %}
+                                    {% if not student.video_logs|get_item:video.youtube_id %}
                                         <td class="status data" title="{% trans "Not Viewed" %}">
                                             &nbsp;
-                                    {% elif not log.complete %}
+                                    {% elif not student.video_logs|get_item:video.youtube_id|get_item:"complete" %}
                                         <td class="status data partial" title="{% trans "Viewing" %}">
-                                            <div class="total_seconds_watched">100%</div>
+                                            <div class="total_seconds_watched">{{ student.video_logs|get_item:video.youtube_id|get_item:"total_seconds_watched" }} {% trans "secs" %}</div>
                                     {% else %}
                                         <td class="status data complete" title="{% trans "Viewed" %}">
-                                            <div class="total_seconds_watched">{{ log.total_seconds_watched }} {% trans "secs" %}</div>
+                                            <div class="total_seconds_watched">100%</div>
                                     {% endif %}
-                                    {% if log %}
-                                            <div class="points">{{ log.points }} {% trans "points" %}</div>
+                                    {% if student.video_logs|get_item:video.youtube_id  %}
+                                            <div class="points">{{ student.video_logs|get_item:video.youtube_id|get_item:"points"  }} {% trans "points" %}</div>
+                                    {% endif %}
                                         </td>
-                                    {% endif %}
                                 {% endfor %}
                             </tr>
                         {% endfor %}


### PR DESCRIPTION
In the currently checked in version of the tabular view coach reports, we make a database query per user to get data out.

Changes:
- Only query once (for all users)

Notes:
- On my local machine with 20 users, this reduced queries from 35 to 16 (of course), from 50ms in SQL to 22ms, and from 420ms overall to ~260ms (all numbers via the Django Debug Toolbar
