### PR TITLE
Update redirects from message, so user is brought to the appropriate page

### DIFF
--- a/kalite/securesync/users/middleware.py
+++ b/kalite/securesync/users/middleware.py
@@ -27,7 +27,7 @@ class FacilityCheck:
         Cache facility data in the session,
           while making sure anybody who can create facilities sees the real (non-cached) data
         """
-        if not "facility_exists" in request.session or request.is_admin:  
+        if not "facility_exists" in request.session or request.is_admin:   # always refresh for admins
             request.session["facility_count"] = Facility.objects.count()
             request.session["facility_exists"] = request.session["facility_count"] > 0
 


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/4072455/1507754/6826b81a-49a7-11e3-842c-3b256f78b9d3.png)

old behavior:
- the link will take you to the register page... even though it's being displayed because there's no facility.

new behavior:
- if the server is not registered, you'll be brought to the registration page.
- if the server is registered, you'll be brought to the facility creation page.

@gimick or @rtibbles could you confirm?
