### PR TITLE
The beauty of counter=None on change...

### DIFF
--- a/kalite/coachreports/management/commands/generaterealdata.py
+++ b/kalite/coachreports/management/commands/generaterealdata.py
@@ -295,7 +295,6 @@ def generate_fake_exercise_logs(facility_user=None, topics=topics, start_date=da
                         points=int(points),
                         complete=completed,
                         completion_timestamp=date_completed,
-                        completion_counter=datediff(date_completed, start_date, units="seconds"),
                     )
                     elog.save(update_userlog=False)
 
@@ -431,7 +430,6 @@ def generate_fake_video_logs(facility_user=None, topics=topics, start_date=datet
                         points=points,
                         complete=(pct_completed == 100.),
                         completion_timestamp=date_completed,
-                        completion_counter=datediff(date_completed, start_date, units="seconds"),
                     )
                     vlog.save(update_userlog=False)  # avoid userlog issues
 

--- a/kalite/main/models.py
+++ b/kalite/main/models.py
@@ -45,7 +45,6 @@ class VideoLog(DeferredCountSyncedModel):
             self.complete = (self.points >= VideoLog.POINTS_PER_VIDEO)
             if not already_complete and self.complete:
                 self.completion_timestamp = datetime.now()
-                self.completion_counter = Device.get_own_device().get_counter_position()
 
             # Tell logins that they are still active (ignoring validation failures).
             #   TODO(bcipolli): Could log video information in the future.
@@ -125,7 +124,6 @@ class ExerciseLog(DeferredCountSyncedModel):
             if not already_complete and self.complete:
                 self.struggling = False
                 self.completion_timestamp = datetime.now()
-                self.completion_counter = Device.get_own_device().get_counter_position()
                 self.attempts_before_completion = self.attempts
 
             # Tell logins that they are still active (ignoring validation failures).


### PR DESCRIPTION
_Background:_
Securesync uses "counter" to determine which records to sync.  The maximum value "counter" sent over the wire becomes the starting counter for the next round-trip of syncing.  

This means that when records are sent over the wire, anything with a lower counter position than what's sent must be sent along with it--otherwise, it will never be requested to be sent in the future.  This logic causes dependencies between models, not just for their ForeignKey values, but for their counter values.

_Issue:_
In both the current version, and develop version of the syncing code, this counter dependency is not taken into account explicitly.  This is problematic.

_Severity:_
Low in the past, high now.  Because UserLogSummary records are sent over the wire before ExerciseLog records, but always have higher counters, this becomes an issue.  In addition, if a Facility or FacilityUser record were ever edited and saved, this could skip unsynced records.  There's some fudge factor, due to "limit" and "boost" in the master code that smooths out some of the issue--but guarantees nothing.

_Changes:_
- Make sure that if a model is going to be sent over the wire, that all models with a lower counter are sent along with it.
- With the new logic to set counters to None, this actually helps avoid this tremendously.  However, if we're sending something over wire with counter=None, then we have to send ALL models with a non-None counter that hasn't been set yet, as updating the None counter to a value would skip over those models.
- To mitigate this, make sure all records that have a deferred counter (Facility*, *Log) have it set to None.  Previously, on create it was NOT set to None, as that value is used for calculating the object's ID.  To solve this, I double-save the record--once to create the ID, once to eliminate the counter.

Concerns:
- If a user upgrades to this code and has not synced, they'll have a HUGE chunk of models that will have to be sent, potentially all at once.  Such large syncs, with unreliable internet connections, can lead to sync never completing, and therefore models never being downloaded.  
  - Future change: instead of sending all models with non-None counters all at once, just set those counters to None.

_Testing:_
- Tested many scenarios, including mixed counter_set and non-counter-set scenarios, including scenarios where models in the past were being skipped (can't send skipped models, but verified that things that would have been skipped in the past are no longer skipped)
