### PR TITLE
Force ajax requests to append the current language.

### DIFF
--- a/kalite/static/js/khan-lite.js
+++ b/kalite/static/js/khan-lite.js
@@ -28,6 +28,9 @@ function csrfSafeMethod(method) {
 }
 
 function doRequest(url, data) {
+    console.log(url);
+    url = setGetParam(url, "lang", CURRENT_LANGUAGE);
+    console.log(url);
     return $.ajax({
         url: url,
         type: data ? "POST" : "GET",


### PR DESCRIPTION
A bit of a hack, as:
- `doRequest` can be used for non-distributed server API calls (assumption: the parameter would simply be ignored)
- The `lang` parameter might already be set (but that's not the case at the moment)
- Other places might use `$.ajax` instead of this function (but we don't really want that; see #328)

This PR turns:
![image](https://f.cloud.github.com/assets/4072455/2284253/34f665be-9fc7-11e3-9efb-34b40ea6d742.png)

into:
![image](https://f.cloud.github.com/assets/4072455/2284255/43eb189e-9fc7-11e3-9867-4537835e8d29.png)
