### PR TITLE
Pass external links through Google Translate

### DIFF
--- a/kalite/templates/admin_distributed.html
+++ b/kalite/templates/admin_distributed.html
@@ -105,11 +105,11 @@
                 </td>
             </tr>
             <tr class="client-online-only">
-                <td class="link"><a href="{% if request.lang and request.lang != "en" %}http://translate.google.com/translate?hl=en&sl=auto&tl={{ request.language }}&u={% endif %}{{wiki_url}}" target="_blank">{% trans "KA Lite Wiki" %}</a></td>
+                <td class="link"><a href="{% if request.language != "en" %}http://translate.google.com/translate?hl=en&sl=auto&tl={{ request.language }}&u={% endif %}{{wiki_url}}" target="_blank">{% trans "KA Lite Wiki" %}</a></td>
                 <td class="desc"> {% trans "Contains the latest information about setting up and using KA Lite." %}</td>
             </tr>
             <tr class="client-online-only">
-                <td class="link"><a href="{% if request.lang and request.lang != "en" %}http://translate.google.com/translate?hl=en&sl=auto&tl={{ request.language }}&u={% endif %}http://{{central_server_host}}/faq" target="_blank">{% trans "FAQ" %}</a></td>
+                <td class="link"><a href="{% if request.language != "en" %}http://translate.google.com/translate?hl=en&sl=auto&tl={{ request.language }}&u={% endif %}http://{{central_server_host}}/faq" target="_blank">{% trans "FAQ" %}</a></td>
                 <td class="desc">{% trans "Contains the latest FAQ for troubleshooting." %}</td>
             </tr>
 


### PR DESCRIPTION
Fix for #1444.

Added Google Translate wrapper to external links when English is not the language.

Note: Google Translate frame will remain to:
*Inform user this is a machine translation
*Prevent undesirable behaviour on the wiki when embedded in central server
