### PR TITLE
Append startup username to cache directory

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -407,8 +407,6 @@ if package_selected("RPi"):
 
     PASSWORD_ITERATIONS_TEACHER = getattr(local_settings, "PASSWORD_ITERATIONS_TEACHER", 2000)
     PASSWORD_ITERATIONS_STUDENT = getattr(local_settings, "PASSWORD_ITERATIONS_STUDENT", 1000)
-    if CACHE_TIME != 0:
-        CACHES["web_cache"]['LOCATION'] = getattr(local_settings, "CACHE_LOCATION", '/var/tmp/kalite_web_cache')
 
 if package_selected("UserRestricted"):
     KEY_PREFIX += "|restricted"  # this option changes templates


### PR DESCRIPTION
Simple fix for #551.  When starting the server, use the current username as part of the cache directory.

Other possible fixes (like setting permissions on the cache directory) had too many caveats / issues; glad to discuss if desired.

@gimick could you take a look?
