### PR TITLE
HTH: develop branch: Zero-config option. Now, you can unpack KA Lite and start immediately! ...

### DIFF
--- a/kalite/management/commands/install.py
+++ b/kalite/management/commands/install.py
@@ -22,10 +22,11 @@ from django.core.management.base import BaseCommand, CommandError
 
 import settings
 import version
-from kalite.utils.general import get_host_name
-from kalite.utils.platforms import is_windows, system_script_extension
-from kalite.securesync.management.commands.initdevice import load_data_for_offline_install, Command as InitCommand
-from kalite.securesync.models import Zone
+from securesync.management.commands.initdevice import load_data_for_offline_install, Command as InitCommand
+from securesync.models import Zone
+from utils.general import get_host_name
+from utils.platforms import is_windows, system_script_extension
+
 
 def raw_input_yn(prompt):
     ans = ""
@@ -214,8 +215,6 @@ class Command(BaseCommand):
 
                 if not validate_username(username):
                     raise CommandError("Username must contain only letters, digits, and underscores, and start with a letter.\n")
-                elif not password:
-                    raise CommandError("Password cannot be blank.\n")
 
         ########################
         # Now do stuff
@@ -241,10 +240,11 @@ class Command(BaseCommand):
         if install_clean:
             call_command("generatekeys", verbosity=options.get("verbosity"))
 
-            call_command("createsuperuser", username=username, email="dummy@learningequality.org", interactive=False, verbosity=options.get("verbosity"))
-            admin = User.objects.get(username=username)
-            admin.set_password(password)
-            admin.save()
+            if options["password"]:  # blank password (non-interactive) means don't create a superuser
+                call_command("createsuperuser", username=username, email="dummy@learningequality.org", interactive=False, verbosity=options.get("verbosity"))
+                admin = User.objects.get(username=username)
+                admin.set_password(password)
+                admin.save()
 
             call_command("initdevice", hostname, description, verbosity=options.get("verbosity"))
 

--- a/kalite/management/commands/kaserve.py
+++ b/kalite/management/commands/kaserve.py
@@ -1,0 +1,113 @@
+"""
+This is a command-line tool to execute functions helpful to testing.
+"""
+import os
+import sys
+from optparse import make_option
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+from django.db import DatabaseError
+from django.utils.translation import ugettext as _
+
+import settings
+from config.models import Settings
+from securesync.models import Device, Facility
+from settings import LOG as logging
+from utils.django_utils import call_command_with_output
+from utils.general import isnumeric
+
+
+class Command(BaseCommand):
+    option_list = BaseCommand.option_list + (
+        make_option(
+            '--host',
+            action='store',
+            dest='host',
+            default="0.0.0.0",
+            help="Host"
+        ),
+        make_option(
+            '--port',
+            action='store',
+            dest='port',
+            default=settings.PRODUCTION_PORT,
+            help="Port"
+        ),
+        make_option(
+            '--threads',
+            action='store',
+            dest='threads',
+            default=settings.CHERRYPY_THREAD_COUNT,
+            help="Thread count"
+        ),
+        make_option(
+            '--daemonize',
+            action='store_false',
+            dest='run_in_proc',
+            default=True,
+            help="Daemonize"
+        ),
+        make_option(
+            '--pidfile',
+            action='store',
+            dest='pidfile',
+            default=os.path.join(settings.PROJECT_PATH, "runcherrypyserver.pid"),
+            help="PID file"
+        ),
+    )
+
+    def handle(self, *args, **options):
+
+        # Eliminate irrelevant settings
+        for opt in BaseCommand.option_list:
+            del options[opt.dest]
+
+        # Parse the crappy way that runcherrypy takes args,
+        #   or the host/port 
+        for arg in args:
+            if "=" in arg:
+                (key,val) = arg.split("=")
+                options[key] = val
+            elif ":" in arg:
+                (options["host"], options["port"]) = arg.split(":")
+            elif isnumeric(arg):
+                options["port"] = arg
+            else:
+                raise CommandError("Unexpected argument format: %s" % arg)
+
+
+        # Now, validate the server.
+        try:
+            if Settings.get("private_key") and Device.objects.count():
+                # The only success case
+                pass
+
+            elif not Device.objects.count():
+                # Nothing we can do to recover
+                raise CommandException("You are screwed, buddy.")
+
+            else:
+                # Force hitting recovery code, by raising a generic error
+                #   that gets us to the "except" clause
+                raise DatabaseError
+
+        except DatabaseError:
+            self.stdout.write("Installing KA Lite; this may take a few minutes; please wait!\n")
+
+            out = call_command_with_output("install", interactive=False)
+            if out[1] or out[2]:
+                # Failed; report and exit
+                self.stderr.write(out[1])
+                raise CommandError("Failed to recover.")
+
+            if not Facility.objects.count():
+                # Install went through, but no facility and no admin.
+                # So, need to add a default
+                Facility(name=_("Default Facility")).save()
+
+        # Now call the proper command
+        if options["run_in_proc"]:
+            call_command("runserver", "%s:%s" % (options["host"], options["port"]))
+        else:
+            call_command("runcherrypyserver", *["%s=%s" % (key,val) for key, val in options.iteritems()])

