### PR TITLE
fix #1399: Lowercase lang codes before comparing

### DIFF
--- a/kalite/main/api_views.py
+++ b/kalite/main/api_views.py
@@ -365,7 +365,7 @@ def getpid(request):
 @backend_cache_page
 def flat_topic_tree(request, lang_code):
 
-    if lang_code != request.language:
+    if lang_code.lower() != request.language.lower():
         return JsonResponseMessageError(_("Currently, only retrieving the flat topic tree in the user's currently selected language is supported (current='%(current_lang)s', requested='%(requested_lang)s').") % {
             "current_lang": request.session.get(settings.LANGUAGE_COOKIE_NAME),
             "requested_lang": lang_code,


### PR DESCRIPTION
Err, there _might_ be a better way to do this, hence the PR. But basically, the problem is sometimes we get 'pt-BR' for `request.language` and `pt-br` for `lang_code`. Bring them first to lowercase before comparing.
