### PR TITLE
Improving performance on knowledge map by minimizing 302 redirects

### DIFF
--- a/kalite/static/js/kmap-editor.js
+++ b/kalite/static/js/kmap-editor.js
@@ -133,7 +133,7 @@ var KMapEditor = {
 
                 $("<img>")
                     .attr({
-                        src: "/static/" + topic.icon_url
+                        src: "/static" + topic.icon_url
                     })
                     .appendTo(newTopic);
 


### PR DESCRIPTION
Addresses https://github.com/learningequality/ka-lite/issues/512 by specifying correct paths to icons, rather than relying on Django-side redirects.

Better to solve here than in NGINX, for example.
