### PR TITLE
Select video-js element based on class, not tag name

### DIFF
--- a/kalite/static/js/videoplayer.js
+++ b/kalite/static/js/videoplayer.js
@@ -257,7 +257,7 @@ window.VideoView = Backbone.View.extend({
 
         this._pointView = new PointView({model: this.model});
 
-        var player_id = this.$("video").attr("id");
+        var player_id = this.$(".video-js").attr("id");
 
         if (player_id) { // if it's using mplayer, there won't be a player here
             this.player = this.model.player = _V_(player_id);
@@ -267,7 +267,7 @@ window.VideoView = Backbone.View.extend({
     },
 
     _initializeEventListeners: function() {
-
+        
         var self = this;
 
         this.player


### PR DESCRIPTION
Fix for #1369.

Tested on WinXP virtualbox in Firefox. Could do with some more testing @bcipolli and @ruimalheiro.

Summary of changes:
- Select video-js element based on the class not on 'video' tag, as it changes to 'object' tag when using flash.

One line fix. Every. Freakin'. Time.
