### PR TITLE
Fix #1608: alphabetize videos in the download topic tree

### DIFF
--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -224,7 +224,12 @@ def annotate_topic_tree(node, level=0, statusdict=None, remote_sizes=None, lang_
         unstarted = True
         complete = True
 
-        for child_node in node["children"]:
+        if level > 0:
+            looped_children = sorted(node["children"] or [], key=lambda n: _(n["title"]))
+        else:
+            looped_children = node["children"] or []
+
+        for child_node in looped_children:
             child = annotate_topic_tree(child_node, level=level+1, statusdict=statusdict, lang_code=lang_code)
             if not child:
                 continue


### PR DESCRIPTION
Title says it all.  Admins don't need to care about the order of topics, they just need to be able to find the right topic to download.  So, alphabetize.

![screen shot 2014-02-22 at 9 42 28 pm](https://f.cloud.github.com/assets/4072455/2239747/b693068a-9c4e-11e3-8e25-a8447560e17c.png)