--- a/kalite/securesync/users/models.py
+++ b/kalite/securesync/users/models.py
@@ -212,5 +212,4 @@ class CachedPassword(models.Model):
     class Meta:
         app_label = "securesync"
 
-
 engine.add_syncing_models([Facility, FacilityGroup, FacilityUser])

--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -1,9 +1,9 @@
 import json
-import os
 import logging
+import os
 import sys
-import time
 import tempfile
+import time
 import uuid
 import version  # in danger of a circular import.  NEVER add settings stuff there--should all be hard-coded.
 
@@ -197,6 +197,13 @@ else:
 
 
 ########################
+# Zero-config options
+########################
+
+ZERO_CONFIG   = getattr(local_settings, "ZERO_CONFIG", False)
+
+
+########################
 # Syncing and synced data
 ########################
 
@@ -354,3 +361,15 @@ if CONFIG_PACKAGE == "RPi":
     if CACHE_TIME != 0:
         CACHES["web_cache"]['LOCATION'] = getattr(local_settings, "CACHE_LOCATION", '/var/tmp/kalite_web_cache')
 
+
+########################
+# ZERO CONFIG
+########################
+
+if ZERO_CONFIG:
+    # Force all commands to run through our own serve command, which does auto-config if necessary
+    # TODO(bcipolli): simplify start scripts, just force everything through kaserve directly.
+    if "runserver" in sys.argv:
+        sys.argv[sys.argv.index("runserver")] = "kaserve"
+    elif "runcherrypyserver" in sys.argv:
+        sys.argv[sys.argv.index("runcherrypyserver")] = "kaserve"


### PR DESCRIPTION
... Will auto-join zone, sync, etc.

Core part of addressing #732.  Now, if the ZERO_CONFIG local setting is set, KA Lite will work the first time you start the server, without ever having to explicitly run the install script!  

![image](https://f.cloud.github.com/assets/4072455/1162515/b26990ba-2016-11e3-821d-443a2517c03c.png)

This means that we can drop the same code package on every USB stick, and users will be able to use KA Lite straightaway, as they are on one of two scenarios:
1. No sharing network information: then a network is created, and a default facility too.
2. With sharing network information: then the network is imported, and syncing can get facility info.

Notes & Future work:
- In this iteration, no superuser is created.  So this is only useful for doing exercises, and for manually copying video files.  Great start!
- In this iteration, sharing network data are not included in the imported JSON file, and only are available after successful sync.  In the future, getting all relevant data into the package would be great!

@jamalex could you take a look at the coding?  @rtibbles and @wangguan could you think about the admin experience?
