### PR TITLE
Checks properly for existence of array element for quiz_log response_log

### DIFF
--- a/kalite/distributed/static/js/distributed/exercises.js
+++ b/kalite/distributed/static/js/distributed/exercises.js
@@ -533,7 +533,7 @@ window.QuizLogModel = Backbone.Model.extend({
             this._response_log_cache = JSON.parse(this.get("response_log") || "[]");
         }
 
-        if(this._response_log_cache[this.get("attempts")]){
+        if(!this._response_log_cache[this.get("attempts")]){
             this._response_log_cache.push(0);
         }
         // add the event to the response log list


### PR DESCRIPTION
Current behaviour:
- Quiz Log's response_log field only records [null, null, null...]

Desired behaviour:
- Response_log should have a list of number correct in each attempt at the quiz.

Summary of changes:
- Add an "!" before checking whether an entry in the response_log exists.
