### PR TITLE
Fix for #1445 - remove some duplicate dubbed video mappings, allow some others.

### DIFF
--- a/kalite/i18n/__init__.py
+++ b/kalite/i18n/__init__.py
@@ -175,11 +175,7 @@ def get_file2id_map(force=False):
         for lang_code, dic in get_dubbed_video_map().iteritems():
             for english_youtube_id, dubbed_youtube_id in dic.iteritems():
                 if dubbed_youtube_id in YT2ID_MAP:
-                    # Sanity check, but must be failsafe, since we don't control these data
-                    if YT2ID_MAP[dubbed_youtube_id] == english_youtube_id:
-                        logging.warn("Duplicate entry found in %s language map for english video %s" % (lang_code, english_youtube_id))
-                    else:
-                        logging.error("Conflicting entry found in %s language map for english video %s; overwriting previous entry." % (lang_code, english_youtube_id))
+                    logging.debug("conflicting entry of dubbed_youtube_id %s in %s dubbed video map" % (dubbed_youtube_id, lang_code))
                 YT2ID_MAP[dubbed_youtube_id] = english_youtube_id  # assumes video id is the english youtube_id
     return YT2ID_MAP
 

--- a/kalite/i18n/management/commands/generate_dubbed_video_mappings.py
+++ b/kalite/i18n/management/commands/generate_dubbed_video_mappings.py
@@ -87,10 +87,24 @@ def generate_dubbed_video_mappings(download_url=None, csv_data=None):
                 # Loop through those columns and, if a video exists,
                 #   add it to the dictionary.
                 for idx in range(english_idx, len(row)):
-                    if row[idx]:  # make sure there's a dubbed video
-                        lang = header_row[idx]
-                        if lang not in video_map:  # add the first level if it doesn't exist
-                            video_map[lang] = {}
+                    if not row[idx]:  # make sure there's a dubbed video
+                        continue
+
+                    lang = header_row[idx]
+                    if lang not in video_map:  # add the first level if it doesn't exist
+                        video_map[lang] = {}
+                    dubbed_youtube_id = row[idx]
+                    if english_video_id == dubbed_youtube_id and lang != "english":
+                        logging.error("Removing entry for (%s, %s): dubbed and english youtube ID are the same." % (lang, english_video_id))
+                    #elif dubbed_youtube_id in video_map[lang].values():
+                        # Talked to Bilal, and this is actually supposed to be OK.  Would throw us for a loop!
+                        #    For now, just keep one.
+                        #for key in video_map[lang].keys():
+                        #    if video_map[lang][key] == dubbed_youtube_id:
+                        #        del video_map[lang][key]
+                        #        break
+                        #logging.error("Removing entry for (%s, %s): the same dubbed video ID is used in two places, and we can only keep one in our current system." % (lang, english_video_id))
+                    else:
                         video_map[lang][english_video_id] = row[idx]  # add the corresponding video id for the video, in this language.
 
     except StopIteration:


### PR DESCRIPTION
After chatting with Bilal, we can keep some duplicates (a single dubbed video ID can be used to replace multiple english IDs), and should remove others (when a dubbed video ID is actually an English youtube ID).

This PR takes care of that, then makes the production system more robust, to avoid any issues in the future.

Note that Bilal has now removed the duplicated IDs that we shoudl remove, so you'll have to trust me that I tested this :)
