### PR TITLE
Adding revoked=False for consistency with Device.by_zone

### DIFF
--- a/kalite/securesync/engine/models.py
+++ b/kalite/securesync/engine/models.py
@@ -91,7 +91,7 @@ class SyncedModelManager(models.Manager):
     def by_zone(self, zone):
         # get model instances that were signed by devices in the zone,
         # or signed by a trusted authority that said they were for the zone
-        return self.filter(Q(signed_by__devicezone__zone=zone) |
+        return self.filter(Q(signed_by__devicezone__zone=zone, signed_by__devicezone__revoked=False) |
             Q(signed_by__devicemetadata__is_trusted=True, zone_fallback=zone))
 
 


### PR DESCRIPTION
title says it all.  @jamalex, this is super low impact; would give it 24 hours, then merge.  no bug, tested on local test central server via control_panel
