### PR TITLE
Adding exception handling and reporting when trying to reconnect to the distributed server.

### DIFF
--- a/kalite/khanload/api_views.py
+++ b/kalite/khanload/api_views.py
@@ -238,11 +238,18 @@ def update_all_central_callback(request):
 
 
     try:
-        message = json.loads(response.content)
+        json_response = json.loads(response.content)
+        if not isinstance(json_response, dict) or len(json_response) != 1:
+            # Could not validate the message is a single key-value pair
+            raise Exception(_("Unexpected response format from your KA Lite installation."))
+        message_type = json_response.keys()[0]
+        message = json_response.values()[0]
     except ValueError as e:
-        message = { "error": unicode(e) }
+        message_type = "error"
+        message = unicode(e)
     except Exception as e:
-        message = { "error": u"Loading json object: %s" % e }
+        message_type = "error"
+        message = _("Loading json object: %s") % e
 
     # If something broke on the distribute d server, we are SCREWED.
     #   For now, just show the error to users.
@@ -252,8 +259,8 @@ def update_all_central_callback(request):
 #        return HttpResponseServerError(response.content)
 
     return HttpResponseRedirect(set_query_params(request.session["distributed_redirect_url"], {
-        "message_type": message.keys()[0],
-        "message": message.values()[0],
+        "message_type": message_type,
+        "message": message,
         "message_id": "id_khanload",
     }))
 


### PR DESCRIPTION
This is a partial fix for #1633 - 

When downloading data from KA, we currently have the central server POST back to a distributed URL.  Well, if the distributed server isn't web-accessible, this will fail.

**Previous behavior:**
The error wasn't caught, and this would leave the user hanging with a blank error page on the central server website.

**Current behavior:**
Now, the central server will catch the post-back error and post an error message back the distributed server user.

![screen shot 2014-03-05 at 2 22 06 pm](https://f.cloud.github.com/assets/4072455/2339449/e1c6b210-a4b5-11e3-80e2-fac99ca7d406.png)

**Testing:**
Tested this on adhoc.learningequality.org
