### PR TITLE
Limit admin usernames to letters, numbers, underscores

### DIFF
--- a/kalite/management/commands/install.py
+++ b/kalite/management/commands/install.py
@@ -57,7 +57,7 @@ def find_owner(file):
     return getpass.getuser()
 
 def validate_username(username):
-    return username and (not re.match(r'^[^a-zA-Z]', username) and not re.match(r'[^a-zA-Z0-9_]+', username))
+    return bool(username and (not re.match(r'^[^a-zA-Z]', username) and not re.match(r'^.*[^a-zA-Z0-9_]+.*$', username)))
 
 def get_username(username):
     while not validate_username(username):


### PR DESCRIPTION
We tried to do that, but apparently we failed!  Our failed check can lead to failures downstream.
(Solves https://github.com/learningequality/ka-lite/issues/870)

Testing:
- Tested with space ("a b") (now fails properly)
- Tested with leading 1 ("1a"), (continues to fail properly)
- Tested with "abc" - still succeeds properly.
