### PR TITLE
Fix to prevent barrage of errors on cancel event

### DIFF
--- a/kalite/shared/jobs.py
+++ b/kalite/shared/jobs.py
@@ -25,6 +25,7 @@ def force_job(command, name="", frequency="YEARLY", stop=False, launch_cron=True
 
     if stop:
         job.is_running = False
+        launch_cron = False
     else:
         job.next_run = datetime.now()
     job.save()

--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -192,7 +192,7 @@ def cancel_video_download(request):
     # unflag all video downloads
     VideoFile.objects.filter(flagged_for_download=True).update(cancel_download=True, flagged_for_download=False, download_in_progress=False)
 
-    force_job("videodownload", stop=True, launch_cron=False)
+    force_job("videodownload", stop=True)
 
     return JsonResponse({})
 

--- a/kalite/updates/management/commands/videodownload.py
+++ b/kalite/updates/management/commands/videodownload.py
@@ -123,23 +123,23 @@ class Command(UpdatesDynamicCommand):
                         self.download_progress_callback(video, 100)
                     handled_youtube_ids.append(video.youtube_id)
                     self.stdout.write(_("Download is complete!") + "\n")
+                except DownloadCancelled:
+                    #Cancellation event
+                    video.percent_complete = 0
+                    video.flagged_for_download = False
+                    video.download_in_progress = False
+                    video.save()
+                    failed_youtube_ids.append(video.youtube_id)
                 except Exception as e:
-                    #Check for cancellation event
-                    if isinstance(e, DownloadCancelled):
-                        video.percent_complete = 0
-                        video.flagged_for_download = False
-                        video.download_in_progress = False
-                        video.save()
-                    else:
-                        # On error, report the error, mark the video as not downloaded,
-                        #   and allow the loop to try other videos.
-                        msg = _("Error in downloading %(youtube_id)s: %(error_msg)s") % {"youtube_id": video.youtube_id, "error_msg": unicode(e)}
-                        self.stderr.write("%s\n" % msg)
-                        video.download_in_progress = False
-                        video.flagged_for_download = not isinstance(e, URLNotFound)  # URLNotFound means, we won't try again
-                        video.save()
-                        # Rather than getting stuck on one video, continue to the next video.
-                        self.update_stage(stage_status="error", notes=_("%(error_msg)s; continuing to next video.") % {"error_msg": msg})
+                    # On error, report the error, mark the video as not downloaded,
+                    #   and allow the loop to try other videos.
+                    msg = _("Error in downloading %(youtube_id)s: %(error_msg)s") % {"youtube_id": video.youtube_id, "error_msg": unicode(e)}
+                    self.stderr.write("%s\n" % msg)
+                    video.download_in_progress = False
+                    video.flagged_for_download = not isinstance(e, URLNotFound)  # URLNotFound means, we won't try again
+                    video.save()
+                    # Rather than getting stuck on one video, continue to the next video.
+                    self.update_stage(stage_status="error", notes=_("%(error_msg)s; continuing to next video.") % {"error_msg": msg})
                     failed_youtube_ids.append(video.youtube_id)
                     continue
 


### PR DESCRIPTION
Fix for #1490.

Summary of changes:
- Call force_job with launch_cron=False
- On raising DownloadCancelled in download_video function, raise again after catch to bubble exception up to handle function on the Command.
- Handle DownloadCancelled separate to ordinary exceptions to handle function:
  - Set flags on video object to prevent future downloads
  - Don't set progress as an error, as failure of the download is desired user behaviour.

Tested, seems to work, but could use a little more pummeling if @dylanjbarth or @aronasorman have time.
