### PR TITLE
 Resolved Issue 1830

### DIFF
--- a/kalite/i18n/custom_context_processors.py
+++ b/kalite/i18n/custom_context_processors.py
@@ -4,8 +4,10 @@ from . import lcode_to_ietf, get_language_name, get_installed_language_packs
 def languages(request):
     if "default_language" not in request.session:
         return {}  # temporarily skipped middleware, but we'll get back here again.  Tricky Django...
-
-    language_choices = get_installed_language_packs(force=True)
+    if request.is_admin:
+        language_choices = get_installed_language_packs(force=True)
+    else:
+        language_choices = get_installed_language_packs()
 
     return {
         "default_language": lcode_to_ietf(request.session["default_language"]),


### PR DESCRIPTION
Resolved the issue After downloading a new language pack, the language does not appear in the videos page dropdown for selecting a language.

https://github.com/learningequality/ka-lite/issues/1830
