### PR TITLE
#1440, #1441: Add translation tags for untranslated values across the coach reports.

### DIFF
--- a/kalite/coachreports/views.py
+++ b/kalite/coachreports/views.py
@@ -273,7 +273,8 @@ def tabular_view(request, facility, report_type="exercise"):
     (groups, facilities) = get_accessible_objects_from_logged_in_user(request, facility=facility)
     context = plotting_metadata_context(request, facility=facility)
     context.update({
-        "report_types": ("exercise", "video"),
+        # For translators: the following two translations are nouns
+        "report_types": (_("exercise"), _("video")),
         "request_report_type": report_type,
         "topics": [{"id": t[0]["id"], "title": t[0]["title"]} for t in topics if t],
     })

--- a/kalite/templates/coachreports/base_d3_visualization.html
+++ b/kalite/templates/coachreports/base_d3_visualization.html
@@ -267,7 +267,7 @@
                 <option value="">----</option>
                 {% for stat in stats %}
                 {% if stat.type == "number" %}
-                <option value="{{ stat.key }}"{% if stat.key = form|get_item:axis_value %} selected{% endif %}>{{ stat.name }}</option>
+                <option value="{{ stat.key }}"{% if stat.key = form|get_item:axis_value %} selected{% endif %}>{% trans stat.name %}</option>
                 {% endif %}
                 {% endfor %}
             {% endblock data_options %}

--- a/kalite/templates/coachreports/scatter_view.html
+++ b/kalite/templates/coachreports/scatter_view.html
@@ -29,7 +29,7 @@
             <option value="">----</option>
                 {% for stat in stats %}
                     {% if stat.type == "number" and not stat.noscatter %}
-                        <option value="{{ stat.key }}"{% if stat.key = form|get_item:axis_value %} selected{% endif %}>{{ stat.name }}</option>
+                        <option value="{{ stat.key }}"{% if stat.key = form|get_item:axis_value %} selected{% endif %}>{% trans stat.name %}</option>
                     {% endif %}
                 {% endfor %}
         {% endblock %}

--- a/kalite/templates/coachreports/student_view.html
+++ b/kalite/templates/coachreports/student_view.html
@@ -78,7 +78,7 @@
         <tr>
             <th colspan="2" class="" >{% trans "Topic" %}</th>
             {% for def in stat_defs %}
-            <th>{{ def.title }}</th>
+            <th>{% trans def.title %}</th>
             {% endfor %}
         </tr>
 
@@ -90,11 +90,11 @@
                 </div>
             </td>
             <td>
-                <span title="{{ topic.description }}">
+                <span title="{% trans topic.description %}">
                     {% if not is_central %}
-                        <a href="{{ topic.path }}">{{ topic.title }}</a>
+                        <a href="{{ topic.path }}">{% trans topic.title %}</a>
                     {% else %}
-                        {{ topic.title }}
+                        {% trans topic.title %}
                     {% endif %}
                 </span>
             </td>

--- a/kalite/templates/coachreports/tabular_view.html
+++ b/kalite/templates/coachreports/tabular_view.html
@@ -81,7 +81,7 @@
             <select id="report_type">
                 <option {% if not request_report_type %}selected{% endif %}>----</option>
                 {% for report_type in report_types %}
-                    <option value="{{ report_type }}" {% if report_type == request_report_type %}selected{% endif %}>{{ report_type }}</option>
+                    <option value="{% trans report_type %}" {% if report_type == request_report_type %}selected{% endif %}>{{ report_type }}</option>
                 {% endfor %}
             </select>
         {% else %}
@@ -103,7 +103,7 @@
             <select id="topic">
                 <option {% if not request.GET.topic %}selected{% endif %}>----</option>
                 {% for topic in topics %}
-                    <option value="{{ topic.id }}"{% if request.GET.topic == topic.id %}selected{% endif %}>{{ topic.title }}</option>
+                    <option value="{{ topic.id }}"{% if request.GET.topic == topic.id %}selected{% endif %}>{% trans topic.title %}</option>
                 {% endfor %}
             </select>
         {% endif %}

--- a/kalite/templates/coachreports/timeline_view.html
+++ b/kalite/templates/coachreports/timeline_view.html
@@ -38,7 +38,7 @@
     <select id="xaxis" name="xaxis">
         {% for stat in stats %}
         {% if stat.type == "datetime" %}
-        <option value="{{ stat.key }}"{% if stat.key = form|get_item:axis_value %} selected{% endif %}>{{ stat.name }}</option>
+        <option value="{{ stat.key }}"{% if stat.key = form|get_item:axis_value %} selected{% endif %}>{% trans stat.name %}</option>
         {% endif %}
         {% endfor %}
     </select>
@@ -46,7 +46,7 @@
     <select id="yaxis" name="yaxis" class="no-select">
             {% for stat in stats %}
                 {% if stat.timeline %}
-                    <option value="{{ stat.key }}"{% if stat.key = form|get_item:axis_value %} selected {% else %} disabled {% endif %}>{{ stat.name }}</option>
+                    <option value="{{ stat.key }}"{% if stat.key = form|get_item:axis_value %} selected {% else %} disabled {% endif %}>{% trans stat.name %}</option>
                 {% endif %}
             {% endfor %}
     </select>


### PR DESCRIPTION
See the issues.  Tested for tabular and scatter views, but not timeline view, not with data, and not the student view.

@aronasorman could you test please?

![image](https://f.cloud.github.com/assets/4072455/2073566/9e802926-8d60-11e3-8be2-11434c6b67a5.png)
![image](https://f.cloud.github.com/assets/4072455/2073564/91e61e32-8d60-11e3-8422-b3b692819a14.png)
