### PR TITLE
Fix for #1481: Add Device, DeviceZone, Zone to syncing models.

### DIFF
--- a/python-packages/securesync/devices/models.py
+++ b/python-packages/securesync/devices/models.py
@@ -15,11 +15,9 @@ from django.utils.translation import ugettext_lazy as _
 
 from fle_utils.general import get_host_name
 from fle_utils.django_utils import validate_via_booleans, ExtendedModel
-from securesync import crypto
-from securesync import ID_MAX_LENGTH, IP_MAX_LENGTH
-from securesync import VERSION
+from securesync import ID_MAX_LENGTH, IP_MAX_LENGTH, VERSION
+from securesync import crypto, engine
 from securesync.engine.models import SyncedModel
-
 
 class RegisteredDevicePublicKey(ExtendedModel):
     public_key = models.CharField(max_length=500, help_text="(This field will be filled in automatically)")
@@ -642,3 +640,9 @@ class ChainOfTrust(object):
 
 # No device data gets "synced" through the same sync mechanism as data--it is only synced
 #   through the special hand-shaking mechanism
+# ... except, now Device, DeviceZone, and Zone do--so that any changes to the models
+#    will be synced.  The special handshake is necessary for new Device/Zone objects.
+#
+# These have circular dependencies, but because they've already been manually added,
+#   dependencies aren't any issue.
+engine.add_syncing_models([Device, Zone, DeviceZone], dependency_check=False)

--- a/python-packages/securesync/engine/__init__.py
+++ b/python-packages/securesync/engine/__init__.py
@@ -17,7 +17,7 @@ from securesync import VERSION
 
 _syncing_models = []  # all models we want to sync
 
-def add_syncing_models(models):
+def add_syncing_models(models, dependency_check=True):
     """When sync is run, these models will be sync'd"""
 
     get_foreign_key_classes = lambda m: set([field.rel.to for field in m._meta.fields if isinstance(field, ForeignKey)])
@@ -43,7 +43,7 @@ def add_syncing_models(models):
 
         # Before inserting, make sure that any models referencing *THIS* model
         # appear after this model.
-        if [True for synmod in _syncing_models[0:insert_after_idx-1] if model in get_foreign_key_classes(synmod)]:
+        if dependency_check and [True for synmod in _syncing_models[0:insert_after_idx-1] if model in get_foreign_key_classes(synmod)]:
             raise Exception("Dependency loop detected in syncing models; cannot proceed.")
 
         # Now we're ready to insert.


### PR DESCRIPTION
TItle says it all.  

Because these models are specially transferred during the syncing hand-shake (only if missing completely), changes in data are never sent.

By adding to syncing models, such changes will now be sent.  It's just that easy!

**Testing:**
- Tested after registering to old central servers; nothing breaks.  I.e. this is at least as good as the old.
- After merging, will test further.  This should work just fine, but the change is so small (essentially 1 line), we can easily back out if needed.

@jamalex please take a look by Thursday afternoon, if you have time.
