### PR TITLE
Lead users who need to register to install, back to installation after account registration and activation

### DIFF
--- a/kalite/main/middleware.py
+++ b/kalite/main/middleware.py
@@ -5,15 +5,6 @@ from config.models import Settings
 from settings import LOG as logging
 
 
-class GetNextParam:
-    def process_request(self, request):
-        next = request.GET.get("next", "")
-        if next.startswith("/"):    
-            request.next = next
-        else:
-            request.next = ""
-
-
 # TODO(dylan): new class that handles finding and setting the language for the session
 class SessionLanguage:
     def process_request(self, request):

--- a/kalite/middleware.py
+++ b/kalite/middleware.py
@@ -1,0 +1,11 @@
+from settings import LOG as logging
+
+class GetNextParam:
+    def process_request(self, request):
+        next = request.GET.get("next", "")
+        if next.startswith("/"):
+            logging.debug("next='%s'" % next)
+            request.next = next
+        else:
+            request.next = ""
+

--- a/kalite/registration/backends/default/__init__.py
+++ b/kalite/registration/backends/default/__init__.py
@@ -77,7 +77,7 @@ class DefaultBackend(object):
         else:
             site = RequestSite(request)
         new_user = RegistrationProfile.objects.create_inactive_user(username, first_name, last_name, email, 
-                                                                    password, site)
+                                                                    password, site, next=getattr(request, "next", None))
         signals.user_registered.send(sender=self.__class__,
                                      user=new_user,
                                      request=request)

--- a/kalite/registration/views.py
+++ b/kalite/registration/views.py
@@ -10,7 +10,7 @@ from django.contrib.auth import logout as auth_logout, views as auth_views, REDI
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db import IntegrityError, transaction
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.shortcuts import render_to_response
 from django.template import RequestContext
@@ -29,7 +29,10 @@ from shared.decorators import central_server_only
 def complete(request, *args, **kwargs):
     messages.success(request, "Congratulations! Your account is now active. To get started, "
         + "login to the central server below, to administer organizations and zones.")
-    return redirect("auth_login")
+    if hasattr(request, "next") and request.next:
+        return HttpResponseRedirect(request.next)
+    else:
+        return redirect("auth_login")
 
 
 @central_server_only
@@ -97,11 +100,14 @@ def activate(request, backend,
     account = backend.activate(request, **kwargs)
 
     if account:
-        if success_url is None:
+        if success_url:
+            return redirect(success_url)
+        elif getattr(request, "next") and request.next:
+            to, args, kwargs = backend.post_activation_redirect(request, account)
+            return HttpResponseRedirect(reverse(to) + "?next=" + request.next, *args, **kwargs)
+        else:
             to, args, kwargs = backend.post_activation_redirect(request, account)
             return redirect(to, *args, **kwargs)
-        else:
-            return redirect(success_url)
 
     if extra_context is None:
         extra_context = {}

--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -145,7 +145,7 @@ MIDDLEWARE_CLASSES = (
     "django.middleware.common.CommonMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-    "main.middleware.GetNextParam",
+    "kalite.middleware.GetNextParam",
     "django.middleware.csrf.CsrfViewMiddleware",
 ) + MIDDLEWARE_CLASSES  # append local_settings middleware, in case of dependencies
 

--- a/kalite/templates/registration/activation_email.txt
+++ b/kalite/templates/registration/activation_email.txt
@@ -1,6 +1,6 @@
 {% load humanize %}
 Someone, hopefully you, signed up for a new account with KA Lite using this email address. If it was you, and you'd like to activate and use your account, click the link below or copy and paste it into your web browser's address bar:
 
-http://{{ central_server_host }}/accounts/activate/{{ activation_key }}/
+http://{{ central_server_host }}/accounts/activate/{{ activation_key }}/{% if next %}?next={{ next }}{% endif %}
 
 If you didn't request this, you don't need to do anything; you won't receive any more email from us, and the account will expire automatically in {{ expiration_days|apnumber }} days.

--- a/kalite/templates/registration/login.html
+++ b/kalite/templates/registration/login.html
@@ -17,7 +17,7 @@
 
 <p>Please note that this is the central server; you cannot log in here using your local server's account information.</p>
 
-<p>If you do not have an account on the central server, you can <a href="/accounts/register/">sign up here</a>.</p>
+<p>If you do not have an account on the central server, you can <a href="{% url registration_register %}{% if request.next %}?next={{ request.next }}{% endif %}">sign up here</a>.</p>
 
 {% if form.errors %}
   {% if debug %}
@@ -66,6 +66,6 @@
 	<input type="submit" class="button" value="Log in" />
 </form>
 
-<p>If you've forgotten your password, you can <a href="/accounts/password/reset/">reset it here</a>.</p>
+<p>If you've forgotten your password, you can <a href="{% url auth_password_reset %}">reset it here</a>.</p>
 
 {% endblock %}


### PR DESCRIPTION
In order for users to install the "multi-server edition", they need to login.  If they haven't registered (and it's unlikely they have), they need to register first... which also requires activation.  By the time they activate, they'll have to restart the installation process, which can be confusing ( #917 )

Now, we expose a "next" URL parameter for the link to "sign up" on the login page.  When this is used, the user will actually be redirected to their desired page upon successful registration and activation.

Testing:
1. Click "install"
2. Click "multi-server edition"
3. From the login page, click "sign up"
4. Register, and copy the activation link (should contain a "next" URL parameter)
5. When activating, you should be brought to the login page (should contain a "next" URL parameter).
6. After logging in, you should be brought to the "multi-server edition" install page.

@wangguan59 could you try this out?
