### PR TITLE
updating schema (and content) of version file

### DIFF
--- a/kalite/version.py
+++ b/kalite/version.py
@@ -1,24 +1,106 @@
 # THIS IS USED BY settings.py.  NEVER import settings.py here; hard-codes only!
 VERSION = "0.11.1"
-BUILD = "dummy"
-RELEASE_DATE="2013/08/26"
 VERSION_INFO = {
+
+    "0.11.1": {
+        "release_date": "2013/11/28",
+        "git_commit": "bb2c7048d22abb76aa7dcfeb89e7a06820372480",
+        "new_features": {
+            "all": ["over 5x faster performance"],
+            "students": [],
+            "coaches": [],
+            "admins": [],
+        },
+        "bugs_fixed": {
+            "all": [],
+            "students": [],
+            "coaches": [],
+            "admins": [],
+        },
+    },
+
     "0.11.0": {
         "release_date": "2013/09/03",
-        "new_features": [
-            "0.11 feature 1",
-            "0.11 feature 2",
-            "0.11 feature 3",
-        ],
-        "bugs_fixed": None,
+        "git_commit": "29eb96e136d702b5d128b6bbb1b5c347457d080f",
+        "new_features": {
+            "all": [],
+            "students": [],
+            "coaches": [],
+            "admins": ["automated registration", "download and install via zip"],
+        },
+        "bugs_fixed": {
+            "all": [],
+            "students": [],
+            "coaches": [],
+            "admins": [],
+        },
     },
+
+    "0.10.2": {
+        "release_date": "2013/10/08",
+        "git_commit": "5831abb8d2ee0815416a17885790679c4672bf97",
+        "new_features": {
+            "all": [],
+            "students": ["import your KA progress into KA Lite"],
+            "coaches": [],
+            "admins": ["now start KA Lite by double-clicking the start script"],
+        },
+        "bugs_fixed": {
+            "all": [],
+            "students": [],
+            "coaches": [],
+            "admins": [],
+        },
+    },
+
+    "0.10.1": {
+        "release_date": "2013/09/16",
+        "git_commit": "f048c11289059f36af0bd1c368f9e0fb354b49b5",
+        "new_features": {
+            "all": ["we have a new (online) website"],
+            "students": [],
+            "coaches": [],
+            "admins": [],
+        },
+        "bugs_fixed": {
+            "all": ["better performance"],
+            "students": [],
+            "coaches": [],
+            "admins": [],
+        },
+    },
+
     "0.10.0": {
         "release_date": "2013/08/26",
-        "new_features": [
-            "0.10.0 feature 1",
-            "0.10.0 feature 2",
-            "0.10.0 feature 3",
-        ],
-        "bugs_fixed": None,
+        "git_commit": "d375134f2f9f1e0cc3cc1bed73227dcecf1061f3",
+        "new_features": {
+            "all": [],
+            "students": ["summary of progress", "video available indicators"],
+            "coaches": ["extended coach reports", "online coach reports"],
+            "admins": ["online usage reports", "synchronization reports"],
+        },
+        "bugs_fixed": {
+            "all": [],
+            "students": [],
+            "coaches": [],
+            "admins": [],
+        },
+    },
+
+    "0.9.2": {
+        "release_date": "2013/02/xx",
+        "git_commit": "",
+        "new_features": {
+            "all": [],
+            "students": [],
+            "coaches": [],
+            "admins": [],
+        },
+        "bugs_fixed": {
+            "all": [],
+            "students": [],
+            "coaches": [],
+            "admins": [],
+        },
     },
 }


### PR DESCRIPTION
Now, our version file contains not only the version #, but manifest data about all released versions.  In this scheme, build number is part of the metadata of each version.

Any comments on the schema of the data (and the data itself!) would be greatly appreciated!
