### PR TITLE
solve #1392: Make an estimate of the video size and indicate it's an estimate

### DIFF
--- a/kalite/shared/videos.py
+++ b/kalite/shared/videos.py
@@ -10,9 +10,10 @@ from utils.videos import *  # get all into the current namespace, override some.
 
 
 REMOTE_VIDEO_SIZE_FILEPATH = os.path.join(settings.DATA_PATH_SECURE, "content", "video_file_sizes.json")
+AVERAGE_VIDEO_SIZE = 14000000
 
 REMOTE_VIDEO_SIZES = None
-def get_remote_video_size(youtube_id, default=None, force=False):
+def get_remote_video_size(youtube_id, default=AVERAGE_VIDEO_SIZE, force=False):
     global REMOTE_VIDEO_SIZES
     if REMOTE_VIDEO_SIZES is None:
         REMOTE_VIDEO_SIZES = softload_json(REMOTE_VIDEO_SIZE_FILEPATH, logger=logging.debug)

--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -270,7 +270,7 @@ def annotate_topic_tree(node, level=0, statusdict=None, remote_sizes=None, lang_
 
         if not percent:
             status = "unstarted"
-            vid_size = get_remote_video_size(youtube_id, 0) / float(2**20)  # express in MB
+            vid_size = get_remote_video_size(youtube_id) / float(2**20)  # express in MB
         elif percent == 100:
             status = "complete"
             vid_size = get_local_video_size(youtube_id, 0) / float(2**20)  # express in MB


### PR DESCRIPTION
When we have no record of the video size (aka it's 0MB), output our estimate of the video size, based on the average size of the videos. The average is set at 14 MB.

![frestimate](https://f.cloud.github.com/assets/191955/2073096/ca71bcc2-8d4f-11e3-84d7-ca6fcd90acf3.png)
