### PR TITLE
Fix for #1852: Always invalidate inmemory_caches.

### DIFF
--- a/kalite/distributed/caching.py
+++ b/kalite/distributed/caching.py
@@ -50,7 +50,7 @@ def invalidate_on_video_update(sender, **kwargs):
     if just_now_available:
         # This event should only happen once, so don't bother checking if
         #   this is the field that changed.
-        logging.debug("Invalidating cache on save for %s" % kwargs["instance"])
+        logging.debug("Invalidating cache on VideoFile save for %s" % kwargs["instance"])
         invalidate_all_caches()
 
 @receiver(pre_delete, sender=VideoFile)
@@ -60,7 +60,7 @@ def invalidate_on_video_delete(sender, **kwargs):
     """
     was_available = kwargs["instance"] and kwargs["instance"].percent_complete == 100
     if was_available:
-        logging.debug("Invalidating cache on delete for %s" % kwargs["instance"])
+        logging.debug("Invalidating cache on VideoFile delete for %s" % kwargs["instance"])
         invalidate_all_caches()
 
 
@@ -137,7 +137,7 @@ def invalidate_all_caches():
     Basic entry-point for clearing necessary caches.  Most functions can
     call in here.
     """
+    invalidate_inmemory_caches()
     if caching_is_enabled():
-        invalidate_inmemory_caches()
         invalidate_web_cache()
-        logging.debug("Great success emptying all caches.")
+    logging.debug("Great success emptying all caches.")

--- a/kalite/updates/management/commands/videodownload.py
+++ b/kalite/updates/management/commands/videodownload.py
@@ -186,6 +186,8 @@ class Command(UpdatesDynamicCommand, CronCommand):
                     handled_youtube_ids.append(video.youtube_id)
                     self.stdout.write(_("Download is complete!") + "\n")
 
+                    # caching.invalidate_all_caches()  # Unnecessary; we have a database listener for this.
+
                 except DownloadCancelled:
                     # Cancellation event
                     video.percent_complete = 0


### PR DESCRIPTION
Invalidation of in-memory caches was dependent on `caching.is_enabled()`.  In-memory caches are always working, so always should be invalidated.
