### PR TITLE
create consistent api endpoint for downloading the windows installer

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -415,6 +415,9 @@ if CENTRAL_SERVER:
     # Default to "test mode" if no API key, to print out the email to the console, rather than trying to send
     POSTMARK_TEST_MODE = getattr(local_settings, "POSTMARK_TEST_MODE", POSTMARK_API_KEY == "")
 
+    # Used for redirecting to the actual installer executables
+    INSTALLER_BASE_URL = getattr(local_settings, 'INSTALLER_BASE_URL', 'http://adhoc.learningequality.org/media/installer/')
+
 else:
     # enable this to use a background mplayer instance instead of playing the video in the browser, on loopback connections
     # TODO(jamalex): this will currently only work when caching is disabled, as the conditional logic is in the Django template

--- a/kalite/stats/api_urls.py
+++ b/kalite/stats/api_urls.py
@@ -9,5 +9,6 @@ urlpatterns = patterns('stats.api_views',
     url(r'^media/language_packs/(?P<version>.*)/(?P<lang_code>.*).zip$', 'download_language_pack'),
     url(r'^download/videos/(?P<video_path>.*)$', 'download_video'),
     url(r'^static/srt/(?P<lang_code>.*)/subtitles/(?P<youtube_id>.*).srt$', 'download_subtitle', {}), # v0.10.0: fetching subtitles.
-    url(r'^static/installer/windows', 'download_windows_installer', {}),
+    url(r'^static/installer/windows$', 'download_windows_installer', {'version': 'latest'}),
+    url(r'^static/installer/windows/(?P<version>.*)$', 'download_windows_installer', {}),
 )

--- a/kalite/stats/api_views.py
+++ b/kalite/stats/api_views.py
@@ -67,8 +67,8 @@ def download_subtitle(request, lang_code, youtube_id):
     return response
 
 
-def download_windows_installer(request, version=""):
-    installer_name = "KALiteSetup.exe"
-    installer_url = 'http://adhoc.learningequality.org/media/installer/%s' % installer_name
-    stats_logger("installer").info("wi;%s" % get_request_ip(request))
+def download_windows_installer(request, version):
+    installer_name = "KALiteSetup-%s.exe" % version
+    installer_url = settings.INSTALLER_BASE_URL + installer_name
+    stats_logger("installer").info("wi;%s;%s" % (get_request_ip(request), installer_name))
     return HttpResponseRedirect(installer_url)


### PR DESCRIPTION
Solves #1625. Self-explanatory. We have a single API endpoint for downloading the windows installer. We can also use this to track installer downloads.
