### PR TITLE
Fix video invalidation by full search on disk for each topic load.

### DIFF
--- a/kalite/main/views.py
+++ b/kalite/main/views.py
@@ -100,7 +100,7 @@ def refresh_topic_cache(handler, force=False):
                 strip_counts_from_ancestors(node)
         return node
 
-    def refresh_topic_cache_wrapper_fn(request, cached_nodes={}, *args, **kwargs):
+    def refresh_topic_cache_wrapper_fn(request, cached_nodes={}, force=False, *args, **kwargs):
         """
         Centralized logic for how to refresh the topic cache, for each type of object.
 
@@ -129,9 +129,10 @@ def refresh_topic_cache(handler, force=False):
             elif node["kind"] == "Topic":
                 bottom_layer_topic =  "Topic" not in node["contains"]
                 # always run video_counts_need_update(), to make sure the (internal) counts stay up to date.
+                force = video_counts_need_update() or force or bottom_layer_topic
                 recount_videos_and_invalidate_parents(
                     node,
-                    force=video_counts_need_update() or force or bottom_layer_topic,
+                    force=force,
                     stamp_urls=bottom_layer_topic,
                 )
 


### PR DESCRIPTION
Fixes #838

There were two issues; one was fixed previously, catching the second here:
- Need to check all videos for any updates, on each (non-cached) topic page load
- `stamp_video_counts` works recursively, and needed to propagate all input flags to all recursive calls.
