### PR TITLE
Hotfix for #1903: metadata check was wrong, outer loop should be model dependencies

### DIFF
--- a/kalite/securesync/devices/models.py
+++ b/kalite/securesync/devices/models.py
@@ -194,7 +194,7 @@ class Device(SyncedModel):
         if soft_set and self.signed_by.get_counter_position() >= counter_position:
             return
 
-        assert counter_position > metadata.counter_position, "You should not be setting the counter position to a number lower than its current value!"
+        assert counter_position >= metadata.counter_position, "You should not be setting the counter position to a number lower than its current value!"
         metadata.counter_position = counter_position
         metadata.save()
 

--- a/kalite/securesync/engine/__init__.py
+++ b/kalite/securesync/engine/__init__.py
@@ -115,24 +115,24 @@ def get_models(device_counters=None, limit=settings.SYNCING_MAX_RECORDS_PER_REQU
     models = []
     remaining = limit
 
-    # loop through each of the devices of interest
-    #   Do devices first, because each device is independent.
-    #   Models within a device are highly dependent (on explicit dependencies,
-    #   as well as counter position)
-    for device_id, counter in device_counters.items():
-        device = Device.objects.get(pk=device_id)
-
+    # loop through all the model classes marked as syncable
+    #  (note: NEVER BREAK OUT OF THIS LOOP!  We need to ensure that
+    #    all models below the counter position selected are sent NOW,
+    #    otherwise they will be forgotten FOREVER)
+    for Model in _syncing_models:
         # We need to track the min counter position (send things above this value)
         #   and the max (we're sending up to this value, so make sure nothing
         #   below it is left behind)
         counter_min = counter + 1
         counter_max = 0
 
-        # loop through all the model classes marked as syncable
-        #  (note: NEVER BREAK OUT OF THIS LOOP!  We need to ensure that
-        #    all models below the counter position selected are sent NOW,
-        #    otherwise they will be forgotten FOREVER)
-        for Model in _syncing_models:
+        # loop through each of the devices of interest
+        #   Do devices first, because each device is independent.
+        #   Models within a device are highly dependent (on explicit dependencies,
+        #   as well as counter position)
+        for device_id, counter in device_counters.items():
+            device = Device.objects.get(pk=device_id)
+
             queryset = Model.objects.filter(Q(signed_by=device) | Q(signed_by__isnull=True))
 
             # for trusted (central) device, only include models with the correct fallback zone


### PR DESCRIPTION
Two syncing issues; one central, the other distributed:
1. We were too stringent on our check on the metadata counter.  Change `>` to `>=`
2. We had assumed that there were no inter-device object dependencies.  This was wrong.  For example:
    \* A `FacilityUser` was created on Device B, and synced to Device A
    \* An `ExerciseLog` was created on Device A
    \* Device C joins the network.  
    \* If Device C gets data from Device A before Device B, then the `ExerciseLog` will refer to an unrecognized user.

**Testing:**
- Tested using the data stored in the issue.  Will push up to the staging server shortly.

@jamlaex This is a simple, but important syncing change.  Can you take a looksie?
