### PR TITLE
Fix for #1950: make delete_zone an API request. 

### DIFF
--- a/kalite/control_panel/api_urls.py
+++ b/kalite/control_panel/api_urls.py
@@ -1,0 +1,5 @@
+from django.conf.urls.defaults import patterns, url
+
+urlpatterns = patterns(__package__ + '.api_views',
+    url(r'zone/(?P<zone_id>\w+)/delete$', 'delete_zone', {}, 'delete_zone'),
+)

--- a/kalite/control_panel/api_views.py
+++ b/kalite/control_panel/api_views.py
@@ -1,0 +1,23 @@
+"""
+"""
+from django.contrib import messages
+from django.conf import settings; logging = settings.LOG
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.utils.translation import ugettext as _
+
+from fle_utils.internet import api_handle_error_with_json, JsonResponseMessageSuccess, JsonResponseMessageError
+from kalite.shared.decorators import require_authorized_admin
+from securesync.models import Zone
+
+
+@require_authorized_admin
+@api_handle_error_with_json
+def delete_zone(request, zone_id):
+    zone = get_object_or_404(Zone, id=zone_id)
+    if zone.has_dependencies(passable_classes=["Organization"]):
+        return JsonResponseMessageError(_("You cannot delete this zone because it is syncing data with with %d device(s)") % zone.devicezone_set.count())
+    else:
+        zone.delete()
+        return JsonResponseMessageSuccess(_("You have successfully deleted %(zone_name)s") % {"zone_name": zone.name})

--- a/kalite/control_panel/static/js/control_panel/zone_management.js
+++ b/kalite/control_panel/static/js/control_panel/zone_management.js
@@ -3,9 +3,11 @@ $(function () {
         force_sync();
     })
 
+    /*
     $(".zone-delete-link").click(function() {
         if (confirm(sprintf(gettext("Are you sure you want to delete sharing network '%(network_name)s'?"), {network_name: event.target.getAttribute("value")}))) {
-            window.location.href = DELETE_ZONE_URL;
+            doRequest(DELETE_ZONE_URL);
         }
     });
+    */
 })

--- a/kalite/control_panel/templates/control_panel/zone_management.html
+++ b/kalite/control_panel/templates/control_panel/zone_management.html
@@ -55,17 +55,6 @@
                     <a class="green_button" href="#">{% trans "Sync via USB" %}</a>
                 </li-->
             {% endblock download_button %}
-            <li>
-                <ul id="zone-management-options">
-                        <li>
-                            <a href="#" class="zone-delete-link btn btn-danger" title="{% trans 'Delete this sharing network' %}" value="{{ zone.name }}">
-                                {% trans 'Delete this sharing network' %}<i class="icon-trash"></i>
-                            </a>
-                        </li>
-                    {% if not facilities and not devices %}{# can only happen on the central server #}
-                    {% endif %}
-                </ul>
-            </li>
 {% endblock buttons %}
 
 {% block control_panel_content %}

--- a/kalite/control_panel/urls.py
+++ b/kalite/control_panel/urls.py
@@ -1,11 +1,11 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls.defaults import patterns, url, include
 
+from . import api_urls
 
 urlpatterns = patterns(__package__ + '.views',
     # Zone
     url(r'zone/(?P<zone_id>\w+)/$', 'zone_management', {}, 'zone_management'),
     url(r'zone/(?P<zone_id>\w+)/edit$', 'zone_form', {}, 'zone_form'),
-    url(r'zone/(?P<zone_id>\w+)/delete$', 'delete_zone', {}, 'delete_zone'),
 
     # Device
     url(r'zone/(?P<zone_id>\w+)/device/(?P<device_id>\w+)/$', 'device_management', {}, 'device_management'),
@@ -16,4 +16,6 @@ urlpatterns = patterns(__package__ + '.views',
     url(r'zone/(?P<zone_id>\w+)/facility/(?P<facility_id>\w+)/management/group/(?P<group_id>\w+)/$', 'facility_management', {}, 'facility_management'),
 
     url(r'account/$', 'account_management', {}, 'account_management'),
+
+    url(r'^api/', include(api_urls)),
 )

--- a/kalite/control_panel/views.py
+++ b/kalite/control_panel/views.py
@@ -87,7 +87,7 @@ def zone_management(request, zone_id="None"):
     if context["zone"]:
         is_headless_zone = re.search(r'Zone for public key ', context["zone"].name)
     else:
-        is_headless_zone = False 
+        is_headless_zone = False
 
     # Accumulate device data
     device_data = OrderedDict()
@@ -145,22 +145,6 @@ def zone_management(request, zone_id="None"):
     })
     context.update(set_clock_context(request))
     return context
-
-
-@require_authorized_admin
-def delete_zone(request, zone_id):
-    zone = get_object_or_404(Zone, id=zone_id)
-    if not zone.has_dependencies(passable_classes=["Organization"]):
-        zone.delete()
-        messages.success(request, _("You have successfully deleted ") + zone.name + ".")
-        if settings.CENTRAL_SERVER:
-            return HttpResponseRedirect(reverse("org_management"))
-        else:
-            return HttpResponseRedirect(reverse("zone_management", kwargs={"zone_id": "None"}))
-    else:
-        messages.warning(request, _("You cannot delete this zone because it is syncing data with with %d device(s)") % zone.devicezone_set.count())
-        return HttpResponseRedirect(reverse("zone_management", kwargs={"zone_id": zone_id}))
-    
 
 
 @require_authorized_admin


### PR DESCRIPTION
next: only offer the option from org_management.

![image](https://cloud.githubusercontent.com/assets/4072455/2686530/ab959e90-c20b-11e3-92a1-30e9c33a2dd2.png)

Changes:
- Move code into `api_*.py`
- Wrap request in `doRequest`
- Return `JsonResponseMessage*` objects, like a good api view should.

Testing:
- Tested the code works from the `zone_management` page.
- Then deleted the option--this should only be available through org management!
