### PR TITLE
disable nginx proxy cache #545 (ka-lite non-static content not to be cached)

### DIFF
--- a/kalite/main/management/commands/nginxconfig.py
+++ b/kalite/main/management/commands/nginxconfig.py
@@ -12,9 +12,6 @@ upstream kalite {
     server 127.0.0.1:7007;
 }
 
-proxy_cache_path  /var/cache/nginx levels=1:2 keys_zone=kalite:8m max_size=256m inactive=600m;
-proxy_temp_path /var/cache/nginx/tmp;
-
 server {
 
     # You may change the following port (8008) to something else,
@@ -39,7 +36,6 @@ server {
 
     location / {
         proxy_pass http://kalite;
-        proxy_cache kalite;
     }
 
 }


### PR DESCRIPTION
Proxy caching of ka-lite non-static content causes performance degrade, and potentially conflicts with django caching.
