### PR TITLE
Fixed the duplication of the message. But I don't know how.

### DIFF
--- a/kalite/static/js/exercises.js
+++ b/kalite/static/js/exercises.js
@@ -111,7 +111,8 @@ $(function() {
         })
         .fail(function (resp) {
             // Expects to receive messages ({ type: message } format) about failures
-            communicate_api_failure(resp, "id_student_logs");
+            // turned off because this duplicates the "Progress not loaded" message    
+            // communicate_api_failure(resp, "id_student_logs");
         });
 });
 

--- a/kalite/static/js/kmap-editor.js
+++ b/kalite/static/js/kmap-editor.js
@@ -254,7 +254,8 @@ $(document).ready(function() {
                         KMapEditor.init(exercises, [], exercisesCompleted, 8);
                     })
                     .fail(function (resp) {
-                        communicate_api_failure(resp, "id_student_logs");
+                        // Turned off because it duplicates "Progress not loaded" message
+                        // communicate_api_failure(resp, "id_student_logs");
                         KMapEditor.init(exercises, [], [], 8);
                     });
             });


### PR DESCRIPTION
@aronasorman this is a potential fix for #1507

I worked out how the message was being generated, and just by experimenting, figured out that the `communicate_api_failure` function was the cause of it. On the knowledgemap it was being generated by the `kmap_editor` making an AJAX request (`get_exercise_logs`) and on the exercise itself it was generated by `exercises.js`. Now that I'm writing this I'm realizing the original message is likely generated by some Django code somewhere, but I searched the codebase for the error message itself and only found them being pieced together in the API. So I'm at a loss as to where the original is being created.

But the fact of the matter is, getting rid of the communicate API failure makes it stop, and I don't think it will hurt anything else. What say you?
