### PR TITLE
Issue 1476 of learningequality/ka-lite - Don't show dropdown if English is the only language

### DIFF
--- a/kalite/templates/base.html
+++ b/kalite/templates/base.html
@@ -93,13 +93,17 @@
                                         {% block sitewide_navigation %}
                                             <span class="not-admin-only">
                                             {% if language_choices %}
+					        {% for lang_code, lang_meta in language_choices.iteritems %}
+			       			    {% if forloop.last and forloop.counter > 1 %}
                                             <form id="language-preferences">
                                                 <select id="language_selector">
-                                                {% for lang_code, lang_meta in language_choices.iteritems %}
+                                                	{% for lang_code, lang_meta in language_choices.iteritems %}
                                                     <option value="{{ lang_code }}" {% if lang_code == current_language %}selected{% endif %}>{% if lang_meta.native_name %}{{ lang_meta.native_name }}{% else %}{% trans lang_meta.name %}{% endif %}</option>
-                                                {% endfor %}
+                                                	{% endfor %}
                                                 </select>
                                             </form>
+						    {% endif %}
+			    			{% endfor %}
                                             {% endif %}
                                             </span>
                                             {% comment %}Translators: this will appear in the navigation bar. Please try to keep it as short as possible.{% endcomment %}


### PR DESCRIPTION
Attaching base.html and the git difference file.
The code is working , its a bit different .

Like if there is only one language ( any one : could be English , could be German ) then the drop down menu won't be displayed. Because if you don't have option to change the language then whats the purpose of drop down box.

If there is more than one language drop down will work as usual.
