### PR TITLE
Hot fix for #1253 to autorun KA Lite server on OSX if set.

### DIFF
--- a/kalite/distributed/management/commands/initdconfig.py
+++ b/kalite/distributed/management/commands/initdconfig.py
@@ -51,6 +51,8 @@ if sys.platform == 'darwin':
         <string>org.learningequality.kalite</string>
         <key>Program</key>
         <string>%(script_path)s/start.sh</string>
+        <key>RunAtLoad</key>
+        <true/>
         <key>StandardOutPath</key>
         <string>/tmp/kalite.out</string>
         <key>StandardErrorPath</key>

--- a/kalite/i18n/__init__.py
+++ b/kalite/i18n/__init__.py
@@ -94,6 +94,8 @@ def get_dubbed_video_map(lang_code=None, force=False):
 
         DUBBED_VIDEO_MAP = {}
         for lang_name, video_map in DUBBED_VIDEO_MAP_RAW.iteritems():
+            if not lang_name:
+                continue
             logging.debug("Adding dubbed video map entry for %s (name=%s)" % (get_langcode_map(lang_name), lang_name))
             DUBBED_VIDEO_MAP[get_langcode_map(lang_name)] = video_map
 


### PR DESCRIPTION
Hi @aronasorman

Hot fix for #1253 - where I accidentally "cleaned-up" the code to automatically run the start.sh script which runs the KA Lite server upon login on OSX.
Hot fix to pass Travis tests by checking that `lang_name` has a value for dubbed video data on `get_dubbed_video_map()`.
This overrides the previous commits to cherry-pick final codes to remove the debug commits.
