### PR TITLE
Add two places where instructions will be displayed: after download, and in a downloaded README file.

### DIFF
--- a/kalite/central/management/commands/package_for_download.py
+++ b/kalite/central/management/commands/package_for_download.py
@@ -38,6 +38,10 @@ from utils.platforms import is_windows, system_script_extension, system_specific
 
 
 def install_from_package(install_json_file, signature_file, zip_file, dest_dir=None):
+    """
+    NOTE: This docstring (below this line) will be dumped as a README file.
+    Congratulations on downloading KA Lite!  These instructions will help you install KA Lite.
+    """
     import glob
     import os
     import shutil
@@ -195,7 +199,7 @@ class Command(BaseCommand):
                 fp.write("print 'Installation completed!'")
             
             # Create clickable scripts: unix
-            install_sh_file = self.install_py_file[:-3] + ".sh"
+            install_sh_file = self.install_py_file[:-3] + "_linux.sh"
             install_files[install_sh_file] = tempfile.mkstemp()[1]
             with open(install_files[install_sh_file], "w") as fp:
                 fp.write(open(os.path.realpath(settings.PROJECT_PATH + "/../scripts/python.sh"), "r").read())
@@ -203,23 +207,26 @@ class Command(BaseCommand):
                 fp.write('\n$PYEXEC "$current_dir/%s"' % self.install_py_file)
 
             # Create clickable scripts: mac
-            install_command_file = self.install_py_file[:-3] + ".command"
+            install_command_file = self.install_py_file[:-3] + "_mac.command"
             install_files[install_command_file] = tempfile.mkstemp()[1]
             with open(install_files[install_command_file], "w") as fp:
                 fp.write('\ncurrent_dir=`dirname "${BASH_SOURCE[0]}"`')
                 fp.write('\nsource "$current_dir/%s"' % install_sh_file)
 
             # Create clickable scripts: windows
-            install_bat_file = self.install_py_file[:-3] + ".bat"
+            install_bat_file = self.install_py_file[:-3] + "_windows.bat"
             install_files[install_bat_file] = tempfile.mkstemp()[1]
             with open(install_files[install_bat_file], "w") as fp:
                 fp.write("start /b /wait python.exe %s" % self.install_py_file)
 
-            # Change permissions--I WISH THIS WORKED!!
-            if not is_windows():
-                for fil in install_files.values():
-                    os.chmod(fil, 0775)
-
+            # Dump readme file
+            readme_file = "README"
+            install_files[readme_file] = tempfile.mkstemp()[1]
+            with open(install_files[readme_file], "w") as fp:
+                # First line of docstring is a message that the docstring will
+                #   be the readme.  Remove that, dump the rest raw!
+                fp.write(inspect.getdoc(install_from_package).split("\n", 2)[1])
+            
             return install_files
         install_files = create_install_files()
 

--- a/kalite/central/urls.py
+++ b/kalite/central/urls.py
@@ -72,6 +72,7 @@ urlpatterns += patterns('central.views',
     # The install wizard app has two views: both options available (here)
     #   or an "edition" selected (to get more info, or redirect to download, below)
     url(r'^install/$', 'install_wizard', {}, 'install_wizard'),
+    url(r'^install/thankyou/$', 'download_thankyou', {}, 'download_thankyou'),
     url(r'^install/(?P<edition>[\w-]+)/$', 'install_wizard', {}, 'install_wizard'),
 
     # Downloads: public

--- a/kalite/templates/central/download_thankyou.html
+++ b/kalite/templates/central/download_thankyou.html
@@ -1,0 +1,52 @@
+{% extends "central/base.html" %}
+
+{% load i18n %}
+{% load my_filters %}
+{% load staticfiles %}
+
+{% block title %}{% trans "Thank you for installing KA Lite!" %}{% endblock %}
+
+{% block install_active %}active{% endblock install_active %}
+
+{% block headcss %}
+<style>
+#instructions li {
+    font-size:14px;
+    margin: 2px;
+}
+</style>
+{% endblock headcss %}
+
+{% block content %}
+<h1>Thank you for downloading KA Lite{% if version %}{{ version }}{% endif %}!</h1>
+
+{% if download_url %}
+<div>
+    <meta http-equiv="refresh" content="1;{{ download_url }}" />
+    <a href="{{ download_url }}">Click here</a> if download does not start within 5 seconds.</a>
+</div>
+{% endif %}
+
+<div id="instructions">
+    <div id="post-download">
+        <h2>What do I do after download?</h2>
+        <ul>
+            <li>When the download completes, copy the file to your server(s).</li>
+            <li>From the server(s), unzip the zip file.</li>
+            <li>From the server(s), run the install_from_zip script file for your operating system</li>
+        </ul>
+    </div>
+    <div id="python-instructions">
+        <h2>Do you have Python?</h2>
+        Python is the program that runs KA Lite; some systems may not have it.
+        <ul>
+            <li>If you need it, <a target="_new" href="http://www.python.org/getit/releases/2.7.5/#download">download Python</a> (version 2.7).</li>
+            <li>Copy the Python installer over to your server(s).</li>
+            <li>Install Python <b>before you install KA Lite</b></li>
+            <li>Make sure to add Python to your PATH (<a target="_new" href="https://www.google.com/search?q=add+python+to+path+tutorial+windows">Windows</a>, <a target="_new" href="https://www.google.com/search?q=add+python+to+path+tutorial+linux">Linux</a>, <a target="_new" href="https://www.google.com/search?q=add+python+to+path+tutorial+mac">MacOS</a>)</li>
+            <li>Then, install KA Lite (instructions above)</li>
+        </ul>
+    </div>
+
+</div>
+{% endblock %}


### PR DESCRIPTION
This partially addresses #905.  README content still TBD (but can be done by others, now that the structure is there).

Also changed script names to include OS name, to be easier to identify.

Testing:
- Browse to /install/thankyou/ to see the raw thankyou page.
- Go through the install wizard (both single-server and multi-server editions); you should go to the thankyou page when download is ready, and it should trigger the download
- After downloading, if you unpack the zip, there should be a README file (with minimal content)

![image](https://f.cloud.github.com/assets/4072455/1488258/4308bc22-4745-11e3-8855-5b312736fdfc.png)
