### PR TITLE
Restore the code that were accidentally "cleaned-up" to automatically ru...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 script:
   - python python-packages/fle_utils/tests.py
   - python kalite/manage.py syncdb --migrate --noinput --traceback # make sure database is all setup
-  - python kalite/manage.py test --traceback -v 2  # run django tests
+  - python kalite/manage.py test  # run django tests
   - grunt jshint  # run jshint
 notifications:
   email:

--- a/kalite/i18n/__init__.py
+++ b/kalite/i18n/__init__.py
@@ -95,7 +95,7 @@ def get_dubbed_video_map(lang_code=None, force=False):
         DUBBED_VIDEO_MAP = {}
         for lang_name, video_map in DUBBED_VIDEO_MAP_RAW.iteritems():
             if not lang_name:
-                lang_name = None
+                continue
             logging.debug("Adding dubbed video map entry for %s (name=%s)" % (get_langcode_map(lang_name), lang_name))
             DUBBED_VIDEO_MAP[get_langcode_map(lang_name)] = video_map
 


### PR DESCRIPTION
Hi @aronasorman 

Hot fix for #1253 - where I accidentally "cleaned-up" the code to automatically run the `start.sh` script which runs the KA Lite server upon login on OSX.
