### PR TITLE
reducing # of cherrypy threads in debug mode

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -33,7 +33,7 @@ CENTRAL_SERVER = getattr(local_settings, "CENTRAL_SERVER", False)
 
 # TODO(jamalex): currently this only has an effect on Linux/OSX
 PRODUCTION_PORT = getattr(local_settings, "PRODUCTION_PORT", 8008 if not CENTRAL_SERVER else 8001)
-CHERRYPY_THREAD_COUNT = getattr(local_settings, "CHERRYPY_THREAD_COUNT", 50)
+CHERRYPY_THREAD_COUNT = getattr(local_settings, "CHERRYPY_THREAD_COUNT", 50 if not DEBUG else 5)
 
 AUTO_LOAD_TEST = getattr(local_settings, "AUTO_LOAD_TEST", False)
 assert not AUTO_LOAD_TEST or not CENTRAL_SERVER, "AUTO_LOAD_TEST only on local server"


### PR DESCRIPTION
@jamalex suggested this could have been a cause for recent memory problems on the central server.  Can be adjusted in local_settings if desired.

Why 5?  No good reason at all.  Could have been 1, but seems unnecessary to go that low.

It is my contention that doing a pull request on this is a waste of time.  As is feedback.  If 5 is such an offensive number that it warrants discussion, a better approach is to merge, then do a new pull request.

I will not assign, because this is an issue for anybody to consider.  I will happily merge this tonight, if it is not done by then.
