### PR TITLE
Remove translation for `title` property of `FacilityGroup`.

### DIFF
--- a/kalite/facility/models.py
+++ b/kalite/facility/models.py
@@ -116,13 +116,11 @@ class FacilityGroup(DeferredCountSyncedModel):
 
         return zone
 
-
     @property
     def title(self):
-        # Translators: This is the name and description of the Facility Group.
         if self.description:
-            return _("%s - %s" % (self.name, self.description,))
-        return _(self.name)
+            return "%s - %s" % (self.name, self.description,)
+        return self.name
 
 
 class FacilityUser(DeferredCountSyncedModel):


### PR DESCRIPTION
This is for #1966 with original PR at #2113 on branch `nalanda-rc2`.

Removed the translation codes as @jamalex pointed out at original PR.
