### PR TITLE
Make all distributed templates use base_template variable.

### DIFF
--- a/kalite/templates/404.html
+++ b/kalite/templates/404.html
@@ -1,4 +1,4 @@
-{% extends "base_distributed.html" %}
+{% extends base_template %}
 
 {% load i18n %}
 

--- a/kalite/templates/500.html
+++ b/kalite/templates/500.html
@@ -1,4 +1,4 @@
-{% extends "base_distributed.html" %}
+{% extends base_template %}
 
 {% load i18n %}
 

--- a/kalite/templates/admin_distributed.html
+++ b/kalite/templates/admin_distributed.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 {% load i18n %}
 {% load staticfiles %}
 

--- a/kalite/templates/current_users.html
+++ b/kalite/templates/current_users.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 
 {% load i18n %}
 {% load staticfiles %}

--- a/kalite/templates/exercise.html
+++ b/kalite/templates/exercise.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 
 {% load i18n %}
 {% load staticfiles %}

--- a/kalite/templates/homepage.html
+++ b/kalite/templates/homepage.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 
 {% load i18n %}
 {% load staticfiles %}

--- a/kalite/templates/knowledgemap.html
+++ b/kalite/templates/knowledgemap.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 {% load i18n %}
 {% load staticfiles %}
 

--- a/kalite/templates/search_page.html
+++ b/kalite/templates/search_page.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 {% load i18n %}
 {% load my_filters %}
 

--- a/kalite/templates/securesync/add_facility_user.html
+++ b/kalite/templates/securesync/add_facility_user.html
@@ -1,10 +1,11 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
+{% load i18n %}
+
 {% block addteacher_active %}{% if user_id == "new" and teacher %}active{% endif %}{% endblock addteacher_active %}
 {% block addstudent_active %}{% if user_id == "new" and not teacher %}active{% endif %}{% endblock addstudent_active %}
 {% block signup_active %}{% if user_id == "new" and not request.admin %}active{% endif %}{% endblock signup_active %}
 {% block easy_admin_active %}{% if user_id != "new" and request.admin %}active{% endif %}{% endblock easy_admin_active %}
 
-{% load i18n %}
 
 {% block headjs %}{{ block.super }}
 <script>

--- a/kalite/templates/securesync/add_group.html
+++ b/kalite/templates/securesync/add_group.html
@@ -1,5 +1,4 @@
-{% extends 'base_distributed.html' %}
-
+{% extends base_template %}
 {% load i18n %}
 
 {% block title %}{% trans "Add Group" %}{% endblock title %}

--- a/kalite/templates/securesync/facility_selection.html
+++ b/kalite/templates/securesync/facility_selection.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 
 {% load i18n %}
 

--- a/kalite/templates/securesync/login.html
+++ b/kalite/templates/securesync/login.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 
 {% load i18n %}
 

--- a/kalite/templates/securesync/register_public_key_client.html
+++ b/kalite/templates/securesync/register_public_key_client.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 
 {% load i18n %}
 

--- a/kalite/templates/securesync/register_public_key_server.html
+++ b/kalite/templates/securesync/register_public_key_server.html
@@ -1,4 +1,4 @@
-{% extends "central/base.html" %}
+{% extends base_template %}
 
 {% load i18n %}
 

--- a/kalite/templates/summary_stats.html
+++ b/kalite/templates/summary_stats.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 
 {% load i18n %}
 

--- a/kalite/templates/topic.html
+++ b/kalite/templates/topic.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 {% load i18n %}
 {% load my_filters %}
 

--- a/kalite/templates/updates/update.html
+++ b/kalite/templates/updates/update.html
@@ -1,5 +1,4 @@
-{% extends 'base_distributed.html' %}
-
+{% extends base_template %}
 {% load i18n %}
 {% load repeatblock %}
 {% load staticfiles %}

--- a/kalite/templates/updates/update_languages.html
+++ b/kalite/templates/updates/update_languages.html
@@ -1,5 +1,4 @@
-{% extends 'base_distributed.html' %}
-
+{% extends base_template %}
 {% load i18n %}
 {% load staticfiles %}
 

--- a/kalite/templates/updates/update_software.html
+++ b/kalite/templates/updates/update_software.html
@@ -1,5 +1,4 @@
-{% extends 'base_distributed.html' %}
-
+{% extends base_template %}
 {% load i18n %}
 {% load staticfiles %}
 {% load my_filters %}

--- a/kalite/templates/updates/update_videos.html
+++ b/kalite/templates/updates/update_videos.html
@@ -1,5 +1,4 @@
-{% extends 'base_distributed.html' %}
-
+{% extends base_template %}
 {% load i18n %}
 {% load staticfiles %}
 

--- a/kalite/templates/video.html
+++ b/kalite/templates/video.html
@@ -1,4 +1,4 @@
-{% extends 'base_distributed.html' %}
+{% extends base_template %}
 
 {% load i18n %}
 {% load staticfiles %}


### PR DESCRIPTION
This allows flexibility moving forward--for example, to have a base template that has a different style, or overall different approach.

Have used this in a couple of demos, but not in production code yet.
