### PR TITLE
Align tables in firefox 

### DIFF
--- a/kalite/coachreports/templates/coachreports/tabular_view.html
+++ b/kalite/coachreports/templates/coachreports/tabular_view.html
@@ -216,16 +216,15 @@
                                 {% for video in videos %}
                                     {% if not student.video_logs|get_item:video.id %}
                                         <td class="status data" title="{% trans "Not Viewed" %}">
-                                            &nbsp;
                                     {% elif not student.video_logs|get_item:video.id|get_item:"complete" %}
                                         <td class="status data partial" title="{% trans "Viewing" %}">
-                                            <div class="total_seconds_watched">{% blocktrans with total_seconds_watched=student.video_logs|get_item:video.id|get_item:"total_seconds_watched" %}{{ total_seconds_watched }} secs{% endblocktrans %}</div>
+                                            {# <div class="total_seconds_watched">{% blocktrans with total_seconds_watched=student.video_logs|get_item:video.id|get_item:"total_seconds_watched" %}{{ total_seconds_watched }} secs{% endblocktrans %}</div> #}
                                     {% else %}
                                         <td class="status data complete" title="{% trans "Viewed" %}">
-                                            <div class="total_seconds_watched">100%</div>
+                                            {# <div class="total_seconds_watched">100%</div> #}
                                     {% endif %}
                                     {% if student.video_logs|get_item:video.id  %}
-                                            <div class="points">{% blocktrans with points=student.video_logs|get_item:video.id|get_item:"points"  %}{{ points}} points{% endblocktrans %}</div>
+                                            {# <div class="points">{% blocktrans with points=student.video_logs|get_item:video.id|get_item:"points"  %}{{ points}} points{% endblocktrans %}</div> #}
                                     {% endif %}
                                         </td>
                                 {% endfor %}


### PR DESCRIPTION
Fix for #2012 

We had a couple of divs with display:none in the tabular report for videos that were causing alignment issues. Commenting them out fixes it. Leaving these commented out instead of deleting in case whoever put them in decides they want to come back and finish the job :+1: 

Thanks @mikewray for finding this and being diligent about it! 

@aronasorman fingers crossed this doesn't blow up our tests. 
