### PR TITLE
Prevent overflow of text in download button box on video update page.

### DIFF
--- a/kalite/static/css/updates/update_videos.css
+++ b/kalite/static/css/updates/update_videos.css
@@ -1,5 +1,5 @@
 .button_text {
-    white-space: nowrap;
+    margin-bottom: 0px;
 }
 
 ul.dynatree-container li, .ui-widget-content {


### PR DESCRIPTION
Fix for #1187.

One line fix. Remove no-wrap for text box, reduce bottom margin on text to reduce risk of overflow out the bottom of the text box. Hopefully German is the most verbose language.

![overflowfix](https://f.cloud.github.com/assets/1680573/1942382/9f2a4576-7f98-11e3-9cba-2a25f52cf0f4.png)
