### PR TITLE
small import errors

### DIFF
--- a/kalite/khanload/api_views.py
+++ b/kalite/khanload/api_views.py
@@ -42,7 +42,7 @@ from main.models import ExerciseLog, VideoLog
 from main.topicdata import NODE_CACHE, ID2SLUG_MAP
 from settings import LOG as logging
 from securesync.models import FacilityUser
-from utils.decorators import require_login, distributed_server_only, central_server_only
+from shared.decorators import require_login, distributed_server_only, central_server_only
 from utils.internet import JsonResponse
 
 

--- a/kalite/main/api_views.py
+++ b/kalite/main/api_views.py
@@ -21,7 +21,6 @@ from shared.caching import invalidate_all_pages_related_to_video
 from shared.decorators import require_admin
 from shared.videos import delete_downloaded_files
 from utils.jobs import force_job, job_status
-from utils.videos import delete_downloaded_files
 from utils.general import break_into_chunks
 from utils.internet import api_handle_error_with_json, JsonResponse
 from utils.mplayer_launcher import play_video_in_new_thread


### PR DESCRIPTION
two imports from recent merges that needed to be changed, but were missed.  one breaks many things, the other is simply semantically wrong.

Will merge straightaway.
