### PR TITLE
Fix for #1457: hide individual progress bars when downloading dubbed videos 

### DIFF
--- a/kalite/templates/updates/progress-bar.html
+++ b/kalite/templates/updates/progress-bar.html
@@ -1,12 +1,15 @@
 {% load i18n %}
 <div class="progress-section">
-    <!-- stage progress -->
-    <h2 class="progress-text">
-        <span class="stage-header"></span>
-        <span class="stage-name"> </span>
-        <span class="ellipsis">...</span>
-    </h2>
-    <div class="progressbar progressbar-current"></div>
+    <!-- stage progress; note: only works with english currently
+        because we are using youtube-dl for dubbed videos -->
+    {% if current_language == "en" %}
+        <h2 class="progress-text">
+            <span class="stage-header"></span>
+            <span class="stage-name"> </span>
+            <span class="ellipsis">...</span>
+        </h2>
+        <div class="progressbar progressbar-current"></div>
+    {% endif %}
 
     <!-- process progress -->
     <h2 id="stage-summary">


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/1319950/2225695/43a927ba-9a93-11e3-9427-4e257004830a.png)

and new behavior

![image](https://f.cloud.github.com/assets/1319950/2225728/e78c8930-9a93-11e3-8135-db723f4c8ee5.png)
