### PR TITLE
 Issue 1420: Disabled Download Button while an active download is going ...

### DIFF
--- a/kalite/updates/static/js/updates/update_languages.js
+++ b/kalite/updates/static/js/updates/update_languages.js
@@ -139,7 +139,8 @@ $(function () {
 
 function start_languagepack_download(lang_code) {
     clear_messages();  // get rid of any lingering messages before starting download
-
+    $("#get-language-button").prop("disabled", true);
+    downloading = true;
     // tell server to start languagepackdownload job
     doRequest(
         start_languagepackdownload_url,
@@ -184,8 +185,6 @@ var language_downloading = null;
 $(function () {
     $("#get-language-button").click(function(event) {
         language_downloading = $("#language-packs").val();
-        $("#get-language-button").prop("disabled", true);
-        downloading = true;
         start_languagepack_download(language_downloading);
         
     });


### PR DESCRIPTION
Disabled Get Language Pack download button when an active language download is going on. 

Even the person choose another language in Select box or browse to another page and come back , the button remains disabled until the language download is complete. 

As the download completes , the user can select another language in select box and the button becomes active again. 
