### PR TITLE
Make sure that multiple installs of KA Lite have their own cache location

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -1,4 +1,5 @@
 import getpass
+import hashlib
 import json
 import logging
 import os
@@ -343,7 +344,10 @@ if not CENTRAL_SERVER:
         KEY_PREFIX = version.VERSION
 
         # File-based cache
-        CACHE_LOCATION = getattr(local_settings, "CACHE_LOCATION", os.path.join(tempfile.gettempdir(), "kalite_web_cache_" + (getpass.getuser() or "unknown_user"))) + "/"
+        install_location_hash = hashlib.sha1(PROJECT_PATH).hexdigest()
+        username = getpass.getuser() or "unknown_user"
+        cache_dir_name = "kalite_web_cache_%s_%s" % (install_location_hash, username)
+        CACHE_LOCATION = os.path.realpath(getattr(local_settings, "CACHE_LOCATION", os.path.join(tempfile.gettempdir(), cache_dir_name ))) + "/"
         CACHES["file_based_cache"] = {
             'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
             'LOCATION': CACHE_LOCATION, # this is kind of OS-specific, so dangerous.


### PR DESCRIPTION
Title says it all.

Issue:
- Install 2 versions of KA Lite on the same machine, and you can get incorrectly rendered pages, as their cache locations may overlap.

Solution:
- Hash the path of the installation (which uniquely defines it), and include that hash in the cache location.

Testing:
- True test:
  - Install KA Lite, download videos, render (and therefore cache) landing page
  - Install another version of KA Lite.  Start as the same user as the previous, render the landing page.
  - In the past, this would show the page of the other install (with videos available).  now, it does not :)
- Fake test:
  - Just install KA Lite and make sure it works :)
