### PR TITLE
Fix summary stats

### DIFF
--- a/kalite/control_panel/templates/control_panel/facility_management.html
+++ b/kalite/control_panel/templates/control_panel/facility_management.html
@@ -183,22 +183,20 @@
         <div class="groups" id="groups">
         {% if group_id %}
             {# comment "First block is a group summary page for a single group's display" #}
-            {% with groups|first as groupdata %}
             <dl class="dl-horizontal">
             <dt>{% trans "# Students" %}</dt>
-            <dd>{{ groupdata.total_users }}</dd>
+            <dd>{{ groups.total_users }}</dd>
             <dt>{% trans "Logins" %}</dt>
-            <dd>{{ groupdata.total_logins }}</dd>
+            <dd>{{ groups.total_logins }}</dd>
             <dt>{% trans "Login Time" %}</dt>
-            <dd>{{ groupdata.total_hours|floatformat }}</dd>
+            <dd>{{ groups.total_hours|floatformat }}</dd>
             <dt>{% trans "Videos Viewed" %}</dt>
-            <dd>{{ groupdata.total_videos }}</dd>
+            <dd>{{ groups.total_videos }}</dd>
             <dt>{% trans "Exercises Completed" %}</dt>
-            <dd>{{ groupdata.total_exercises }}</dd>
+            <dd>{{ groups.total_exercises }}</dd>
             <dt>{% trans "Mastery " %}</dt>
-            <dd>{{ groupdata.pct_mastery }}</dd>
+            <dd>{{ groups.pct_mastery }}</dd>
             </dl>
-            {% endwith %}
 
         {% else %}
             {# "Second block is a list of all available groups, in table form." %}{% endcomment #}

--- a/kalite/control_panel/views.py
+++ b/kalite/control_panel/views.py
@@ -288,12 +288,20 @@ def facility_management(request, facility, group_id=None, zone_id=None, per_page
     period_end = form.data.get("period_end")
     (period_start, period_end) = _get_date_range(frequency, period_start, period_end)
 
+    # If group_id exists, we don't need the data for the other groups, 
+    # so make groupdata specific to that individual group (Fix for #151 on ka-lite-central)
+    if group_id:
+        group_id_index = next(index for (index, d) in enumerate(group_data.values()) if d["id"] == group_id)
+        group_data = group_data.values()[group_id_index]
+    else: 
+        group_data = group_data.values()
+
     context.update({
         "form": form,
         "date_range": [str(period_start), str(period_end)],
         "group": group,
         "group_id": group_id,
-        "groups": group_data.values(),
+        "groups": group_data, # sends dict if group page, list of group data otherwise
         "student_pages": student_pages,  # paginated data
         "coach_pages": coach_pages,  # paginated data
         "page_urls": {


### PR DESCRIPTION
This ought to make @mikewray happy!

Fix for [#151 on ka-lite-central](https://github.com/fle-internal/ka-lite-central/issues/151) which also was also appearing on distributed (so fixed here, and will trickle merge with central). 

Now we show summary stats correctly for all groups, not just the first one. 

@aronasorman should be a fairly low friction change, but would be good to have someone sanity check the code and test the views
