### PR TITLE
HTH: Allow packaging of data (like an initial sync) into downloadable json.

### DIFF
--- a/kalite/central/urls.py
+++ b/kalite/central/urls.py
@@ -80,6 +80,7 @@ urlpatterns += patterns('central.views',
     url(r'^download/kalite/(?P<version>[^\/]+)/(?P<platform>[^\/]+)/(?P<locale>[^\/]+)/$', 'download_kalite_public', {}, 'download_kalite_public'),
     # Downloads: private
     url(r'^download/kalite/(?P<version>[^\/]+)/(?P<platform>[^\/]+)/(?P<locale>[^\/]+)/(?P<zone_id>[^\/]+)/$', 'download_kalite_private', {}, 'download_kalite_private'),
+    url(r'^download/kalite/(?P<version>[^\/]+)/(?P<platform>[^\/]+)/(?P<locale>[^\/]+)/(?P<zone_id>[^\/]+)/(?P<include_data>[^\/]+)/$', 'download_kalite_private', {}, 'download_kalite_private'),
     # redirects for downloads
     url(r'^download/videos/(.*)$', lambda request, vpath: HttpResponseRedirect(OUTSIDE_DOWNLOAD_BASE_URL + vpath)),
 

--- a/kalite/central/views.py
+++ b/kalite/central/views.py
@@ -257,6 +257,7 @@ def install_multiple_server_edition(request):
         "version": kalite.VERSION,
         "platform": get_request_var(request, "platform", "all"),
         "locale": get_request_var(request, "locale", "en"),
+        "include_data": bool(get_request_var(request, "include_data", True)),
     }
 
     # Loop over orgs and zones, building the dict of all zones

--- a/kalite/securesync/devices/models.py
+++ b/kalite/securesync/devices/models.py
@@ -467,8 +467,13 @@ class ChainOfTrust(object):
         as well as supporting objects (such as DeviceMetadata)
         """
         device_list = [dict["device"] for dict in self.chain]
+        device_list += [self.zone_owner]  # make sure the zone owner makes it on there!
+
         invitation_list = [dict["zone_invitation"] for dict in self.chain if dict["zone_invitation"]]
+        invitation_list += ZoneInvitation.objects.filter(used_by=self.zone_owner)
+
         devicezone_list = [dict["device_zone"] for dict in self.chain if dict["device_zone"]]
+        devicezone_list += DeviceZone.objects.filter(device=self.zone_owner)
 
         # We return in this order because we know this order is necessary for serializing
         #   objects (due to interdependencies)

--- a/kalite/utils/platforms.py
+++ b/kalite/utils/platforms.py
@@ -80,7 +80,7 @@ def system_specific_zipping(files_dict, zip_file=None, compression=ZIP_DEFLATED,
             # Add with exec perms
             else:
                 info = ZipInfo(dest_path)
-                info.external_attr = 0755 << 16L # give full access to included file
+                info.external_attr = 0775# << 16L # give full access to included file
                 with open(src_path, "r") as fh:
                     zfile.writestr(info, fh.read())
 


### PR DESCRIPTION
This is a step in the direction of USB-based syncing and android installs.  It is needed for the HTH deployment of student-specific installs on USB sticks.

Changes:
- Make a generic function for getting models (not serialized models, but models) based on device counters.
- Use that function to get all models on a zone*

Issues:
- This may or may not work with zone_fallback data.  Haven't tested this, but this isn't specific to this PR--this would be a develop branch issue, if so, and part of the ChainOfTrust code.
