### PR TITLE
Skip over log data with no completion timestamp when rendering timeline stats on central server

### DIFF
--- a/kalite/templates/stats/timelines.html
+++ b/kalite/templates/stats/timelines.html
@@ -44,6 +44,9 @@
           //
           for (var k in raw_data){
             var row = raw_data[k];
+            if (!row["completion_timestamp"]) {
+              continue;
+            }
             var cur_date = new Date(row["completion_timestamp"].substr(0, 10));  // parse the date, forget the time
 
             // Date changed; store the last date info into the database


### PR DESCRIPTION
Fix for #1480

Summary of changes:
- If there is no completion_timestamp don't try to include the data in the graph.

@bcipolli This is the next iteration in my long running series of tiny pull requests. It works.
