### PR TITLE
Fix for #1457 - don't show "current" progress bar when using youtube-dl in video download

### DIFF
--- a/kalite/static/js/updates/update_videos.js
+++ b/kalite/static/js/updates/update_videos.js
@@ -11,6 +11,11 @@ function video_start_callback(progress_log, resp) {
     lastKey = null;
     nErrors = 0;
     videos_downloading = false;
+
+    // Assumption here (not quite valid) is that all, and only,
+    //   English videos are on amazon, and so we can download with
+    //   current stage progress (and not just overall)
+    $(".progressbar-current").toggle(CURRENT_LANGUAGE == "en");
 }
 
 function video_reset_callback() {

--- a/kalite/templates/base.html
+++ b/kalite/templates/base.html
@@ -61,7 +61,7 @@
          var CENTRAL_SERVER_HOST = "{{ central_server_host }}";
          var SECURESYNC_PROTOCOL = "{{ securesync_protocol }}";
          var INSTALLED_LANGUAGES_URL = "{% url installed_language_packs %}";
-         var DEFAULT_LANGUAGE = "{{ default_language }}"
+         var CURRENT_LANGUAGE = "{{ current_language }}";
         </script>
         <script type="text/javascript" src="{% static 'js/sprintf.min.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/khan-lite.js' %}?{{ BUILD_ID }}"></script>


### PR DESCRIPTION
As per comments in #1576 - this needs to be done dynamically in JS, and only for the `update_video` page.
