### PR TITLE
Fixed minor issue causing setup_linux.sh to crash on Mac

### DIFF
--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -6,7 +6,7 @@ pyexec=`"$SCRIPT_DIR"/python.sh`
 "$pyexec" "$current_dir/kalite/manage.py" setup
 
 # TODO: make a check to see if we're running the rpi
-we_are_rpi=""
+we_are_rpi="False"
 if [ $we_are_rpi = "True" ]; then
     while true
     do


### PR DESCRIPTION
setup_linux.sh crashed on line 10 because $we_are_rpi was a null string.
So I changed $we_are_rpi to "False".

This very minor issue should be fixed eventually when the TODO on line 8 is carried out,
but I decided to fix it anyway so that no one else runs into this error when installing ka-lite.
