### PR TITLE
Fix userlist display and navigation.

### DIFF
--- a/kalite/main/views.py
+++ b/kalite/main/views.py
@@ -343,7 +343,7 @@ def easy_admin(request):
 def user_list(request, facility):
 
     # Use default group
-    group_id = request.REQUEST.get("group")
+    group_id = request.REQUEST.get("group_id")
     if not group_id:
         groups = FacilityGroup.objects \
             .annotate(Count("facilityuser")) \

--- a/kalite/static/js/control_panel/facility_user_management.js
+++ b/kalite/static/js/control_panel/facility_user_management.js
@@ -10,11 +10,9 @@ function getSelectedUsers() {
 $(function() {
 
     $("#group").change(function(){
-        // Change the URL to the selcted group.
-        var group_id = $("#group option:selected").val();
-        if (group_id) {
-            window.location.href = TEMPLATE_GROUP_URL.replace("group_id", group_id);
-        }
+        // Change the URL to the selected group.
+        GetParams["group_id"] = $("#group option:selected").val();
+        window.location.href = setGetParamDict(window.location.href, GetParams);
     });
 
     $("#all").click(function(){

--- a/kalite/templates/current_users.html
+++ b/kalite/templates/current_users.html
@@ -13,7 +13,11 @@
 
 {% block headjs %}{{ block.super }}
     <script type="text/javascript">
-        var TEMPLATE_GROUP_URL = "{% url user_list zone_id=zone_id facility_id=facility.id group_id='group_id' %}";
+        var GetParams = {
+            "zone_id": "{{ zone_id }}",
+            "facility_id": "{{ facility.id }}",
+            "group_id": {% if group_id == "Ungrouped" %}""{% else %}"{{ group_id }}"{% endif %}
+        };
     </script>
     <script type="text/javascript" src="{% static 'js/control_panel/facility_user_management.js' %}"></script>
 {% endblock headjs %}
@@ -48,7 +52,7 @@
                 {% for group in groups %}
                 <option value="{{ group.id }}" {% if group_id == group.id %}selected{% endif %}>{{ group }}</option>
                 {% endfor %}
-                <option {% if group_id == "Ungrouped" %}selected{% endif %}>{% trans "Ungrouped" %}</option>
+                <option value="" {% if group_id == "Ungrouped" %}selected{% endif %}>{% trans "Ungrouped" %}</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
Fix for #1458 - making User management page work again, and navigate properly.

URL reversing does not work for GET params!

Use setGetParams for navigation between lists, rather than trying to do a URL reverse.

@aronasorman This seems to work, confident for the merge, and definitely better than what is currently there!
