### PR TITLE
Hotfix/2034 knowledge map cant be scrolled

### DIFF
--- a/kalite/distributed/static/css/distributed/kmap_editor.css
+++ b/kalite/distributed/static/css/distributed/kmap_editor.css
@@ -3,7 +3,7 @@ div#map-container {
     top: 0;
     left: 0;
     height: 100%;
-    overflow: hidden;
+    overflow: auto;
     background: #000;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
@@ -13,7 +13,7 @@ div#map-container {
     user-select: none;
     line-height: 11px;
     min-height: 1100px;
-    min-width: 800px;
+    min-width: 700px;
 }
 
 a.topic-button {

--- a/kalite/distributed/static/js/distributed/kmap-editor.js
+++ b/kalite/distributed/static/js/distributed/kmap-editor.js
@@ -110,9 +110,6 @@ var KMapEditor = {
         //  when it's width is less than the container width or set it to a constant 10px when
         // it is scrollable.
 
-        // CSS class to use for the map container.
-        var overflow = "hidden";
-
         // canvas height
         var raphaelHeight = this.raphael.height;
         if (mapHeight < raphaelHeight) {
@@ -125,9 +122,8 @@ var KMapEditor = {
         // canvas width
         var raphaelWidth = this.raphael.width;
         var marginLeft = (mapWidth - (raphaelWidth + (this.maxX * 2))) / 2;
-        if ((marginLeft < 10)) {
+        if ((marginLeft < 20)) {
             marginLeft = 10;
-            overflow = "scroll";
         } else {
             marginLeft = mapWidth / 2 - ((this.maxX - this.minX) * this.X_SPACING / 2);
         }
@@ -135,10 +131,6 @@ var KMapEditor = {
         $("#map").css({
             "margin-left": marginLeft,
             "margin-top": 30
-        });
-
-        $("#map-container").css({
-            "overflow": overflow
         });
     },
 


### PR DESCRIPTION
For #2034 - "Knowledge map can't be scrolled" - this is the initial fix to allow user to scroll horizontally if the contents of the map is more than its container's width. 

I also modified the formula to compute for the `margin-left` attribute of the container and to set it's `overflow` attribute to `scroll` as needed.

I have tested this with browser size of "1024 x 768" on Chrome v34.0.1847.131, Firefox v29.0.1, and Safari v7.0.3.
