### PR TITLE
disable gzip in nginx

### DIFF
--- a/scripts/optimizerpi.sh
+++ b/scripts/optimizerpi.sh
@@ -124,8 +124,8 @@ http {
 
     ##
     # Gzip Settings
-    gzip on;
-    gzip_disable "msie6";
+    # We are CPU limited, not bandwidth limited, so don't gzip
+    gzip off;
 
     ##
     # Virtual Host Configs


### PR DESCRIPTION
We are CPU limited, not network bandwidth limited, so don't waste resources gzipping content.

This PR gives a 1-2 percentage point improvement on CPU usage (50% vs 52%)
