### PR TITLE
Set a max # of results, to avoid churn on the server.  Configurable (but not currently exposed)

### DIFF
--- a/kalite/templates/search_page.html
+++ b/kalite/templates/search_page.html
@@ -1,29 +1,48 @@
 {% extends 'base_distributed.html' %}
+{% load i18n %}
+{% load my_filters %}
+
+{% block headcss %}
+<style>
+    h3 {
+        margin:20px 0px 5px 0px;
+    }
+</style>
+{% endblock headcss %}
 
 {% block content %}
-<h2>Search results for '{{ query }}'</h2>
-  {% for category, subresults in results.iteritems %}
-    <h3 style="margin:20px 0px 5px 0px">{{ category }}</h3>
-    <ul>
-    {% for node in subresults %}
-      <li>
-	{% if node.kind == 'Topic' %}
-	    {% if node.nvideos_local == 0 %}
-		<a href="{{ node.path }}" class="topic-unavailable">{{ node.title }}</a>
-	    {% else %}
-		<a href="{{ node.path }}" class="topic-available">{{ node.title }}</a>
-	    {% endif %}
-	{% elif node.kind == 'Video' %}
-	    {% if node.video_on_disk %}
-		<a href="{{ node.path }}" class="video-available">{{ node.title }}</a>
-	    {% else %}
-		<a class="video-unavailable">{{ node.title }}</a>
-	    {% endif %}
-	{% else %}
-	    <a href="{{ node.path }}">{{ node.title }}</a>
-	{% endif %}
-      </li>
+{% if query_error %}
+    <h2 class="errorlist">{{ query_error }}</h2>
+
+{% else %}
+    <h2>{{ title }}</h2>
+
+    {% for category, subresults in results.iteritems %}
+        <h3>{{ category }}{% if hit_max|get_item:category %} ({% trans "showing first " %}{{ max_results }} {% trans " results" %}){% endif %}</h3>
+        <ul>
+        {% for node in subresults %}
+            <li>
+            {% if node.kind == 'Topic' %}
+                {% if node.nvideos_local == 0 %}
+                <a href="{{ node.path }}" class="topic-unavailable">{{ node.title }}</a>
+                {% else %}
+                <a href="{{ node.path }}" class="topic-available">{{ node.title }}</a>
+                {% endif %}
+            {% elif node.kind == 'Video' %}
+                {% if node.video_on_disk %}
+                <a href="{{ node.path }}" class="video-available">{{ node.title }}</a>
+                {% else %}
+                <a class="video-unavailable">{{ node.title }}</a>
+                {% endif %}
+            {% else %}
+                <a href="{{ node.path }}">{{ node.title }}</a>
+            {% endif %}
+            </li>
+        {% endfor %}
+        {% if hit_max|get_item:category %}
+            <li>...</li>
+        {% endif %}
+        </ul>
     {% endfor %}
-    </ul>
-  {% endfor %}
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Issue:
- Blank search string, or generic ("a") search string, could churn the server--even if accidental
- Missing search would redirect to the homepage--could be confusing.

Changes:
- Limit searches to a configurable number (default: 25)
- Notify the user (print a message in each header, add "..." to bottom of results) when that limit has been hit
- Show an error when no query was passed

Notes:
- Still not efficient enough on the client, nor server sides:
  - Clients should persist (if possible) the flat_topic_tree dictionary (takes a lot of time to compute).  Otherwise, we'll have to disable by default (to avoid slow loading on every page for weak clients, like tablets)
  - Server should cache l-cased titles during the first search.  Re-computing on every search uses CPU, whereas memory is still much cheaper.

PR Help requests:
- @aronasorman please take a look.  Take a look at the styling of code as well, some style differences that we're trying to make uniform (spaces instead of tabs, indenting style for dictionaries, function calls, etc)

![image](https://f.cloud.github.com/assets/4072455/1325612/ea520422-34ce-11e3-867a-8d7d5559f914.png)

![image](https://f.cloud.github.com/assets/4072455/1325610/dfb89990-34ce-11e3-8e62-f505e3ec1cca.png)
