### PR TITLE
Use SECURESYNC_PROTOCOL as protocol for CORS request to central server

### DIFF
--- a/kalite/templates/updates/update_languages.html
+++ b/kalite/templates/updates/update_languages.html
@@ -47,7 +47,7 @@
     <script type="text/javascript">
         var start_languagepackdownload_url = "{% url start_languagepack_download %}";
         var INSTALLED_LANGUAGES_URL = "{% url installed_language_packs %}"
-        var AVAILABLE_LANGUAGEPACK_URL = "http://" + CENTRAL_SERVER_HOST +  "/api/i18n/language_packs/available/{{ VERSION }}";
+        var AVAILABLE_LANGUAGEPACK_URL = SECURESYNC_PROTOCOL + "://" + CENTRAL_SERVER_HOST +  "/api/i18n/language_packs/available/{{ VERSION }}";
         var defaultLanguage = "{{ default_language }}";
     </script>
     <script type="text/javascript" src="{% static 'js/updates/update_languages.js' %}"></script>


### PR DESCRIPTION
Was getting a cross-site request error when the CORS AJAX request for language pack metadata was being redirected to https. Here, we set it to make the initial request use the appropriate protocol.
