### PR TITLE
use blocktrans instead of trans

### DIFF
--- a/kalite/templates/registration/logout.html
+++ b/kalite/templates/registration/logout.html
@@ -3,6 +3,6 @@
 {% block title %}{% trans "Logged out" %}{{ block.super }}{% endblock title %}
 
 {% block content %}
-    <h1>{% trans 'You've been logged out.' %}</h1>
-    <p>{% trans 'Thanks for stopping by; when you come back, don't forget to <a href="/accounts/login/">log in</a> again.' %}</p>
+    <h1>{% blocktrans %}You've been logged out.{% endblocktrans %}</h1>
+    <p>{% blocktrans %}Thanks for stopping by; when you come back, don't forget to <a href="/accounts/login/">log in</a> again.{% endblocktrans %}</p>
 {% endblock content %}


### PR DESCRIPTION
so you don't have to escape the apostrophe (text is cut of at crowdin)
