### PR TITLE
Enable khanload to download latest topic files.

### DIFF
--- a/kalite/khanload/management/commands/khanload.py
+++ b/kalite/khanload/management/commands/khanload.py
@@ -608,7 +608,7 @@ def save_topic_tree(topic_tree=None, node_cache=None, data_path=os.path.join(set
     # Dump the topic tree (again)
     topic_tree = topic_tree or node_cache["Topic"]["root"][0]
 
-    dest_filepath = os.path.join(data_path, topic_tools.topics_file)
+    dest_filepath = os.path.join(data_path, topic_tools.TOPICS_FILEPATH)
     logging.debug("Saving topic tree to %s" % dest_filepath)
     with open(dest_filepath, "w") as fp:
         fp.write(json.dumps(topic_tree, indent=2))


### PR DESCRIPTION
Fix for #1795, with the following caveats:
- Knowledge map construction is broken, and needs to essentially be implemented from scratch (#1796)
- I am not updating the topic tree now, because:
  - #1796 - knowledge map won't update
  - The # of exercises we support reduced from 435 to 415.
  - Need to check how many videos are not part of our torrent files.

So, bottom line: this fix has no impact, except to update the `khanload` command for further testing.

**Testing:**
- Run `khanload` command--it should work!  Then restart the server and see if you can detect any topic changes :)
