### PR TITLE
Fix for Bootstrap's collapsible menu in Firefox and supposedly IE

### DIFF
--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -103,17 +103,18 @@
 
         <div class="navbar navbar-default navbar-fixed-top">
             <div class="container">
+                <div class="navbar-header">
+                    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                        <span class="icon-bar"></span>
+                    </button>
 
-                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                    <span class="icon-bar"></span>
-                </button>
-
-                <a class="navbar-brand" href="/" title="{% trans 'KA Lite Home' %}">
-                    <img src="{% static "images/distributed/horizontal-logo-small.png" %}" alt="{% trans 'KA Lite logo' %}">
-                    <div class="pull-right visible-xs" id="sitepoints-xs"></div>
-                </a>
+                    <a class="navbar-brand" href="/" title="{% trans 'KA Lite Home' %}">
+                        <img src="{% static "images/distributed/horizontal-logo-small.png" %}" alt="{% trans 'KA Lite logo' %}">
+                        <div class="pull-right visible-xs" id="sitepoints-xs"></div>
+                    </a>
+                </div>
                 <div class="collapse navbar-collapse">
                     <ul class="nav navbar-nav navbar-right">
                         {% block sitewide_navigation %}


### PR DESCRIPTION
While starting on a new Bootstrap project I discovered that the menu icon and logo should be wrapped in a "navbar-header" div class tag so that the menu appears correctly in Firefox and supposedly IE (I was able to test in Firefox but not IE).  It's really just 2 lines of code that have changed - 106 and 117.
