### PR TITLE
1406: Capitalize the native names of the supported languages.

### DIFF
--- a/data/i18n/languagelookup.json
+++ b/data/i18n/languagelookup.json
@@ -186,7 +186,7 @@
   },
   "fr":{
     "name":"French",
-    "native_name":"français, langue française",
+    "native_name":"Français, langue française",
     "ka_name":"francais"
   },
   "ff":{
@@ -507,7 +507,7 @@
   },
   "pl":{
     "name":"Polish",
-    "native_name":"polski"
+    "native_name":"Polski"
   },
   "ps":{
     "name":"Pashto, Pushto",
@@ -821,7 +821,7 @@
   },
   "fr-CA":{
     "name":"French, Canada",
-    "native_name":"français, canada"
+    "native_name":"Français, canada"
   },
   "ful":{
     "name":"Fula",
@@ -866,10 +866,6 @@
   "pnb":{
     "name":"Punjabi",
     "native_name":"ਪੰਜਾਬੀ"
-  },
-  "pt-BR":{
-    "name":"Portuguese, Brazil",
-    "native_name":"português, brasil"
   },
   "que":{
     "name":"Quechua",

--- a/kalite/shared/i18n.py
+++ b/kalite/shared/i18n.py
@@ -235,7 +235,7 @@ def get_code2lang_map(lang_code=None, force=False):
 
         CODE2LANG_MAP = {}
         for lc, entry in lmap.iteritems():
-            CODE2LANG_MAP[lcode_to_ietf(lc)] = dict(zip(entry.keys(), [v.lower() for v in entry.values()]))
+            CODE2LANG_MAP[lcode_to_ietf(lc)] = entry
 
     return CODE2LANG_MAP.get(lang_code) if lang_code else CODE2LANG_MAP
 


### PR DESCRIPTION
Solves #1406. Straightforward. We capitalize the native names in `languagelookup.json`, and then avoid further downcasing in `getcode2langmap`. There is also some duplication of `pt-BR`, which made debugging this problem longer than i'd like.
