### PR TITLE
Added i18n documentation and starting places for Stanford hackathon 

### DIFF
--- a/docs/I18N.md
+++ b/docs/I18N.md
@@ -1,0 +1,83 @@
+# KA Lite i18n Documentation
+## Everything you ever wanted to know about KA Lite internationalization 
+
+`[ toc ]`
+
+## Notes for Hackathoners!
+If you're interested in helping with the i18n project, there are a few ways you can contribute. These instructions probably won't make much sense when you first read through them, but try reading the rest of the documentation and then coming back to them. They will definitely start to make more sense! 
+
+Ways to help:
+
+- After reading through the documentation below, check out the `update_po.py` management command. You will see that there is a flag `-t` whose functionality hasn't been built yet. If this flag is set, the command should read in the contents of freshly generated po files, fill in the translation strings with asterisks (and variable names if they exist) and then recompile the files by running `compilemessages`. See if you can make some progress on this helpful tool! 
+
+- Another way would be simply following the instructions below, manually finding unwrapped strings, and wrapping them in the translation tags. This would be extremely useful!  
+
+### Creating and Testing Interface Translations
+Note: many questions about i18n with Django can be answered via the [Django i18n Docs](https://docs.djangoproject.com/en/dev/topics/i18n/translation/). Also, check out the i18n management commands for shortcuts on following the steps below. 
+
+1. First, make sure you have the [GNU gettext toolset](https://www.gnu.org/software/gettext/) installed. If you have any trouble, try Googling "[How to install GNU gettext toolset for [insert-operating-system-here]](http://lmgtfy.com/?q=how+do+I+install+GNU+gettext+toolset+on+Mac)"
+
+2. Next, navigate to the project root directory (e.g. ```[local-path-to-ka-lite]/ka-lite/```)
+
+3. Run the ```makemessages``` command to generate po files for the languages you want. Read the docs linked above for more info on how this process works. You'll want to ignore the bundled python packages, because they've already been translated and are *big*. It's also a good idea to add the `--no-obsolete` flag to remove outdated strings. Example command: ```python kalite/manage.py makemessages -l en --ignore=python-packages/* --no-obsolete``` to generate po files for English. This example will create a ```django.po``` file in the ```locale/en/LC_MESSAGES``` directory.
+
+4. Run the ```makemessages``` command again to generate po files for javascript. It's a good idea to ignore any admin static files, as django has taken care of the i18n already. Example: ```python kalite/manage.py makemessages -d djangojs -l en --ignore=kalite/static/admin/js/* --no-obsolete```. This example will create a ```djangojs.po``` file in the ```locale/en/LC_MESSAGES``` directory.
+
+5. Inspect the two files you have generated. You should see something like:
+
+
+	> `#: kalite/central/views.py:85`
+
+	> `msgid "Account administration"`
+
+	> `msgstr ""`
+
+
+	> **Explanation**: each msgid string is a string in the KA Lite codebase. Each msgstr is where the translation for this language goes. Since this is an English po file and KA Lite is in English, no translation is necessary, but for testing, pick a string to translate into something else. 
+
+
+6. Find ```msgid "Admin"``` and translate it to something fun: e.g. ```msgstr "What does the fox say?"```
+
+7. Now that we have updated our translations, we need to compile the po files into a mo file so that it can be rendered by Django. To do that, we use the ```compilemessages``` command. Example: ```python kalite/manage.py compilemessages -l en```. This command compiles each po file in the ```en``` language directory and if you've been following along, should have created two new files: ```django.mo``` and ```djangojs.mo```. 
+
+8. Now, restart your local server and check out your translations! Note: Not seeing your translations? It *could* be a caching problem! Try opening in a different browser, clearing your cache, or turning caching off. 
+
+####Common Error Messages 
+- Error: This script should be run from the Django SVN tree or your project or app tree. If you did indeed run it from the SVN checkout or your project or application, maybe you are just missing the conf/locale (in the django tree) or locale (for project and application) directory? It is not created automatically, you have to create it by hand if you want to enable i18n for your project or application. **Solution**: You need to create an empty ```locale``` directory in the project root ```path-to-kalite/ka-lite/locale/```. After creating, try running ```makemessages``` again. 
+- python: can't open file 'manage.py': [Errno 2] No such file or directory. **Solution**: ensure that when you are running manage.py commands from the project root, you specify where to find manage.py, e.g. python kalite/manage.py [command]
+
+
+### Finding unwrapped strings and wrapping them
+*This should be done periodically. As the codebase changes, it is likely that user-facing strings will be added, and these will need to wrapped in the appropriate translation tags so that they can appear in our po template files and be translated.*
+
+1. The easiest way to identify unwrapped strings in the codebase is to translate the interface into something wacky, and see what's left in plain english. Then you just find that spot in the code, wrap it in translation tags, and move on with your day! Therefore, the first step in this process is following steps 1-5 in the above section "Creating and Testing Interface Translations"
+
+2. Once you have fresh new po files, you basically just replace step 6 with the following: translate every single string into something obviously non-English. You could get fancy and write a script to reverse  all of the msgids, or you could just use a test editor to select all the msgstrs and fill them in with '\*\*\*\*\*'. 
+
+3. Once all msgstrs have been filled in, follow steps 7-8 in the above section "Creating and Testing Interface Translations".
+
+4. Walk through all of the views in the interface. When you see something in English, you know that string needs to be wrapped. Follow the instructions in the [Django i18n Docs](https://docs.djangoproject.com/en/dev/topics/i18n/translation/) to wrap the offending string in the correct translation tags. You can use examples in other parts of the codebase as well for help. 
+
+	**Important**: When running `compilemessages` you will probably run into the error: `a format specification for argument 'variable_name' doesn't exist in 'msgstr'`. Check out the line in the file. You'll probably see something like `'%(variable_name)s'` in msgid. This is how variables appear. You simply need to copy and paste this variable name (e.g. `'%(variable_name)s'`) into the asterisk filled msgstr. There shouldn't be too many, so doing it manually isn't a killer. E.g. `msgstr "***** '%(facility_name)s'"`
+
+
+5. Once you think you've found everything, repeat the steps in this section. See if you find anything else. Rinse and repeat! 
+
+6. Once you're done testing, be sure to delete the po and mo files you have created. Translations are not overwritten by creating running the makemessages command, so you will want clear the tests you created so that people using KA Lite in English won't just see a bunch of asterisks :). 
+
+
+### How to use i18n Management Commands
+A couple of management commands have been written to automate the processes outlined in other sections of the documentation. Here's how to use them.
+
+#### Command: update_po
+
+- This command is useful for automating some of the processes described below, including generating po files and compiling translations. You can run `python manage.py update_po -h` to see available options.  
+
+#### Command: generate_dubbed_video_mappings
+
+- This command creates a dictionary that maps english videos to dubbed video ids, using the manually curated online Google Docs spreadsheet provided by Khan Academy's i18n team.
+
+
+###### Help:
+If anything is unclear, email Dylan Barth: dylan@learningequality.org with questions. It's his fault that this is so messy :)  
+

--- a/docs/TESTBED.md
+++ b/docs/TESTBED.md
@@ -67,38 +67,3 @@ Setting up KA Lite testing servers
     5. Select your zone, and click the "register" button.
 6. On LOCAL, run `python manage.py generaterealdata` to generate test data.
 7. On LOCAL, run `python manage.py syncmodels` to begin the syncing process.  The output should confirm that syncing has occurred.
-
-
-### Creating and Testing Interface Translations
-Note: many questions about i18n with Django can be answered via the [Django i18n Docs](https://docs.djangoproject.com/en/dev/topics/i18n/translation/)
-
-1. First, make sure you have the [GNU gettext toolset](https://www.gnu.org/software/gettext/) installed. If you have any trouble, try Googling "[How to install GNU gettext toolset for [insert-operating-system-here]](http://lmgtfy.com/?q=how+do+I+install+GNU+gettext+toolset+on+Mac)"
-
-2. Next, navigate to the project root directory (e.g. ```[local-path-to-ka-lite]/ka-lite/```)
-
-3. Run the ```makemessages``` command to generate po files for the languages you want. Read the docs linked above for more info on how this process works. Example: ```python kalite/manage.py makemessages -l en``` to generate po files for English. This example will create a ```django.po``` file in the ```locale/en/LC_MESSAGES``` directory.
-
-4. Run the ```makemessages``` command again to generate po files for javascript. Example: ```python kalite/manage.py makemessages -d djangojs -l en```. This example will create a ```djangojs.po``` file in the ```locale/en/LC_MESSAGES``` directory.
-
-5. Inspect the two files you have generated. You should see something like:
-
-
-    #: kalite/central/views.py:85
-    msgid "Account administration"
-    msgstr ""
-
-
-    **Explanation**: each msgid string is a string in the KA Lite codebase. Each msgstr is where the translation for this language goes. Since this is an English po file and KA Lite is in English, no translation is necessary, but for testing, pick a string to translate into something else. 
-
-
-6. Find ```msgid "Admin"``` and translate it to something fun: e.g. ```msgstr "I'm in Hawaii lol"```
-
-7. Now that we have updated our translations, we need to compile the po files into a mo file so that it can be rendered by Django. To do that, we use the ```compilemessages``` command. Example: ```python kalite/manage.py compilemessages -l en```. This command compiles each po file in the ```en``` language directory and if you've been following along, should have created two new files: ```django.mo``` and ```djangojs.mo```. 
-
-8. Now, restart your local server and check out your translations! Note: Not seeing your translations? It *could* be a caching problem! Try opening in a different browser, clearing your cache, or turning caching off. 
-
-####Common Error Messages 
-- Error: This script should be run from the Django SVN tree or your project or app tree. If you did indeed run it from the SVN checkout or your project or application, maybe you are just missing the conf/locale (in the django tree) or locale (for project and application) directory? It is not created automatically, you have to create it by hand if you want to enable i18n for your project or application. **Solution**: You need to create an empty ```locale``` directory in the project root ```path-to-kalite/ka-lite/locale/```. After creating, try running ```makemessages``` again. 
-- python: can't open file 'manage.py': [Errno 2] No such file or directory. **Solution**: ensure that when you are running manage.py commands from the project root, you specify where to find manage.py, e.g. python kalite/manage.py [command]
-
-

--- a/kalite/i18n/management/commands/update_po.py
+++ b/kalite/i18n/management/commands/update_po.py
@@ -14,23 +14,47 @@ from utils.general import ensure_dir
 
 class Command(BaseCommand):
 	option_list = BaseCommand.option_list + (
-		# make_option('--verbose', '-v', dest='', help=''),
+		make_option('--test', '-t', dest='test_wrappings', action="store_true", default=False, help='Running with -t will fill in current po files msgstrs with asterisks. This will allow you to quickly identify unwrapped strings in the codebase and wrap them in translation tags! Remember to delete after your finished testing.'),
+		make_option('--new_po', '-n', dest='new_po', action="store_true", default=False, help='Running with -n will run the makemessages command to generate new po files.'),
+		make_option('--post_po', '-p', dest='post_po', action="store_true", default=False, help='Running with -p will copy the current po files to the static url so that they can be inserted into CrowdIn.'),
 	)
-	help = 'Run command to generate a fresh pot file and expose it via the central/api.'
+	help = 'Po management commands. See options for usage help.'
 
 	def handle(self, **options):
-		# Change to project root dir
-		project_root = os.path.join(settings.PROJECT_PATH, "../")
-		os.chdir(project_root)
-		ensure_dir(os.path.join(project_root, "locale/"))
 
-		# Generate english po file
-		management.call_command('makemessages', locale='en')
-		# Generate english po file for javascript
-		management.call_command('makemessages', domain='djangojs', locale='en')
+		if options.get("new_po"):
+			generate_new_po_files()
+		if options.get("post_po"):
+			# check_po_files() -- check them for asterisks before posting them - another great hackathon project!
+			post_po_files()
+		if options.get("test_wrappings"):
+			generate_test_files()
 
-		# cp new files into static dir (which should be exposed for download) 
-		static_path = os.path.join(settings.STATIC_ROOT, "pot/")
-		ensure_dir(static_path)
-		shutil.copy(os.path.join(settings.LOCALE_PATHS[0], "en/LC_MESSAGES/django.po"), os.path.join(static_path, "kalite.pot"))
-		shutil.copy(os.path.join(settings.LOCALE_PATHS[0], "en/LC_MESSAGES/djangojs.po"), os.path.join(static_path, "kalitejs.pot"))
+def generate_new_po_files():
+	"""Run makemessages on relevant parts of codebase to create new po files"""
+	# Change to project root dir
+	project_root = os.path.join(settings.PROJECT_PATH, "../")
+	os.chdir(project_root)
+	ensure_dir(os.path.join(project_root, "locale/"))
+
+	# Generate english po file
+	ignore_pattern = ['python-packages/*']
+	management.call_command('makemessages', locale='en', ignore_patterns=ignore_pattern, no_obsolete=True)
+	# Generate english po file for javascript
+	ignore_pattern = ['kalite/static/admin/js/*']
+	management.call_command('makemessages', domain='djangojs', locale='en', ignore_patterns=ignore_pattern, no_obsolete=True)
+
+
+def post_po_files():
+	"""Copy current po files into static dir (which is be exposed for download)""" 
+	static_path = os.path.join(settings.STATIC_ROOT, "pot/")
+	ensure_dir(static_path)
+	shutil.copy(os.path.join(settings.LOCALE_PATHS[0], "en/LC_MESSAGES/django.po"), os.path.join(static_path, "kalite.pot"))
+	shutil.copy(os.path.join(settings.LOCALE_PATHS[0], "en/LC_MESSAGES/djangojs.po"), os.path.join(static_path, "kalitejs.pot"))
+
+def generate_test_files():
+	"""Insert asterisks as translations in po files"""
+	# A great hackathon project!!
+	# (hopefully) helpful outline: you'll probably need to open up the po files, read through them, extract any variables, and insert 
+	# asterisks and variables into the msgstr. 
+	return True


### PR DESCRIPTION
Changed:
1. I extracted i18n testing info from TESTBED.md and created an I18N.md doc with that info plus more helpful stuff.
2. I broke out the functionality of `update_po.py` into individual parts that can be called by using the different options. I also added a function stub for the people participating in the hackathon to have somewhere to start. 

@bcipolli you're pretty familiar with this code already from the number of times you had to test it for me... 
To test, you can run `python manage.py update_po -h` to see the options, and run with each flag to test functionality. 

@wangguan59 if you have time, I would really appreciate someone with a UX eye reading through the docs and seeing 1) if they make sense and 2) if following the instructions gets you up and running from scratch. 
