### PR TITLE
Cache the own_device, to avoid (innumerable) queries for this object 

### DIFF
--- a/kalite/securesync/devices/models.py
+++ b/kalite/securesync/devices/models.py
@@ -146,6 +146,7 @@ class Device(SyncedModel):
 
     objects = DeviceManager()
     key = None
+    own_device = None  # cached property, shared globally.
 
     class Meta:
         app_label = "securesync"
@@ -231,12 +232,13 @@ class Device(SyncedModel):
 
     @classmethod
     def get_own_device(cls):
-        devices = DeviceMetadata.objects.filter(is_own_device=True)
-        if devices.count() == 0:
-            own_device = cls.initialize_own_device() # why don't we need name or description here?
-        else:
-            own_device = devices[0].device
-        return own_device
+        if not cls.own_device:
+            devices = DeviceMetadata.objects.filter(is_own_device=True)
+            if devices.count() == 0:
+                cls.own_device = cls.initialize_own_device() # why don't we need name or description here?
+            else:
+                cls.own_device = devices[0].device
+        return cls.own_device
 
     @classmethod
     def initialize_own_device(cls, **kwargs):


### PR DESCRIPTION
(which, after install, never changes)

For logging in, for example, this reduces queries from ~40 to ~25.

Testing:
- Tested fresh install (works)
- Ran test suite (no unexpected failures)

PR Help:
- Timing: 24 hours.  This is a small change, with appropriate testing.
- @jamalex could you code review the code change?
- @aronasorman could you code review the code change
