### PR TITLE
solve #1381: Define settings.LANGUAGES based on language packs we have downloaded

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -507,3 +507,15 @@ if package_selected("UserRestricted"):
 
     if CACHE_TIME != 0 and not hasattr(local_settings, KEY_PREFIX):
         KEY_PREFIX += "|restricted"  # this option changes templates
+
+
+# (Aron): Setting the LANGUAGES configuration.
+# This is a bit more involved, as we need to hand out to a function to calculate
+# the LANGUAGES settings. This LANGUAGES setting is basically a whitelist of
+# languages. Anything not in here is not accepted by Django, and will simply show
+# english instead of the selected language.
+if 'LANGUAGES' in dir(local_settings):
+    LANGUAGES = local_settings.LANGUAGES
+else:
+    from settingshelper import get_language_alist
+    LANGUAGES = set(get_language_alist(LOCALE_PATHS))

--- a/kalite/settingshelper.py
+++ b/kalite/settingshelper.py
@@ -1,0 +1,12 @@
+import glob
+import json
+import os
+
+def get_language_alist(localepaths):
+    for localepath in localepaths:
+        for langdir in os.listdir(localepath):
+            mdfile = glob.glob(os.path.join(localepath, langdir, '*_metadata.json'))[0]
+            with open(mdfile) as f:
+                metadata = json.load(f)
+            lc = metadata['code'].lower() # django reads language codes in lowercase
+            yield (lc, metadata['name'])


### PR DESCRIPTION
Solves #1381. Small change. We basically define our set of languages upon initialization by looking into the `LOCALE_PATHS`, iterating over each language found there, and returning that list (well, a generator, which we turn into a list).
