### PR TITLE
Fixing badness in south files.

### DIFF
--- a/kalite/management/commands/install.py
+++ b/kalite/management/commands/install.py
@@ -231,7 +231,7 @@ class Command(BaseCommand):
         import serverstop
 
         # Should clean_pyc for (clean) reinstall purposes
-        call_command("clean_pyc", migrate=True, interactive=False, verbosity=options.get("verbosity"))
+        call_command("clean_pyc", interactive=False, verbosity=options.get("verbosity"))
 
         # Migrate the database
         call_command("syncdb", interactive=False, verbosity=options.get("verbosity"))

--- a/kalite/securesync/migrations/0020_auto__add_field_devicemetadata_is_demo_device.py
+++ b/kalite/securesync/migrations/0020_auto__add_field_devicemetadata_is_demo_device.py
@@ -20,6 +20,12 @@ class Migration(SchemaMigration):
 
 
     models = {
+        'securesync.cachedpassword': {
+            'Meta': {'object_name': 'CachedPassword'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'unique': 'True'})
+        },
         'securesync.device': {
             'Meta': {'object_name': 'Device'},
             'counter': ('django.db.models.fields.IntegerField', [], {'default': '0'}),


### PR DESCRIPTION
@jamalex, wrote this email, then solved the problem.  Can you check that this is the right fix?

CachedPassword exists in the db, but when I run ./manage.py schemamigration securesync --auto, I get a migration file creating that table.

It's created in one of the 0019 migration files.  I assume that the fact that there are multiple 0019 migration files is part of the problem, but I thought that was solved by using the merge=True flag.

I look at 0020_*, and that file has no cachedpassword in it.  When I copy that table in, seems to iron things out.

Help?
