### PR TITLE
Allow admins to set LOCKDOWN, and force all users to log in to an account to view.

### DIFF
--- a/kalite/securesync/users/middleware.py
+++ b/kalite/securesync/users/middleware.py
@@ -1,3 +1,7 @@
+from django.core.exceptions import PermissionDenied
+from django.core.urlresolvers import reverse
+
+import settings
 from .models import Facility
 
 
@@ -39,3 +43,11 @@ class FacilityCheck:
         if not "facility_exists" in request.session or request.is_admin:
             # always refresh for admins, or when no facility exists yet.
             refresh_session_facility_info(request, facility_count=Facility.objects.count())
+
+class LockdownCheck:
+    def process_request(self, request):
+        """
+        Whitelist only a few URLs, otherwise fail.
+        """
+        if settings.LOCKDOWN and not request.is_logged_in and request.path not in [reverse("homepage"), reverse("login"), reverse("add_facility_student"), reverse("status")]:
+            raise PermissionDenied()

--- a/kalite/securesync/users/views.py
+++ b/kalite/securesync/users/views.py
@@ -260,6 +260,7 @@ def login(request, facility):
     return {
         "form": form,
         "facilities": facilities,
+        "sign_up_url": reverse("add_facility_student"),
     }
 
 

--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -225,6 +225,7 @@ else:
         "securesync.middleware.RegisteredCheck",
         "securesync.middleware.DBCheck",
         "kalite.i18n.middleware.SessionLanguage",
+        "securesync.middleware.LockdownCheck",
     )
 
     TEMPLATE_CONTEXT_PROCESSORS += ("i18n.custom_context_processors.languages",)
@@ -346,6 +347,9 @@ assert PASSWORD_ITERATIONS_STUDENT_SYNCED >= 2500, "PASSWORD_ITERATIONS_STUDENT_
 PASSWORD_CONSTRAINTS = getattr(local_settings, "PASSWORD_CONSTRAINTS", {
     'min_length': getattr(local_settings, 'PASSWORD_MIN_LENGTH', 6),
 })
+
+LOCKDOWN = getattr(local_settings, "LOCKDOWN", False)
+
 
 ########################
 # Storage and caching

--- a/kalite/templates/securesync/login.html
+++ b/kalite/templates/securesync/login.html
@@ -14,4 +14,11 @@
 
         <input type="submit" value="{% trans 'Log in' %}" class="submit" />
     </form>
+    <div style="margin-top:20px">
+    {% if not restricted %}
+        {% blocktrans %}If you don't have a login, please <a href="{{ sign_up_url }}" style="font-weight: bold; color:blue">sign up</a>.{% endblocktrans %}
+    {% else %}
+        {% blocktrans %}If you don't have a login, please contact your administrator.{% endblocktrans %}
+    {% endif %}
+    </div>
 {% endblock content %}


### PR DESCRIPTION
**Background**:
I believe we originally set up KA Lite to be completely open (no login required), because we wanted to err on the side of accessible.  The downsides of this are:
- Schools and users may not take advantage of the mastery-based learning approach by accessing the content while logged in.  In fact, _they may not even be aware of these features_.
- We still sync back very little data from users.

My experience in Gitwe is that at least some users are both informed by administrators on how to log in, and familiar with the login process.  

**Changes**:
I've implemented a `setting`, `LOCKDOWN`, that  when set to `True`, will require students to have an account, and to log in, in order to access resources.  If they try to access resources without being logged in, they'll be prompted to log in--which now, also has a link to `sign up`.

Currently, by default, `LOCKDOWN = False`; however, I would argue that it is generally in the best interests of the users _and_ us to set the default to `True.
