### PR TITLE
Quick fix to get Backbone wrapper/point tracking working on Flash again.

### DIFF
--- a/kalite/static/js/videoplayer.js
+++ b/kalite/static/js/videoplayer.js
@@ -262,7 +262,7 @@ window.VideoView = Backbone.View.extend({
 
         this._pointView = new PointView({model: this.model});
 
-        var player_id = this.$("video").attr("id");
+        var player_id = this.$("video, object").parent().attr("id");
 
         if (player_id) { // if it's using mplayer, there won't be a player here
             this.player = this.model.player = _V_(player_id);


### PR DESCRIPTION
Was able to narrow down my fixes to this single line change, to fix #1369 (in my testing). Anyone with Firefox (@aronasorman, @ruimalheiro ?), please test that videos load correctly (using the Flash player), and point tracking works correctly. Thanks!
