### PR TITLE
 Issue 1422 Button to delete language packs

### DIFF
--- a/kalite/static/js/updates/update_languages.js
+++ b/kalite/static/js/updates/update_languages.js
@@ -55,8 +55,10 @@ function display_languages() {
                 link_text = "(Default)";
             }
             var lang_name = sprintf("<b>%(name)s</b> (%(code)s)", lang);
+	    var lang_code = lang['code'];
             var lang_data = sprintf(gettext("%(subtitle_count)d Subtitles / %(percent_translated)d%% Translated"), lang);
             var lang_description = sprintf("<div class='lang-link'>%s </div><div class='lang-name'>%s</div><div class='lang-data'> - %s</div>", link_text, lang_name, lang_data);
+	    lang_description += sprintf("<div class='delete-language-button'> <button value='%s' type='button'>%s</button></div>", lang_code, sprintf('Delete %(lang_code)s', {lang_code: lang_code}));
 
             // check if there's a new version of the languagepack, if so, add an "UPGRADE NOW!" option
             // NOTE: N^2 algorithm right here, but meh
@@ -88,6 +90,28 @@ function display_languages() {
             $("div.installed-languages").append(lang_description);
         }
     });
+
+function delete_languagepack(lang_name) {
+        doRequest(DELETE_LANGUAGEPACK_URL, {lang: lang_name})
+            .success(function() {
+                handleSuccessAPI("deleted");
+		get_installed_languages();
+		display_languages(installables);
+		
+            })
+            .fail(function(resp) {
+                handleFailedAPI(resp, gettext("Error deleting"), "lang_name");
+            });
+
+}
+
+$(function () {
+    $(".delete-language-button").children('button').click(function(event) {
+        language = $(this).val();
+	console.log(language);
+        delete_languagepack(language);
+    });
+});
 
     //
     // show list of installable languages in the dropdown box

--- a/kalite/templates/updates/update_languages.html
+++ b/kalite/templates/updates/update_languages.html
@@ -15,7 +15,7 @@
         #language-packs {
             margin-top: 20px;
         }
-        .lang-link, .lang-name, .lang-data, .upgrade-link {
+        .lang-link, .lang-name, .lang-data, .upgrade-link, .delete-language-button {
             float: left;
             font-size: 12pt;
         }
@@ -27,6 +27,7 @@
         .lang-name { width: 250px; }
         .lang-data { width: 250px; }
         .upgrade-link { width: 300px; }
+	.delete-language-button { width: 120px; }
 
         #langpack-details {
             margin-top: 10px;
@@ -48,6 +49,7 @@
         var start_languagepackdownload_url = "{% url start_languagepack_download %}";
         var INSTALLED_LANGUAGES_URL = "{% url installed_language_packs %}"
         var AVAILABLE_LANGUAGEPACK_URL = "http://" + CENTRAL_SERVER_HOST +  "/api/i18n/language_packs/available/{{ VERSION }}";
+	var DELETE_LANGUAGEPACK_URL = "{% url delete_language_pack %}";
         var defaultLanguage = "{{ default_language }}";
     </script>
     <script type="text/javascript" src="{% static 'js/updates/update_languages.js' %}"></script>

--- a/kalite/updates/api_urls.py
+++ b/kalite/updates/api_urls.py
@@ -9,6 +9,7 @@ urlpatterns = patterns('updates.api_views',
 
     url(r'^languagepacks/start$', 'start_languagepack_download', {}, 'start_languagepack_download'),
     url(r'^languagepacks/installed$', 'installed_language_packs', {}, 'installed_language_packs'),
+    url(r'^languagepacks/delete$', 'delete_language_pack', {}, 'delete_language_pack'),
 
     url(r'^software/start$', 'start_update_kalite', {}, 'start_update_kalite'),
 

--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import math
+import shutil
 from annoying.functions import get_object_or_None
 from collections import defaultdict
 
@@ -207,6 +208,14 @@ def start_languagepack_download(request):
         force_job('languagepackdownload', _("Language pack download"), lang_code=data['lang'], locale=request.language)
 
         return JsonResponse({'success': True})
+
+@require_admin
+@api_handle_error_with_json
+def delete_language_pack(request):
+    delete_id = simplejson.loads(request.raw_post_data or "{}").get("lang")
+    delete_path=settings.LOCALE_PATHS[0] + delete_id
+    shutil.rmtree(delete_path)
+    return JsonResponse({})
 
 
 def annotate_topic_tree(node, level=0, statusdict=None, remote_sizes=None, lang_code=settings.LANGUAGE_CODE):


### PR DESCRIPTION
It provides a delete button with every language pack as shown in screen shot. 

![second](https://f.cloud.github.com/assets/4207886/2384844/960b0102-a913-11e3-921a-18f5f6e14409.png)

I have made almost all the changes suggested in previous pull request i.e.
https://github.com/learningequality/ka-lite/pull/1696/files

Some of them was not possible like 
1. We can't merge both $(function() because both is dynamically generated so on click event we have to keep it inside the display_languages function.
2.  Language are stored in Locale directory and to get that path we don't need any function from i18n/**init**.py ,   instead could just use settings.LOCALE_PATHS[0](same is used in  i18n/__init__.py) .
3. In api_views.py the function defined delete_language_pack  name is self explanatory , i don't think we need a doc string.
4. Instead of calling ajax request we could directly call the get_installed_languages() function defined in update_languages.js . So we dont need any refresh function in views as well.
5. I think ,  missed removing a console.log ( i added it just for testing). Will generate a new PR , but first i would like to get the suggested changes . So, i can include that in new PR as well.
