### PR TITLE
generate [lc]_available_srts.json needed by old versions of kalite

### DIFF
--- a/kalite/i18n/management/commands/cache_subtitles.py
+++ b/kalite/i18n/management/commands/cache_subtitles.py
@@ -404,4 +404,33 @@ class Command(BaseCommand):
         else:
             raise CommandError("Unknown argument: %s" % args[0])
 
+        # for compatibility with KA Lite versions less than 0.10.3
+        for lang in lang_codes:
+            generate_srt_availability_file(lang)
+
         logging.info("Process complete.")
+
+def generate_srt_availability_file(lang_code):
+    '''
+    For compatibility with versions less than 0.10.3, we need to generate this
+    json file that contains the srts for the videos.
+    '''
+
+    # this path is a direct copy of the path found in the old function that generated this file
+    srts_file_dest_path = os.path.join(settings.STATIC_ROOT, 'data', 'subtitles', 'languages', "%s_available_srts.json") % lang_code
+    ensure_dir(os.path.dirname(srts_file_dest_path))
+
+    srts_path = get_srt_path(lang_code) # not sure yet about this; change once command is complete
+    try:
+        files = os.listdir(srts_path)
+    except OSError:             # directory doesnt exist or we cant read it
+        files = []
+
+    yt_ids = [f.rstrip(".srt") for f in files]
+    srts_dict = { 'srt_files': yt_ids }
+
+    with open(srts_file_dest_path, 'wb') as fp:
+        logging.debug('Creating %s', srts_file_dest_path)
+        json.dump(srts_dict, fp)
+
+    return yt_ids

--- a/kalite/i18n/management/commands/update_language_packs.py
+++ b/kalite/i18n/management/commands/update_language_packs.py
@@ -169,10 +169,6 @@ class Command(BaseCommand):
         # Now, we're going to build the language packs, collecting metadata long the way.
         package_metadata = update_language_packs(lang_codes, options)
 
-        # for compatibility with KA Lite versions less than 0.10.3
-        for lang in lang_codes:
-            generate_srt_availability_file(lang)
-
 
 def update_language_packs(lang_codes, options):
 
@@ -766,30 +762,6 @@ def download_crowdin_metadata(project_id=None, project_key=None):
         logging.error("Error getting crowdin metadata: %s" % e)
         crowdin_meta_dict = {}
     return crowdin_meta_dict
-
-def generate_srt_availability_file(lang_code):
-    '''
-    For compatibility with versions less than 0.10.3, we need to generate this
-    json file that contains the srts for the videos.
-    '''
-
-    # this path is a direct copy of the path found in the old function that generated this file
-    srts_file_dest_path = os.path.join(settings.STATIC_ROOT, 'data', 'subtitles', 'languages', "%s_available_srts.json") % lang_code
-    ensure_dir(os.path.dirname(srts_file_dest_path))
-
-    srts_path = get_srt_path(lang_code) # not sure yet about this; change once command is complete
-    try:
-        files = os.listdir(srts_path)
-    except OSError:             # directory doesnt exist or we cant read it
-        files = []
-
-    yt_ids = [f.rstrip(".srt") for f in files]
-    srts_dict = { 'srt_files': yt_ids }
-
-    with open(srts_file_dest_path, 'wb') as fp:
-        json.dump(srts_dict, fp)
-
-    return yt_ids
 
 def increment_language_pack_version(stored_meta, updated_meta):
     """Increment language pack version if translations have been updated


### PR DESCRIPTION
Completing the fix for #1556. Old versions of KA Lite also request this json to know which srts they can download. So we generate them and add it to the appropriate place where old clients expect it.
