### PR TITLE
Fix for #1782: select default language properly in facility_user template

### DIFF
--- a/kalite/facility/forms.py
+++ b/kalite/facility/forms.py
@@ -28,12 +28,10 @@ class FacilityUserForm(forms.ModelForm):
         self.fields["facility"].initial = facility.id
         self.fields["default_language"].choices = [(lang_code, get_language_name(lang_code)) for lang_code in get_installed_language_packs()]
 
-        # Select the initial default language
+        # Select the initial default language,
+        #   but only if we're not in the process of updating it to something else.
         if not self.fields["default_language"].initial and "default_language" not in self.changed_data:
-            if self.instance:
-                self.fields["default_language"].initial = self.instance.default_language or get_default_language()
-            else:
-                self.fields["default_language"].initial = get_default_language()
+            self.fields["default_language"].initial = (self.instance and self.instance.default_language) or get_default_language()
 
         # Passwords only required on new, not on edit
         self.fields["password_first"].required = self.instance.pk == ""

--- a/kalite/facility/templates/facility/facility_user.html
+++ b/kalite/facility/templates/facility/facility_user.html
@@ -7,9 +7,9 @@
 <script>
     var DEFAULT_LANGUAGE = "{{ default_language }}";
     $(function() {
-        // Guarantee that SOME language code is selected.
-        var lang_code_found = $('#id_default_language option[selected]');
-        if (lang_code_found.length == 0) {
+        // Guarantee that SOME language code is either SELECTED by the back-end,
+        //   or selected to the default value in the front-end.
+        if ($('#id_default_language option[selected]').length == 0) {
             $("#id_default_language").val(DEFAULT_LANGUAGE);
         }
 


### PR DESCRIPTION
- Add logic to `forms.py` to select language (works in most, but not all cases--not sure why; tested it's setting the right thing)
- Add JS to `facility_user.html` template to make sure that if a `default_language` dropdown value is not selected, the `DEFAULT_LANGUAGE` value is selected.

**Testing: Tested all 3 relevant scenarios:**
- Adding a new user
- Editing a user (`default_language=None`)
- Editing a user (`default_language` is set)
