### PR TITLE
HOTFIX: renaming misnamed 'total_logins' to 'count'

### DIFF
--- a/kalite/main/migrations/0018_auto__del_field_userlogsummary_total_logins__add_field_userlogsummary_.py
+++ b/kalite/main/migrations/0018_auto__del_field_userlogsummary_total_logins__add_field_userlogsummary_.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'UserLogSummary.total_logins'
+        db.delete_column('main_userlogsummary', 'total_logins')
+
+        # Adding field 'UserLogSummary.count'
+        db.add_column('main_userlogsummary', 'count',
+                      self.gf('django.db.models.fields.IntegerField')(default=0),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Adding field 'UserLogSummary.total_logins'
+        db.add_column('main_userlogsummary', 'total_logins',
+                      self.gf('django.db.models.fields.IntegerField')(default=0),
+                      keep_default=False)
+
+        # Deleting field 'UserLogSummary.count'
+        db.delete_column('main_userlogsummary', 'count')
+
+
+    models = {
+        'main.exerciselog': {
+            'Meta': {'object_name': 'ExerciseLog'},
+            'attempts': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'attempts_before_completion': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'exercise_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'streak_progress': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'struggling': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'main.languagepack': {
+            'Meta': {'object_name': 'LanguagePack'},
+            'lang_id': ('django.db.models.fields.CharField', [], {'max_length': '5', 'primary_key': 'True'}),
+            'lang_name': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'lang_version': ('django.db.models.fields.CharField', [], {'max_length': '5'}),
+            'software_version': ('django.db.models.fields.CharField', [], {'max_length': '12'})
+        },
+        'main.userlog': {
+            'Meta': {'object_name': 'UserLog'},
+            'activity_type': ('django.db.models.fields.IntegerField', [], {}),
+            'end_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_active_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'start_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'total_seconds': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"})
+        },
+        'main.userlogsummary': {
+            'Meta': {'object_name': 'UserLogSummary'},
+            'activity_type': ('django.db.models.fields.IntegerField', [], {}),
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'device': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Device']"}),
+            'end_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'start_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'total_seconds': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'main.videofile': {
+            'Meta': {'ordering': "['priority', 'youtube_id']", 'object_name': 'VideoFile'},
+            'cancel_download': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'download_in_progress': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'flagged_for_download': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'flagged_for_subtitle_download': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'percent_complete': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'priority': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'subtitle_download_in_progress': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'subtitles_downloaded': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'youtube_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'primary_key': 'True'})
+        },
+        'main.videolog': {
+            'Meta': {'object_name': 'VideoLog'},
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'total_seconds_watched': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'youtube_id': ('django.db.models.fields.CharField', [], {'max_length': '20', 'db_index': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.device': {
+            'Meta': {'object_name': 'Device'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'public_key': ('django.db.models.fields.CharField', [], {'max_length': '500', 'db_index': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'version': ('django.db.models.fields.CharField', [], {'default': "'0.9.2'", 'max_length': '9', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.facility': {
+            'Meta': {'object_name': 'Facility'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'address_normalized': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'contact_email': ('django.db.models.fields.EmailField', [], {'max_length': '60', 'blank': 'True'}),
+            'contact_name': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'contact_phone': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'longitude': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_count': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"}),
+            'zoom': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'securesync.facilitygroup': {
+            'Meta': {'object_name': 'FacilityGroup'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'facility': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Facility']"}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.facilityuser': {
+            'Meta': {'unique_together': "(('facility', 'username'),)", 'object_name': 'FacilityUser'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'facility': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Facility']"}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityGroup']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'is_teacher': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.zone': {
+            'Meta': {'object_name': 'Zone'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        }
+    }
+
+    complete_apps = ['main']

--- a/kalite/main/models.py
+++ b/kalite/main/models.py
@@ -113,12 +113,12 @@ class UserLogSummary(SyncedModel):
     activity_type = models.IntegerField(blank=False, null=False)
     start_datetime = models.DateTimeField(blank=False, null=False)
     end_datetime = models.DateTimeField(blank=True, null=True)
-    total_logins = models.IntegerField(default=0, blank=False, null=False)
+    count = models.IntegerField(default=0, blank=False, null=False)
     total_seconds = models.IntegerField(default=0, blank=False, null=False)
 
     def __unicode__(self):
         self.full_clean()  # make sure everything that has to be there, is there.
-        return u"%d seconds over %d logins for %s/%s/%d, period %s to %s" % (self.total_seconds, self.total_logins, self.device.name, self.user.username, self.activity_type, self.start_datetime, self.end_datetime)
+        return u"%d seconds over %d logins for %s/%s/%d, period %s to %s" % (self.total_seconds, self.count, self.device.name, self.user.username, self.activity_type, self.start_datetime, self.end_datetime)
 
 
     @classmethod
@@ -201,14 +201,14 @@ class UserLogSummary(SyncedModel):
             start_datetime=cls.get_period_start_datetime(user_log.end_datetime, settings.USER_LOG_SUMMARY_FREQUENCY),
             end_datetime=cls.get_period_end_datetime(user_log.end_datetime, settings.USER_LOG_SUMMARY_FREQUENCY),
             total_seconds=0,
-            total_logins=0,
+            count=0,
         )
 
         logging.debug("Adding %d seconds for %s/%s/%d, period %s to %s" % (user_log.total_seconds, device.name, user_log.user.username, user_log.activity_type, log_summary.start_datetime, log_summary.end_datetime))
 
         # Add the latest info
         log_summary.total_seconds += user_log.total_seconds
-        log_summary.total_logins += 1
+        log_summary.count += 1
         log_summary.save()
 
 


### PR DESCRIPTION
This can't be done after publishing a model, but "total_logins" of UserLogSummary is misnamed--UserLogSummary can refer generically to any type, so "total_logins" is better named "count", and interpreted by the activity_type field.

Testing:
- Did a "grep" on total_logins to confirm all were replaced (Except in the original migrations file)
- Started the server with UserLogs enabled (and disabled) to confirm no exceptions.

Note: also tweaked a report, to limit activity_type to "login".  Tested that the report still works properly.
