### PR TITLE
Tweaks to content pages, landing page

### DIFF
--- a/kalite/central/urls.py
+++ b/kalite/central/urls.py
@@ -43,6 +43,8 @@ urlpatterns += patterns('',
 urlpatterns += patterns('central.views',
     url(r'^$', 'homepage', {}, 'homepage'), 
     url(r'^content/(?P<page>\w+)/', 'content_page', {}, 'content_page'), # Example of a new landing page
+    url(r'^wiki/(?P<path>.*)$', 'content_page', {"page": "wiki_page", "wiki_site": settings.CENTRAL_WIKI_URL}, 'wiki'),
+
     url(r'^delete_admin/(?P<org_id>\w+)/(?P<user_id>\w+)/$', 'delete_admin', {}, 'delete_admin'), 
     url(r'^delete_invite/(?P<org_id>\w+)/(?P<invite_id>\w+)/$', 'delete_invite', {}, 'delete_invite'), 
     url(r'^accounts/', include(registration.urls)),
@@ -66,7 +68,6 @@ urlpatterns += patterns('central.views',
     url(r'^faq/', include(faq.urls)),
 
     url(r'^contact/', include(contact.urls)),
-    url(r'^wiki/(?P<path>.*)$', lambda request, path: HttpResponseRedirect(settings.CENTRAL_WIKI_URL + path), {}, 'wiki'),
     url(r'^about/$', lambda request: HttpResponseRedirect('http://learningequality.org/'), {}, 'about'),
 
     # Endpoint for remote admin

--- a/kalite/central/views.py
+++ b/kalite/central/views.py
@@ -166,8 +166,10 @@ def delete_organization(request, org_id):
     return HttpResponseRedirect(reverse("org_management"))
 
 
-def content_page(request, page):
-    return render_to_response("central/content/%s.html" % page, context_instance=RequestContext(request))
+def content_page(request, page, **kwargs):
+    context = RequestContext(request)
+    context.update(kwargs)
+    return render_to_response("central/content/%s.html" % page, context_instance=context)
 
 
 @render_to("central/glossary.html")

--- a/kalite/static/less/landing_page.less
+++ b/kalite/static/less/landing_page.less
@@ -15,7 +15,7 @@
   color:black;
   text-align: center;
   font-size: 26px;  
-  padding: 80px 0px ;
+  padding: 50px 0px ;
   p{
 
     font-size: 18px;

--- a/kalite/static/less/style_with_bootstrap.less
+++ b/kalite/static/less/style_with_bootstrap.less
@@ -335,8 +335,8 @@ h4{font-size: 118%;}
 
 
 
-// users_manual.html
-#user-manual-container {
+// wiki_page.html
+#wiki-container {
   overflow: hidden;
   iframe {
     position: relative;

--- a/kalite/templates/central/base.html
+++ b/kalite/templates/central/base.html
@@ -61,7 +61,7 @@
                             <ul class="header__horizontal-menu__right">
 
                                 <li><a href="{% url homepage %}" class="{% block home_active %}{% endblock home_active %}">{% trans "Home" %}</a></li>
-                                <li><a href="{% url wiki path='installation' %}" target="_blank">{% trans "Install" %}</a></li>
+                                <li><a href="{% url wiki path='installation' %}" class="{% block install_active %}{% endblock install_active %}">{% trans "Install" %}</a></li>
                                 <li><a href="{% url faq_topic_list %}" class="{% block faq_active %}{% endblock faq_active%}">{% trans "FAQ" %}</a></li>
                                 <li><a href="{% url contact_wizard %}"class="{% block contact_active %}{% endblock contact_active%}">{% trans "Contact" %}</a></li>
                                 <li><a href="{% url content_page page='about' %}" class="{% block about_active %}{% endblock about_active%}">{% trans "About Us" %}</a></li>

--- a/kalite/templates/central/content/users.html
+++ b/kalite/templates/central/content/users.html
@@ -4,18 +4,134 @@
 {% block content %}
 
 <h1>Our Users</h1>
-<p>
-    KA Lite is being used around the world in locations that have limited or no access to the Internet.
-</p>
+
+<div class="row-fluid">
+    <p>
+        KA Lite is being used around the world in locations that have limited or no access to the Internet.
+        Below are two deployments we've chosen to actively support, and some indication of the hundreds
+        of people and organizations that are using our software off-the-shelf for their own needs.
+    </p>
+
+    <p>
+        Have you installed KA Lite?  Are you using it?  <a href="{% url contact_wizard type='deployment' %}">If so, tell us about it!</a>
+</div>
+
 <div class="row-fluid">
 
     <div class="span6">
-    <h2>Nalanda Project in Maharashtra State, India</h2>
+        <h2>Nalanda Project in Maharashtra State, India</h2>
 
-    <p>4th Grade Students at <a href="http://www.akanksha.org/">Akanksha Schools</a> in Mumbai and Pune are using KA Lite to learn Mathematics. With a Raspberry Pi as a server and low cost Akash Tablets as client devices, students watch videos to learn and review Mathematics concepts, and then complete automated exercises to receive feedback on their procedural understanding.</p></div>
+        <p>4th Grade Students at <a href="http://www.akanksha.org/" target="_blank">Akanksha Schools</a> in Mumbai and Pune are using KA Lite to learn Mathematics. With a <a href="{% url wiki path='' %}">Raspberry Pi</a> as a server and low cost Akash Tablets as client devices, students watch videos to learn and review Mathematics concepts, and then complete automated exercises to receive feedback on their procedural understanding.</p>
+    </div>
+
     <div class="span6">
-    <h2>Idaho Department of Corrections</h2>
+        <h2>Idaho Department of Corrections</h2>
 
-    <p>As part of the KA in Idaho project, the Idaho Department of Corrections is using KA Lite in the Education programs in Correctional Facilities across the state. Lacking access to Internet access, inmates are able to watch videos and complete exercises, appropriate to their needs. In a population this diverse, the personalization afforded by KA Lite allows the students to learn at their own pace, and also learn valuable IT literacy skills at the same time.</p></div>
+        <p>As part of the <a href="http://www.khanidaho.org/" target="_blank">KA in Idaho</a> project, the <a href="http://www.idoc.idaho.gov" target="_blank">Idaho Department of Corrections</a> is using KA Lite in the Education programs in Correctional Facilities across the state. Lacking access to Internet access, inmates are able to watch videos and complete exercises, appropriate to their needs. In a population this diverse, the personalization afforded by KA Lite allows the students to learn at their own pace, and also learn valuable IT literacy skills at the same time.</p>
+    </div>
+</div>
+
+<div class="row-fluid">
+    <div class="span12">
+        <h2>Known countries where KA Lite is being tested/deployed</h2>
+
+        <p>
+            In openly distributing software to offline communities, a big challenge is knowing when and where KA Lite is installed, 
+            and how it is being used.  Below is a list of countries where we have confirmed that KA Lite has been installed.
+            For a more detailed view, you can visit our <a href="http://learningequality.org/map/">map of known installations</a>
+        </p>
+
+        <p class="span2">
+            Argentina<br/>
+            Australia<br/>
+            Austria<br/>
+            Bangladesh<br/>
+            Belgium<br/>
+            Bhutan<br/>
+            Brazil<br/>
+            Bulgaria<br/>
+            Cameroon<br/>
+            Canada<br/>
+            Central African Republic<br/>
+            China<br/>
+            Cook Islands<br/>
+            Czech Republic<br/>
+            Denmark<br/>
+            Dominican Republic<br/>
+            Egypt<br/>
+        </p>
+
+        <p class="span2">
+Ethiopia<br/>
+Europe<br/>
+Finland<br/>
+France<br/>
+Germany<br/>
+Ghana<br/>
+Guatemala<br/>
+Haiti<br/>
+Hong Kong<br/>
+Hungary<br/>
+India<br/>
+Indonesia<br/>
+Italy<br/>
+Jamaica<br/>
+Japan<br/>
+Kenya<br/>
+Korea<br/>
+</p>
+
+        <p class="span2">
+Kuwait<br/>
+Latvia<br/>
+Liberia<br/>
+Madagascar<br/>
+Malawi<br/>
+Malaysia<br/>
+Mexico<br/>
+Mongolia<br/>
+Myanmar<br/>
+Namibia<br/>
+Nepal<br/>
+Netherlands<br/>
+New Zealand<br/>
+Nigeria<br/>
+Norway<br/>
+Pakistan<br/>
+Paraguay<br/>
+</p>
+        <p class="span2">
+Peru<br/>
+Philippines<br/>
+Poland<br/>
+Portugal<br/>
+Puerto Rico<br/>
+Qatar<br/>
+Romania<br/>
+Saudi Arabia<br/>
+Serbia<br/>
+Singapore<br/>
+Slovenia<br/>
+South Africa<br/>
+Spain<br/>
+Sweden<br/>
+Switzerland<br/>
+Taiwan<br/>
+Tanzania<br/>
+</p>
+        <p class="span2">
+Thailand<br/>
+Uganda<br/>
+Ukraine<br/>
+United Arab Emirates<br/>
+United Kingdom<br/>
+U.S.A. (46+ states)<br/>
+Zambia<br/>
+Zimbabwe<br/>
+</p>
+</div>
+
+
+
 </div>
 {% endblock %}

--- a/kalite/templates/central/content/users_manual.html
+++ b/kalite/templates/central/content/users_manual.html
@@ -1,12 +1,1 @@
-{% extends "central/content_page.html" %}
-{% block title %}
-User's Manual
-{% endblock title %}
-
-{% block home_active %}active{% endblock home_active %}
-
-{% block content %}
-<div id="user-manual-container">
-	<iframe src="{% url wiki path='user-s-manual' %}" width="100%" height="800px;"></iframe>		
-</div>
-{% endblock content %}
+{% include "central/content/wiki_page.html" with path="user-s-manual" title="User's Manual" active="home" %}

--- a/kalite/templates/central/content/wiki_page.html
+++ b/kalite/templates/central/content/wiki_page.html
@@ -1,0 +1,10 @@
+{% extends "central/content_page.html" %}
+
+{% block home_active %}{% if active == "home" %}active{% endif %}{% endblock %}
+{% block install_active %}{% if active == "install" or path == "installation" %}active{% endif %}{% endblock %}
+
+{% block content %}
+<div id="wiki-container">
+	<iframe src="{{ wiki_site }}{{ path }}" width="100%" height="800px;"></iframe>
+</div>
+{% endblock content %}

--- a/kalite/templates/central/homepage.html
+++ b/kalite/templates/central/homepage.html
@@ -43,7 +43,7 @@
         <div class="span4">
             <h2>How do I use it?</h2>
 
-            <a href="{% url content_page page='users_manual' %}">
+            <a href="{% url wiki path='user-s-manual' %}">
             <div class="round-border-install"></div>
             </a>
             <p>
@@ -53,16 +53,16 @@
             </p>
         </div>
         <div class="span4">
-            <h2 class="">Our mission</h2>
+            <h2 class="">Who is using it?</h2>
 
-            <a href="{% url content_page page='about' %}">
+            <a href="{% url content_page page='users' %}">
             <div class="round-border-rural"></div>
             </a>
 
             <p>
-                Bringing the online education<br/>
-                revolution to rural<br/>
-                communities.
+                Read about our partnerships<br/>
+                and world-wide installations.<br/>
+                <a href="{% url contact_wizard type='deployment' %}">Tell us about yours.</a></br>
             </p>
         </div>
 


### PR DESCRIPTION
A slew of changes that I _thought_ were already merged from Tuesday's JHT.  Things like:
- Link to proper pages from the landing page
- Embed installation instructions into iframe
- Add info about countries with confirmed installs

And probably more.  These were contained in the images I emailed out to the team, and info in that email.  So will merge directly, so that @rtibbles, @jamalex, and others can use these pages to finish their content pages.
