### PR TITLE
hints no longer reset points if you've correctly answered the question

### DIFF
--- a/kalite/static/js/exercises.js
+++ b/kalite/static/js/exercises.js
@@ -58,6 +58,8 @@ function updatePercentCompleted(correct) {
 
 };
 
+var hintsResetPoints = true; // Sometimes it's OK to view hints (like, after a correct answer)
+
 $(function() {
 
     $(Khan).bind("loaded", function() {
@@ -66,9 +68,19 @@ $(function() {
     });
     $(Exercises).bind("checkAnswer", function(ev, data) {
         updatePercentCompleted(data.correct);
+        
+        // after giving a correct answer, no penalty for viewing a hint.
+        // after giving an incorrect answer, penalty for giving a hint (as a correct answer will give you points)
+        hintsResetPoints = !data.correct;
+        $("#hint-remainder").toggle(hintsResetPoints); // hide/show message about hints
+    });
+    $(Exercises).bind("gotoNextProblem", function(ev, data) {
+        // When ready for the next problem, hints matter again!
+        hintsResetPoints = true;
+        $("#hint-remainder").toggle(hintsResetPoints); // hide/show message about hints
     });
     $(Exercises).bind("hintUsed", function(ev, data) {
-        if (exerciseData.hintUsed) { // only register the first hint used on a question
+        if (exerciseData.hintUsed || !hintsResetPoints) { // only register the first hint used on a question
             return;
         }
         exerciseData.hintUsed = true;

--- a/kalite/static/js/search_autocomplete.js
+++ b/kalite/static/js/search_autocomplete.js
@@ -16,7 +16,7 @@ function fetchTopicTree() {
         url: "/api/flat_topic_tree",
         cache: true,
         dataType: "json",
-	timeout: timeout_length;
+        timeout: timeout_length,
         success: function(categories) {
             results = [];
             for (var category_name in categories) { // category is either Video, Exercise or Topic


### PR DESCRIPTION
...until the next question begins!

Addresses #810.

Test scenarios:
- After right answer, click hint, points OK!
- After right answer, click hint, next problem right, points OK!
- After right answer, click hint, next problem wrong, points to 0
- After wrong answer, click hint, answer: still get 0
