### PR TITLE
Force runserver and runcherrypyserver through kaserve, EXCEPT on a 'stop'

### DIFF
--- a/kalite/manage.py
+++ b/kalite/manage.py
@@ -1,30 +1,46 @@
 #!/usr/bin/env python
-import os, sys, warnings
+import os
+import sys
+import warnings
 
 # We are overriding a few packages (like Django) from the system path.
 #   Suppress those warnings
 warnings.filterwarnings('ignore', message=r'Module .*? is being added to sys\.path', append=True)
 
+# Now build the paths that point to all of the project pieces
 PROJECT_PATH = os.path.dirname(os.path.realpath(__file__))
+PROJECT_PYTHON_PATHS = [
+    os.path.join(PROJECT_PATH, "..", "python-packages"),
+    PROJECT_PATH,
+    os.path.join(PROJECT_PATH, ".."),
+]
+sys.path = PROJECT_PYTHON_PATHS + sys.path
 
-sys.path = [PROJECT_PATH, os.path.join(PROJECT_PATH, "../"), os.path.join(PROJECT_PATH, "../python-packages/")] + sys.path
+# Now we can get started.
 
 from django.core.management import execute_manager
 import settings
-
-
+from settings import LOG as logging
 
 ########################
-# ZERO CONFIG
+# kaserve
 ########################
 
-if settings.ZERO_CONFIG:
-    # Force all commands to run through our own serve command, which does auto-config if necessary
-    # TODO(bcipolli): simplify start scripts, just force everything through kaserve directly.
-    if "runserver" in sys.argv:
-        sys.argv[sys.argv.index("runserver")] = "kaserve"
-    elif "runcherrypyserver" in sys.argv:
-        sys.argv[sys.argv.index("runcherrypyserver")] = "kaserve"
+# Force all commands to run through our own serve command, which does auto-config if necessary
+# TODO(bcipolli): simplify start scripts, just force everything through kaserve directly.
+if "runserver" in sys.argv:
+    logging.info("You requested to run runserver; instead, we're funneling you through our 'kaserve' command.")
+    sys.argv[sys.argv.index("runserver")] = "kaserve"
+elif "runcherrypyserver" in sys.argv and "stop" not in sys.argv:
+    logging.info("You requested to run runcherrypyserver; instead, we're funneling you through our 'kaserve' command.")
+    sys.argv[sys.argv.index("runcherrypyserver")] = "kaserve"
+
+if settings.DEBUG:
+    # In debug mode, add useful debugging flags
+    for flag in ["traceback", "auto-pdb"]:
+        dashed_flag = "--%s" % flag
+        if dashed_flag not in sys.argv:
+            sys.argv.append(dashed_flag)
 
 ########################
 # clean_pyc
@@ -39,7 +55,6 @@ if len(sys.argv) == 2 and sys.argv[1] == "clean_pyc":
 
 if "runserver" in sys.argv and "--nostatic" not in sys.argv:
     sys.argv += ["--nostatic"]
-
 
 
 if __name__ == "__main__":

--- a/kalite/management/commands/kaserve.py
+++ b/kalite/management/commands/kaserve.py
@@ -58,7 +58,8 @@ class Command(BaseCommand):
         ),
     )
 
-    def setup_server(self):
+    def setup_server_if_needed(self):
+        """Run the setup command, if necessary."""
 
         # Now, validate the server.
         try:
@@ -86,7 +87,7 @@ class Command(BaseCommand):
             #    raise CommandError("Failed to setup/recover.")
 
     def reinitialize_server(self):
-
+        """Reset the server state."""
         if not settings.CENTRAL_SERVER:
             logging.info("Invalidating the web cache.")
             from main.caching import invalidate_web_cache
@@ -129,7 +130,10 @@ class Command(BaseCommand):
         #   code if autoreloader won't be run (daemonize), or if
         #   RUN_MAIN is set (autoreloader has started)
         if options["daemonize"] or os.environ.get("RUN_MAIN"):
-            self.setup_server()
+            self.setup_server_if_needed()
+
+            # we do this on every server request,
+            # as we don't know what happens when we're not looking.
             self.reinitialize_server()
 
         # Now call the proper command


### PR DESCRIPTION
Also changed the order of paths - add `python-packages` first, as we want to avoid any name collisions within the `ka-lite` project with any of our libraries.

This is needed because without running `kaserve`, we're open to caching issues (`VideoFile` out of sync, HTTP file cache out of sync)
