### PR TITLE
fix #1381: show language's native names if possible in the installed language list

### DIFF
--- a/kalite/shared/i18n.py
+++ b/kalite/shared/i18n.py
@@ -105,6 +105,9 @@ def get_supported_language_map(lang_code=None):
         lang_map.update(SUPPORTED_LANGUAGE_MAP.get(lang_code) or {})
         return lang_map
 
+def lang_best_name(l):
+    return l.get('native_name') or l.get('ka_name') or l.get('name')
+
 def get_supported_languages():
     return get_supported_language_map().keys()
 

--- a/kalite/updates/views.py
+++ b/kalite/updates/views.py
@@ -30,7 +30,7 @@ from securesync.models import Facility, FacilityUser, FacilityGroup, Device
 from securesync.views import require_admin, facility_required
 from shared import topic_tools
 from shared.decorators import require_admin
-from shared.i18n import lcode_to_ietf, get_installed_language_packs
+from shared.i18n import lcode_to_ietf, get_installed_language_packs, lang_best_name
 from shared.jobs import force_job
 from utils.internet import am_i_online, JsonResponse
 
@@ -60,7 +60,7 @@ def update_videos(request, max_to_show=5):
     force_job("videodownload", _("Download Videos"))  # async request
 
     installed_languages = set_language_choices(request, force=True)
-    languages_to_show = [l['name'] for l in installed_languages.values()[:max_to_show]]
+    languages_to_show = [lang_best_name(l) for l in installed_languages.values()[:max_to_show]]
     other_languages_count = max(0, len(installed_languages) - max_to_show)
 
     context = update_context(request)


### PR DESCRIPTION
Short change. New utility function (`lang_best_name`) allows us to choose the best name to display for a language. Then use that function in the language list before we hand off to the template.

Picture time!
![translatedlangs](https://f.cloud.github.com/assets/191955/2055906/418d9a4a-8acd-11e3-9c1a-1620297fa3c5.png)
