### PR TITLE
Add i18n loading to templates that were missing them after strings were wrapped

### DIFF
--- a/kalite/templates/central/homepage.html
+++ b/kalite/templates/central/homepage.html
@@ -1,5 +1,6 @@
 {% extends 'central/base.html' %}
 
+{% load i18n %}
 {% load staticfiles %}
 
 {% block title %}Home{% endblock title %}

--- a/kalite/templates/coachreports/scatter_view.html
+++ b/kalite/templates/coachreports/scatter_view.html
@@ -1,5 +1,6 @@
 {% extends "coachreports/base_d3_visualization.html" %}
 
+{% load i18n %}
 {% load repeatblock %}
 {% load my_filters %}
 {% load staticfiles %}

--- a/kalite/templates/registration/registration_form.html
+++ b/kalite/templates/registration/registration_form.html
@@ -1,5 +1,7 @@
 {% extends "registration/base.html" %}
 
+{% load i18n %}
+
 {% block title %}{% trans "Sign up" %}{% endblock %}
 
 {% block headcss %}


### PR DESCRIPTION
Added {% load i18n %} to templates that were missing them.
