### PR TITLE
Getting initdevice working on PostGRE

### DIFF
--- a/kalite/securesync/devices/models.py
+++ b/kalite/securesync/devices/models.py
@@ -194,11 +194,16 @@ class Device(SyncedModel):
         own_device = Device(**kwargs)
         own_device.set_key(crypto.get_own_key())
         own_device.sign(device=own_device)
-        own_device.save(own_device=own_device)
+
+        # imported=True is for when the local device should not sign the object,
+        #   and when counters should not be incremented.  That's our situation here!
+        super(Device, own_device).save(imported=True, increment_counters=False)
+
         metadata = own_device.get_metadata()
         metadata.is_own_device = True
         metadata.is_trusted = settings.CENTRAL_SERVER
         metadata.save()
+
         return own_device
 
     @transaction.commit_on_success
@@ -235,7 +240,9 @@ class Device(SyncedModel):
         #     raise ValidationError("ID must match device's public key.")
         if self.signed_by_id and self.signed_by_id != self.id and not self.signed_by.get_metadata().is_trusted:
             raise ValidationError("Devices must either be self-signed or signed by a trusted authority.")
+
         super(Device, self).save(*args, **kwargs)
+
         if is_trusted:
             metadata = self.get_metadata()
             metadata.is_trusted = True

--- a/kalite/securesync/engine/models.py
+++ b/kalite/securesync/engine/models.py
@@ -205,7 +205,7 @@ class SyncedModel(ExtendedModel):
 
         return "&".join(chunks)
 
-    def save(self, own_device=None, imported=False, increment_counters=True, *args, **kwargs):
+    def save(self, imported=False, increment_counters=True, *args, **kwargs):
         """
         Some of the heavy lifting happens here.  There are two saving scenarios:
         (a) We are saving an imported model.
@@ -214,10 +214,6 @@ class SyncedModel(ExtendedModel):
             In this case, we need to mark the model with appropriate fields, so that
             it can be sync'd (self.counter), and that it will verify (self.signature)
         """
-        # we allow for the "own device" to be passed in so that a device can sign itself (before existing)
-        own_device = own_device or _get_own_device()
-        assert own_device, "own_device is None--this should never happen, as get_own_device should create if not found."
-
         if imported:
             # imported models are signed by other devices; make sure they check out
             if not self.signed_by_id:
@@ -225,6 +221,8 @@ class SyncedModel(ExtendedModel):
             if not self.verify():
                 raise ValidationError("Imported model's signature did not match.")
         else:
+            own_device = _get_own_device()
+
             # Two critical things to do:
             # 1. local models need to be signed by us
             # 2. and get our counter position


### PR DESCRIPTION
This localizes the logic out of SyncModel and into Device. Uses the "imported" codepath to accomplish goals--save without signing, and without mucking with counters (which is the codepath that breaks in postgre)

This code path is only hit during installation, so should be low impact.  I believe the code is a bit cleaner (with documentation as to why we're using the "imported" codepath).

@gimick can you test this out?
