### PR TITLE
Special-case english by making it always 100% translated

### DIFF
--- a/kalite/i18n/management/commands/update_language_packs.py
+++ b/kalite/i18n/management/commands/update_language_packs.py
@@ -354,6 +354,11 @@ def update_translations(lang_codes=None,
                 else:
                     pmlc["percent_translated"] = 100. * (pmlc['kalite_ntranslations'] + pmlc['ka_ntranslations']) / float(pmlc['kalite_nphrases'] + pmlc['ka_nphrases'])
 
+
+            # english is always 100% translated
+            if lang_code == 'en':
+                pmlc['percent_translated'] = 100
+
     return package_metadata
 
 


### PR DESCRIPTION
Solves #1493. To avoid the ugly negative 100% from english, we make translation metadata for the english language pack always have 100% translations. Now it sums up to 0% additional translations.

![english](https://f.cloud.github.com/assets/191955/2213531/9eeb3136-99c1-11e3-9428-21305f33b302.png)
