### PR TITLE
Fix for #292: Allow selecting non-math topics with exercises for viewing coaching data.

### DIFF
--- a/kalite/coachreports/api_urls.py
+++ b/kalite/coachreports/api_urls.py
@@ -4,6 +4,6 @@ urlpatterns = patterns('coachreports.api_views',
     url(r'data/$',      'api_data', {}, 'api_data'),
     url(r'^data/(?P<xaxis>\w+)/(?P<yaxis>\w+)/$', 'api_data', {}, 'api_data_2'),
 #    url(r'friendly/$',  'api_friendly_names', {}, 'api_friendly_names'),
-    url(r'^get_topic_tree(?P<topic_path>.*)', 'get_exercise_topic_tree', {}, 'get_exercise_topic_tree')
+    url(r'^get_topic_tree(?P<topic_path>.*)$', 'get_topic_tree_by_kinds', {}, 'get_topic_tree_by_kinds')
 )
 

--- a/kalite/templates/coachreports/base_d3_visualization.html
+++ b/kalite/templates/coachreports/base_d3_visualization.html
@@ -184,7 +184,7 @@
                 });
 
                 // Get the topic tree (starting on window load)
-                doRequest("{% url get_exercise_topic_tree topic_path='/math/' %}")
+                doRequest("{% url get_exercise_topic_tree topic_path='/' %}")
                     .success(function(treeData) {
                         treeData["expand"] = true; // expand the top level
 


### PR DESCRIPTION
Title says it all.  A few tweaks to the function were all that was necessary.

I also made the function ready to accept kinds other than `"Exercise"`
