### PR TITLE
Short circuit KA /api/v1 calls, which actually slow down our server.

### DIFF
--- a/kalite/main/api_urls.py
+++ b/kalite/main/api_urls.py
@@ -1,15 +1,13 @@
 from django.conf.urls.defaults import include, patterns, url
-from django.http import HttpResponse
+from django.http import HttpResponseServerError
 
 import settings
 import updates.api_urls
 
+
 # Note that these patterns are all under /api/,
 # due to the way they've been included into main/urls.py
 urlpatterns = patterns('main.api_views',
-
-    # toss out any requests made to actual KA site urls
-    url(r'^v1/', lambda x: HttpResponse("{}")),
 
     # For video / exercise pages
     url(r'^save_video_log$', 'save_video_log', {}, 'save_video_log'),
@@ -38,6 +36,13 @@ urlpatterns = patterns('main.api_views',
     url(r'^getpid$', 'getpid', {}, 'getpid'),
 )
 
+
 urlpatterns += patterns('updates.api_views',
     url(r'^', include(updates.api_urls)),
+)
+
+# Placed at the bottom, so that it's the last to be checked (not first)
+urlpatterns += patterns('',
+    # toss out any requests made to actual KA site urls
+    url(r'^v1/', lambda x: HttpResponseServerError("This is an assert--you should disable these calls from KA in the javascript code!")),
 )

--- a/kalite/static/js/khan-exercises/interface.js
+++ b/kalite/static/js/khan-exercises/interface.js
@@ -511,6 +511,9 @@ $(window).unload(function() {
 });
 
 function request(method, data) {
+    // short circuit
+    return true;
+
     var apiBaseUrl = (Exercises.assessmentMode ?
             "/api/v1/user/assessment/exercises" : "/api/v1/user/exercises");
 


### PR DESCRIPTION
Put a simple short-circuit into the KA exercises code.
Change our URLs logic to make sure we don't forget to do this every time we update the `khan-exercises` code.
