### PR TITLE
HOTFIX: No serverside synchronous online check

### DIFF
--- a/kalite/main/views.py
+++ b/kalite/main/views.py
@@ -280,7 +280,6 @@ def easy_admin(request):
     context = {
         "wiki_url" : settings.CENTRAL_WIKI_URL,
         "central_server_host" : settings.CENTRAL_SERVER_HOST,
-        "am_i_online": am_i_online(settings.CENTRAL_WIKI_URL, allow_redirects=False),
         "in_a_zone":  Device.get_own_device().get_zone() is not None,
     }
     return context


### PR DESCRIPTION
Found this while updating for branch "force_sync" (https://github.com/learningequality/ka-lite/pull/529)

In fact #178 was not fully fixed--the synchronous check for online status still exists for the easy_admin page--even though it's no longer used.  This causes admins to have to wait while that request times out.

To completely fix that bug, we need to remove this check, and let users proceed to the page directly, where we check this status using AJAX/JsonP.

Testing: did a grep to see that the template doesn't reference the am_i_online template variable.  It doesn't, nor does any other.
