### PR TITLE
Create the locate directory in case it not exists.

### DIFF
--- a/kalite/utils/django_utils/i18n.py
+++ b/kalite/utils/django_utils/i18n.py
@@ -6,6 +6,7 @@ import os
 import json
 
 import settings
+from utils.general import ensure_dir
 
 class MetaDataNotFound(Exception):
 
@@ -19,6 +20,7 @@ def get_installed_languages():
 
 	# Loop through locale folder
 	locale_dir = settings.LOCALE_PATHS[0]
+	ensure_dir(locale_dir)
 
 	for lang in os.listdir(locale_dir):
 		# Inside each folder, read from the JSON file - language name, % UI trans, version number


### PR DESCRIPTION
When starting ka-lite for the first time and trying to install more languages, I received an error message:

OSError at /update/languages/
[Errno 2] No such file or directory: $PATH/ka-lite/locale/'

This ensure the locate directory is created and should fix the issue.
