### PR TITLE
 Issue 1476 Don't show Dropdown box if only one language is there

### DIFF
--- a/kalite/i18n/custom_context_processors.py
+++ b/kalite/i18n/custom_context_processors.py
@@ -8,6 +8,7 @@ def languages(request):
     return {
         "default_language": lcode_to_ietf(request.session["default_language"]),
         "language_choices": get_installed_language_packs(),
+	"num_language_choices": len(get_installed_language_packs()),
         "current_language": request.language,
         "current_language_native_name": get_language_name(request.language, native=True),
         "current_language_name": get_language_name(request.language),

--- a/kalite/templates/base.html
+++ b/kalite/templates/base.html
@@ -93,13 +93,15 @@
                                         {% block sitewide_navigation %}
                                             <span class="not-admin-only">
                                             {% if language_choices %}
+						{% if num_language_choices > 1 %}
                                             <form id="language-preferences">
                                                 <select id="language_selector">
-                                                {% for lang_code, lang_meta in language_choices.iteritems %}
+                                                	{% for lang_code, lang_meta in language_choices.iteritems %}
                                                     <option value="{{ lang_code }}" {% if lang_code == current_language %}selected{% endif %}>{% if lang_meta.native_name %}{{ lang_meta.native_name }}{% else %}{% trans lang_meta.name %}{% endif %}</option>
-                                                {% endfor %}
+                                                	{% endfor %}
                                                 </select>
                                             </form>
+						{% endif %}
                                             {% endif %}
                                             </span>
                                             {% comment %}Translators: this will appear in the navigation bar. Please try to keep it as short as possible.{% endcomment %}


### PR DESCRIPTION
Only one if condition is there in the base.html which works as:
If installed languages are more than one then print the drop down box ( form-- select--option)
else don't print them

No extra loop is added for the counting purpose. So, the logic and code is very much clear now.

The variable used in that if condition is defined in custom_context_processors.py    (  i18n/custom_context_processors.py )
which is  num_language_choices which gets the length of the list containing the installed language choices.

Greetings
