### PR TITLE
Fix for #1022 - show Video points

### DIFF
--- a/kalite/static/js/videoplayer.js
+++ b/kalite/static/js/videoplayer.js
@@ -391,7 +391,7 @@ window.PointView = Backbone.View.extend({
     Passively display the point count to the user (and listen to changes on the model to know when to update).
     */
 
-    el: $(".points-container"),
+    el: ".points-container",
 
     initialize: function() {
 


### PR DESCRIPTION
Changed the video points view, so that it was no longer reliant on the DOM being loaded to bind the view to the DOM element.

This fixes #1022
