### PR TITLE
Reduce complexity of error messages in the common case where there is only one facility.

### DIFF
--- a/kalite/securesync/users/forms.py
+++ b/kalite/securesync/users/forms.py
@@ -48,9 +48,14 @@ class FacilityUserForm(forms.ModelForm):
         username_taken = FacilityUser.objects.filter(username__iexact=username, facility=facility).count() > 0
         username_changed = not self.instance or self.instance.username != username
         if username_taken and username_changed:
-            raise forms.ValidationError(_("A user with this username at this facility already exists. Please choose a new username (or select a different facility) and try again."))
+            if self.fields["facility"].queryset and self.fields["facility"].queryset.count() > 1:
+                error_message = _("A user with this username at this facility already exists. Please choose a new username (or select a different facility) and try again.")
+            else:
+                error_message = _("A user with this username already exists. Please choose a new username and try again.")
+            raise forms.ValidationError(error_message)
 
-        if User.objects.filter(username__iexact=username).count() > 0:
+        elif User.objects.filter(username__iexact=username).count() > 0:
+            # Admin (django) user exists with the same name; we don't want overlap there!
             raise forms.ValidationError(_("The specified username is unavailable. Please choose a new username and try again."))
 
         return self.cleaned_data['username']
@@ -124,7 +129,11 @@ class LoginForm(forms.ModelForm):
         try:
             self.user_cache = FacilityUser.objects.get(username=username, facility=facility)
         except FacilityUser.DoesNotExist as e:
-            raise forms.ValidationError(_("Username was not found for this facility. Did you type your username correctly, and choose the right facility?"))
+            if self.fields["facility"].queryset.count() > 1:
+                error_message = _("Username was not found for this facility. Did you type your username correctly, and choose the right facility?")
+            else:
+                error_message = _("Username was not found. Did you type your username correctly?")
+            raise forms.ValidationError(error_message)
 
         if not self.user_cache.check_password(password):
             self.user_cache = None


### PR DESCRIPTION
Title says it all.  Low impact change, testing not necessary.  Just look at the screen shots:
Note that when 2 or more facilities exist (rare), users will see the old error messages.

old:
![image](https://f.cloud.github.com/assets/4072455/1505969/a5c36ee6-48ff-11e3-8b92-8118d349fa46.png)

new:
![image](https://f.cloud.github.com/assets/4072455/1505968/92089aac-48ff-11e3-8498-bbc658456243.png)

old:
![image](https://f.cloud.github.com/assets/4072455/1505971/b3bc1c1e-48ff-11e3-8d55-49d99ada722c.png)

new:
![image](https://f.cloud.github.com/assets/4072455/1505972/ca2d9e1e-48ff-11e3-8317-488ac7c496bd.png)
