### PR TITLE
tweaking devices page, to show device metadata.  Add titles to pages with missing

### DIFF
--- a/kalite/templates/control_panel/account_management.html
+++ b/kalite/templates/control_panel/account_management.html
@@ -7,7 +7,7 @@
 
 {% block control_panel_active %}{% endblock control_panel_active %}
 {% block account_management_active %}active{% endblock account_management_active %}
-{% block title %}User Management{% endblock title%}
+{% block title %}{{ student.get_name }} - User Management{% endblock title%}
 
 {% block headcss %}{% comment %}Don't insert block.super here, because block.super is WEIRD and isn't the super for student_view IN student view, but instead THIS super.{% endcomment %}
     {% include_block "coachreports/student_view.html" "headcss" %}

--- a/kalite/templates/control_panel/base_printable.html
+++ b/kalite/templates/control_panel/base_printable.html
@@ -1,5 +1,4 @@
 {% extends "control_panel/base.html" %}
-
 {% load i18n %}
 
 {% block buttons %}{{ block.super }}

--- a/kalite/templates/control_panel/device_management.html
+++ b/kalite/templates/control_panel/device_management.html
@@ -1,17 +1,30 @@
 {% extends "control_panel/base.html" %}
 {% load i18n %}
 
-{% if not is_central %}
-    {% block buttons %}
+{% block title %}{{ device.name }} : Device Syncing History{% endblock title %}
+
+{% block buttons %}{{ block.super }}
+    {% if not is_central %}
         <!--li>
             <a class="green_button" href="javascript:alert('NYI; sorry!');">{% trans "Sync device now!" %}</a>
         </li-->
-    {% endblock buttons %}
-{% endif %}
+    {% endif %}
+{% endblock buttons %}
 
 {% block control_panel_content %}
 <div id="zone_container">
-        
+
+    <div class="device_metadata">
+        <h2>Device Metadata</h2>
+
+        {% if not sync_sessions %}
+        <li>Version: {{ device.version }}</li>
+        {% else %}
+        <li>Version: {{ sync_sessions.0.client_version }}</li>
+        <li>OS:  {{ sync_sessions.0.client_os }}</li>
+        {% endif %}
+    </div>
+
     <div class="sync_sessions">
         <h2>Sync Sessions</h2>
 
@@ -40,5 +53,6 @@
             </table>
         {% endif %}
     </div>
+
 </div><!-- zone_container -->
 {% endblock control_panel_content %}

--- a/kalite/templates/control_panel/facility_form.html
+++ b/kalite/templates/control_panel/facility_form.html
@@ -1,7 +1,7 @@
 {% extends "control_panel/base.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Facility" %}{% endblock title %}
+{% block title %}{% trans "Facility" %} - Facility Update{% endblock title %}
 {% block control_panel_active %}active{% endblock control_panel_active %}
 
 {% block headjs %}{{ block.super }}

--- a/kalite/templates/control_panel/zone_form.html
+++ b/kalite/templates/control_panel/zone_form.html
@@ -1,6 +1,6 @@
 {% extends "control_panel/base.html" %}
 
-{% block title %}{{ zone.name }} - Zone Management Console{% endblock title %}
+{% block title %}{{ zone.name }} - Zone Update{% endblock title %}
 {% block control_panel_active %}active{% endblock control_panel_active %}
 
 {% block control_panel_content %}


### PR DESCRIPTION
Ugly, but useful.  @arnaudbenard can help out the styling in the future?

Other pages are missing titles / have wrong titles; fixed them.

![image](https://f.cloud.github.com/assets/4072455/1158378/8ff7a1c4-1fb3-11e3-9654-2fbd282a3e02.png)
