### PR TITLE
Defer loading of flat_topic_tree until the first keypress.

### DIFF
--- a/kalite/static/js/search_autocomplete.js
+++ b/kalite/static/js/search_autocomplete.js
@@ -1,23 +1,33 @@
 $(document).ready(function() {
-    var results = [];
+    var results = null;
     
-    $.ajax({ 
-        url: "/api/flat_topic_tree", 
-        cache: true,
-        dataType: "json",
-        success: function(categories) {
-            for (var category_name in categories) { // category is either Video, Exercise or Topic
-                var category = categories[category_name];
-                for (var node_name in category) {
-                    node = category[node_name];
-                    results.push(node.title);
-                }
-            }
-        }
-    });
     $("#search").autocomplete({
-        minLength: 3,
+        minLength: 0,
         source: function(request, response) {
+            // Load on demand.
+            if (!results) {
+                results = [];  // prevent multiple requests
+                $.ajax({ 
+                    url: "/api/flat_topic_tree", 
+                    cache: true,
+                    dataType: "json",
+                    success: function(categories) {
+                        for (var category_name in categories) { // category is either Video, Exercise or Topic
+                            var category = categories[category_name];
+                            for (var node_name in category) {
+                                node = category[node_name];
+                                results.push(node.title);
+                            }
+                        }
+                    }
+                });
+            }
+            // secondary way to do 'minlength', to allow early load-on-demand
+            if (request.term.length < 3) {
+                return;
+            }
+
+            // Do the filtering
             var results_filtered = $.ui.autocomplete.filter(results, request.term); // do some filtering here already
             response(results_filtered.slice(0, 15));
         }


### PR DESCRIPTION
Issue:
Pageloads are still quite laggy after the search checkin.  This is due to the client parsing a 1.1MB json file on every request.

Changes:
For now, defer getting/parsing of the json until the first keypress.  The lag for users (hitting the 3rd key) should not be noticeable, except perhaps the first time the json is retrieved.

PR help:
- @aronasorman, what do you think?
