### PR TITLE
The script now exits properly...

### DIFF
--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -55,3 +55,4 @@ if not exist "%KALITE_DIR%\database\data.sqlite" (
     )
 )
 
+exit


### PR DESCRIPTION
After running "start.bat", the script would make some calls and not exit to the main CMD.

Simple fix - added "exit" to the main script.
