### PR TITLE
small fix to address bug, migrating to cleaner interface using inspect

### DIFF
--- a/kalite/central/tests/__init__.py
+++ b/kalite/central/tests/__init__.py
@@ -1,5 +1,2 @@
-import os
-
-from utils.importing import import_all_from
-
-import_all_from(os.path.dirname(__file__), locals(), globals())
+from utils.importing import import_all_child_modules
+import_all_child_modules()

--- a/kalite/faq/tests/__init__.py
+++ b/kalite/faq/tests/__init__.py
@@ -1,5 +1,2 @@
-import os
-
-from utils.importing import import_all_from
-
-import_all_from(os.path.dirname(__file__), locals(), globals())
+from utils.importing import import_all_child_modules
+import_all_child_modules()

--- a/kalite/main/tests/__init__.py
+++ b/kalite/main/tests/__init__.py
@@ -1,5 +1,2 @@
-import os
-
-from utils.importing import import_all_from
-
-import_all_from(os.path.dirname(__file__), locals(), globals())
+from utils.importing import import_all_child_modules
+import_all_child_modules()

--- a/kalite/registration/tests/__init__.py
+++ b/kalite/registration/tests/__init__.py
@@ -1,5 +1,2 @@
-import os
-
-from utils.importing import import_all_from
-
-import_all_from(os.path.dirname(__file__), locals(), globals())
+from utils.importing import import_all_child_modules
+import_all_child_modules()

--- a/kalite/securesync/tests/__init__.py
+++ b/kalite/securesync/tests/__init__.py
@@ -1,5 +1,2 @@
-import os
-
-from utils.importing import import_all_from
-
-import_all_from(os.path.dirname(__file__), locals(), globals())
+from utils.importing import import_all_child_modules
+import_all_child_modules()

--- a/kalite/shared/decorators/__init__.py
+++ b/kalite/shared/decorators/__init__.py
@@ -1,5 +1,2 @@
-import os
-
-from utils.importing import import_all_from
-
-import_all_from(os.path.dirname(__file__), locals(), globals())
+from utils.importing import import_all_child_modules
+import_all_child_modules()

--- a/kalite/shared/testing/__init__.py
+++ b/kalite/shared/testing/__init__.py
@@ -1,5 +1,2 @@
-import os
-
-from utils.importing import import_all_from
-
-import_all_from(os.path.dirname(__file__), locals(), globals())
+from utils.importing import import_all_child_modules
+import_all_child_modules()

--- a/kalite/tests/__init__.py
+++ b/kalite/tests/__init__.py
@@ -1,0 +1,2 @@
+from utils.importing import import_all_child_modules
+import_all_child_modules()

--- a/kalite/utils/django_utils/__init__.py
+++ b/kalite/utils/django_utils/__init__.py
@@ -1,5 +1,2 @@
-import os
-
-from utils.importing import import_all_from
-
-import_all_from(os.path.dirname(__file__), locals(), globals())
+from utils.importing import import_all_child_modules
+import_all_child_modules()

--- a/kalite/utils/importing.py
+++ b/kalite/utils/importing.py
@@ -2,17 +2,28 @@
 Contains helper functions for importing modules.
 """
 
-import os, glob
+import glob
+import os
+import inspect
+
+
+def import_all_child_modules():
+    current_frame = inspect.currentframe()
+    caller_locals = current_frame.f_back.f_locals
+    caller_globals = current_frame.f_back.f_globals
+    caller_path = os.path.dirname(caller_locals["__file__"])
+
+    return import_all_from(caller_path, caller_locals, caller_globals)
+
 
 def import_all_from(path, locals, globals, pattern="*"):
-    """Import * from all the .py files in a particular directory whose names match a particular pattern.
-    
-    This is currently only used for auto-import of test suites, but may also be useful elsewhere.
     """
-
+    Import * from all the .py files in a particular directory whose names match a particular pattern.
+    """
     # load the names of all the modules in the directory
     module_names = [os.path.basename(f)[:-3] for f in glob.glob("%s/%s.py" % (path, pattern))]
-
+    base_module_name=os.path.basename(path)
+    # print ("Importing into %s" % base_module_name)
     # effectively do a `from <module> import *` for all the modules
     for module_name in module_names:
 
@@ -23,7 +34,11 @@ def import_all_from(path, locals, globals, pattern="*"):
         # import the module by name, passing globals so it can make use of Django stuff
         # http://www.diveintopython.net/functional_programming/dynamic_import.html
         module = __import__(module_name, globals=globals)
+        # print ("\tImporting from internal module:%s" % (module_name))
 
         # bring all the contents of the module into the original namespace (ala `from ... import *`)
         for name in dir(module):
+            if name.startswith("_"):
+                continue
+            # print ("\t\tBringing %s into %s" % (name, base_module_name))
             locals[name] = getattr(module, name)

--- a/kalite/utils/internet/__init__.py
+++ b/kalite/utils/internet/__init__.py
@@ -1,5 +1,2 @@
-import os
-
-from utils.importing import import_all_from
-
-import_all_from(os.path.dirname(__file__), locals(), globals())
+from utils.importing import import_all_child_modules
+import_all_child_modules()


### PR DESCRIPTION
@jamalex another for you--your code that pretty much others are unaware of.  If you don't have time to merge, I may simply merge, as this causes the project to be a non-starter on some OS's / installs (based on install-specific ordering of files, perhaps)

Issues:
We've been seeing cryptic import errors here and there (hi @dylanjbarth , @gimick).  With a bit of investigation, we found that it's due to our convenient `import_all_from` function is importing private guts from it's children (`__file__`, `__module`, etc), not just public guts.

(This was a two line change.)

While I was in there, I found that it's easy to get the same functionality without having to pass any parameters, or duplicate any logic (by using inspect, available since Python 2.1--so OK for us).  So, I used it!  That's where the rest of this churn comes from.

Changes:
- Fix the major problem by skipping imports of anything starting with "_"
- Add a wrapper function around `import_all_from` that requires no params
- Use that function wherever we were using `import_all_from`
