### PR TITLE
Always return a complete dict in custom_context_processors

### DIFF
--- a/kalite/i18n/custom_context_processors.py
+++ b/kalite/i18n/custom_context_processors.py
@@ -1,13 +1,10 @@
-from shared.i18n import lcode_to_ietf, get_language_name
-
+from config.models import Settings
+from shared.i18n import lcode_to_ietf, get_language_name, get_installed_language_packs
 
 def languages(request):
-    if "default_language" not in request.session:
-        return {}  # temporarily skipped middleware, but we'll get back here again.  Tricky Django...
-
     return {
-        "default_language": lcode_to_ietf(request.session["default_language"]),
-        "language_choices": request.session["language_choices"],
+        "default_language": lcode_to_ietf(request.session.get("default_language") or Settings.get("default_language") or "en"),
+        "language_choices": request.session.get('language_choices') or get_installed_language_packs(),
         "current_language": request.language,
         "current_language_native_name": get_language_name(request.language, native=True),
         "current_language_name": get_language_name(request.language),


### PR DESCRIPTION
Solves #1462. Depends on #1470. Only the last commit is relevant. Old logic is basically return an empty dict on the custom_context_processors if there's no `default_language` in the session. Now, we have a hierarchy of defaults on which language to use: either look in the session, look into Settings, or default to `en`.
