### PR TITLE
Remove print statement from bottom of settings.py, as it breaks things

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -224,5 +224,3 @@ if package_selected("Demo"):
     DEMO_ADMIN_PASSWORD = getattr(local_settings, "DEMO_ADMIN_PASSWORD", "pass")
 
     MIDDLEWARE_CLASSES += ('distributed.demo_middleware.StopAdminAccess','distributed.demo_middleware.LinkUserManual','distributed.demo_middleware.ShowAdminLogin',)
-
-print INSTALLED_APPS


### PR DESCRIPTION
The setup_linux.sh script reads the output of running get_setting.sh, which runs `"$pyexec" -c "import settings; print settings.$1"`. Since the settings print stuff now, this breaks ("too many values to unpack").
