### PR TITLE
Fix registration template permissions

### DIFF
--- a/kalite/distributed/settings.py
+++ b/kalite/distributed/settings.py
@@ -30,6 +30,12 @@ def USER_FACING_PORT():
 # Django settings
 ##############################
 
+# TODO(bcipolli): change these to "login" and "logout", respectively, if/when
+#  we migrate to a newer version of Django.  Older versions require these
+#  to be set if using the login_required decorator.
+LOGIN_URL = "/securesync/login/"
+LOGOUT_URL = "/securesync/logout/"
+
 TEMPLATE_DIRS = (os.path.join(os.path.dirname(__file__), "templates"),)
 
 TEMPLATE_CONTEXT_PROCESSORS = (


### PR DESCRIPTION
This depends on #1729.

Bug:
- If you didn't have permission to register (say, logged out), Django was forwarding to the wrong URL (settings.LOGIN_URL), as `securesync` is now using the `login_required` header for auth.

Expected:
- Get forwarded to our app-specific login URL (`/securesync/login`)

Changes:
- Given our older version of Django, I had to hard-code the login URL.  

Newer versions of Django would allow a named URL (for use with `reverse`), which would be nice.  Oh well!

Testing:
- Access `/securesync/register/` and made sure it forwarded to `/securesync/login/` rather than `/accounts/login/`, the Django default.
