### PR TITLE
Make text on all input forms to overflow properly

### DIFF
--- a/kalite/static/css/khan-lite.css
+++ b/kalite/static/css/khan-lite.css
@@ -214,7 +214,6 @@ div.exercises-card {
 
 .basic-form label {
     font-weight: bold;
-    width: 120px;
     padding-right: 12px;
     display: block;
 }


### PR DESCRIPTION
Fix for #1443 - but will affect all forms globally.

Overflow form input labels to new line.

Push input boxes to last line of label.
