### PR TITLE
Adding missing translation to Tabular coach report.

### DIFF
--- a/kalite/static/css/coachreports/tabular_view.css
+++ b/kalite/static/css/coachreports/tabular_view.css
@@ -62,6 +62,8 @@ th.headrow, th.headrow div {
     width: 80px;
     font-weight: bold;
     background-color: white;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 th.headrowuser {

--- a/kalite/templates/coachreports/tabular_view.html
+++ b/kalite/templates/coachreports/tabular_view.html
@@ -172,7 +172,7 @@
                         <tr>
                             {% for exercise in exercises %}
                                 <th class="headrow data">
-                                    <div><a href="{{ exercise.path }}" title='"{{ exercise.display_name }}"{% if exercise.description %} ({{ exercise.description }}){% endif %}'>{{ exercise.title }}</a></div>
+                                    <div><a href="{{ exercise.path }}" title='"{% trans exercise.display_name %}"{% if exercise.description %} ({% trans exercise.description %}){% endif %}'>{% trans exercise.title %}</a></div>
                                 </th>
                             {% endfor %}
                         </tr>
@@ -207,7 +207,7 @@
                         <tr>
                             {% for video in videos %}
                                 <th class="headrow data">
-                                    <div><a href="{{ video.path }}"><span title='"{{ video.title }}"{% if video.description %} ({{ video.description }}){% endif %}'>{{ video.title }}</span></a></div>
+                                    <div><a href="{{ video.path }}"><span title='"{% trans video.title %}"{% if video.description %} ({% trans video.description %}){% endif %}'>{% trans video.title %}</span></a></div>
                                 </th>
                             {% endfor %}
                         </tr>

--- a/kalite/templates/video.html
+++ b/kalite/templates/video.html
@@ -61,7 +61,7 @@
             <span class="progress-circle" data-exercise-id="{{ video.related_exercise.slug }}"></span>
             {# Translators: Example usage=> Exercise: Name of Exercise #}
             {% trans "Exercise" as exercise %}
-            <a href="{{ video.related_exercise.path }}" class="simple-button green" title="{{ exercise }}: '{{ video.related_exercise.title }}'">{% trans "Practice this concept" %}</a>
+            <a href="{{ video.related_exercise.path }}" class="simple-button green" title="{% trans exercise %}: '{% trans video.related_exercise.title %}'">{% trans "Practice this concept" %}</a>
         </span>
         {% endif %}
         <div class="clear"></div>


### PR DESCRIPTION
Fix for #1461.

Items changed:
Translate coach report header items.

Translate tooltips for coach report headers and video 'practice concept' button.

Style coach report headers to ellipsis on overflow.

@aronasorman Looks good, and finally got the ellipsis overflow working on coach report headers - somehow not managed to make that stick for nearly a year now!
