### PR TITLE
Allow start.sh to be used to trigger automated setup via kaserve.

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,15 +13,11 @@ else
     SCRIPT_DIR=$SCRIPT_DIR/scripts
 fi
 
-if [ ! -e "$KALITE_DIR/database/data.sqlite" ] ; then
-    echo "Please run install.sh first!"
-else
-    # move any previously downloaded content from the old location to the new
-    mv "$KALITE_DIR/static/videos/*" "$KALITE_DIR/../content" > /dev/null 2> /dev/null
+# move any previously downloaded content from the old location to the new
+mv "$KALITE_DIR/static/videos/*" "$KALITE_DIR/../content" > /dev/null 2> /dev/null
 
-    echo
-    source "$SCRIPT_DIR/cronstart.sh"
+echo
+source "$SCRIPT_DIR/serverstart.sh"
 
-    echo
-    source "$SCRIPT_DIR/serverstart.sh"
-fi
+echo
+source "$SCRIPT_DIR/cronstart.sh"


### PR DESCRIPTION
We allow kaserve to be run without having been configured (as it calls setup if needed), but this ability didn't transfer to the start.sh script. Two fixes to get it working from there as well:
1. Don't require that a DB already exists when running start.sh
2. Run serverstart.sh before cronstart.sh, otherwise the cron server fails if the DB hasn't been initialized yet.
