### PR TITLE
Fix for 1866: Hiding meaningless headless zone information 

### DIFF
--- a/kalite/control_panel/templates/control_panel/base.html
+++ b/kalite/control_panel/templates/control_panel/base.html
@@ -21,8 +21,8 @@
                 <li>
                     {% if org %}&gt;{% endif %}
                     {% if facility or device %}<a href="{%url zone_management zone_id=zone_id %}">{% endif %}
-                        {% if headless_zone %}
-                            Overview for Auto-Registered Zone
+                        {% if is_headless_zone %}
+                            Local KA Lite Installation
                         {% elif zone %}
                             {{ zone.name|truncatechars:35 }}
                         {% elif not zone %}

--- a/kalite/control_panel/views.py
+++ b/kalite/control_panel/views.py
@@ -84,7 +84,7 @@ def zone_management(request, zone_id="None"):
         raise Http404()  # on distributed server, we can make due if they're not registered.
 
     # Denote the zone as headless or not
-    headless_zone = re.search(r'Zone for public key .{50}', context["zone"].name)
+    is_headless_zone = re.search(r'Zone for public key ', context["zone"].name)
 
     # Accumulate device data
     device_data = OrderedDict()
@@ -134,7 +134,7 @@ def zone_management(request, zone_id="None"):
         }
 
     context.update({
-        "headless_zone": headless_zone,
+        "is_headless_zone": is_headless_zone,
         "facilities": facility_data,
         "devices": device_data,
         "upload_form": UploadFileForm(),


### PR DESCRIPTION
Addresses #1866

Previously for headless zones: ![82666ad0-bb36-11e3-8e78-a6ff8be00c4a](https://cloud.githubusercontent.com/assets/1319950/2635130/fc1b3a10-be81-11e3-8e0e-a556e9698a3e.png)

Now: 
![image](https://cloud.githubusercontent.com/assets/1319950/2635151/306d017c-be82-11e3-8d39-12cce59b84f8.png)
