### PR TITLE
Handle failures in setting copied script file permissions gracefully.

### DIFF
--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -285,7 +285,10 @@ class Command(BaseCommand):
                 dest_dir = os.path.join(settings.PROJECT_PATH, "..")
                 src_dir = os.path.join(dest_dir, "scripts")
                 shutil.copyfile(os.path.join(src_dir, script_file), os.path.join(dest_dir, script_file))
-                shutil.copystat(os.path.join(src_dir, script_file), os.path.join(dest_dir, script_file))
+                try:
+                    shutil.copystat(os.path.join(src_dir, script_file), os.path.join(dest_dir, script_file))
+                except OSError: # even if we have write permission, we might not have permission to change file mode
+                    sys.stdout.write("WARNING: Unable to set file permissions on %s! \n" % script_file)
 
             start_script_path = os.path.realpath(os.path.join(settings.PROJECT_PATH, "..", "start%s" % system_script_extension()))
 


### PR DESCRIPTION
In some cases, KA Lite is installed with read/write permissions, but not owned by the user who will be running it (e.g. in a shared environ). In this case, the setup script would fail when trying to set the stats
of a copied script, and end up in an unrecoverable state ("buddy, you're screwed").

Since it's likely to work fine without setting the file stats, this PR switches to just warning, rather than dying.
