### PR TITLE
Show download zip size when upgrading.

### DIFF
--- a/kalite/static/js/updates/update_languages.js
+++ b/kalite/static/js/updates/update_languages.js
@@ -71,13 +71,14 @@ function display_languages() {
                         var percent_translated_diff = matching_installable.percent_translated - lang.percent_translated;
                         var subtitle_count_diff = matching_installable.subtitle_count - lang.subtitle_count;
                         lang_description += sprintf(
-                            "<div class='upgrade-link'><a href='#' onclick='start_languagepack_download(\"%(lang.code)s\")'>%(upgrade_text)s</a> (+%(translated)d%% %(translated_text)s / +%(srt)d %(srt_text)s)</div>", {
+                            "<div class='upgrade-link'><a href='#' onclick='start_languagepack_download(\"%(lang.code)s\")'>%(upgrade_text)s</a> (+%(translated)d%% %(translated_text)s / +%(srt)d %(srt_text)s / %(size)s)</div>", {
                                 lang: lang,
                                 upgrade_text: gettext("Upgrade"),
                                 translated: percent_translated_diff,
                                 translated_text: gettext("Translated"),
                                 srt: subtitle_count_diff,
-                                srt_text: gettext("Subtitles")
+                                srt_text: gettext("Subtitles"),
+                                size: sprintf("%5.2f MB", matching_installable.zip_size/1.0E6 || 0)
                         });
                     }
                 }


### PR DESCRIPTION
Solves #1494. Also includes a fix for not loading the lang pack list due to `CHANGE_SERVER_LANGUAGE_URL` being deleted. Screenshot explains it better:

![upgradesize](https://f.cloud.github.com/assets/191955/2144096/18db33fe-937f-11e3-9654-a475291ff32d.png)
