### PR TITLE
LocalStorage-cached search

### DIFF
--- a/kalite/static/js/search_autocomplete.js
+++ b/kalite/static/js/search_autocomplete.js
@@ -1,3 +1,6 @@
+var results = null;
+var timeout_length = 1000 * 20; // 20 seconds
+
 function isLocalStorageAvailable() {
     var testString = "hello peeps"
     try {
@@ -8,13 +11,12 @@ function isLocalStorageAvailable() {
     }
 }
 
-var results = null;
-
 function fetchTopicTree() {
     $.ajax({
         url: "/api/flat_topic_tree",
         cache: true,
         dataType: "json",
+	timeout: timeout_length;
         success: function(categories) {
             results = [];
             for (var category_name in categories) { // category is either Video, Exercise or Topic
@@ -39,8 +41,7 @@ $(document).ready(function() {
         }
 
         if (results === null) {
-            var timeout = 1000 * 20 // 20 second timeout
-            setTimeout(fetchTopicTree(), timeout);
+	    fetchTopicTree();
         }
     });
 


### PR DESCRIPTION
Here's an alternative to the "start fetching only on 1st keypress" solution to the slow page load. This basically caches the topic tree titles onto localStorage when present (which is basically in all browsers except IE versions < 8). Therefore we avoid fetching the 1.1 MB JSON except on the first page load of KA Lite.

I got motivated to do this because I was having usability issues with the other solution: Autocomplete suggestions don't appear when I start typing and wait, and only come back once I start typing again. So this PR also contains a revert of that solution, restoring the autocomplete to the previous behavior.

@bcipolli can you test this if page load feels snappy again (hopefully by the 2nd reload)?
