### PR TITLE
Fix to order of JS in update page, to prevent errors in Firefox.

### DIFF
--- a/kalite/templates/video_download.html
+++ b/kalite/templates/video_download.html
@@ -447,9 +447,6 @@ ul.dynatree-container li, .ui-widget-content {
 
                     if (!$("#retry-video-download").is(":visible")) {
 
-                        // wait 5 seconds before showing the retry button, in case it's just a momentary blip
-                        setTimeout(retry_download, 5000);
-
                         // keep pressing the retry button every 60 seconds, when this page is open
                         function retry_download() {
                             if (!window.download_check_interval || !$("#retry-video-section").is(":visible")) {
@@ -460,6 +457,9 @@ ul.dynatree-container li, .ui-widget-content {
                             $("#retry-video-download").show()
                             setTimeout(retry_download, 60000);
                         }
+
+                        // wait 5 seconds before showing the retry button, in case it's just a momentary blip
+                        setTimeout(retry_download, 5000);
                     }
 
                 } else {


### PR DESCRIPTION
For some reason, this was only an issue in Firefox (Chrome didn't care), which was why it wasn't caught previously. Merging in now, but please take a look when you have a chance, someone.
