### PR TITLE
Add link to coach ungrouped students.

### DIFF
--- a/kalite/control_panel/templates/control_panel/facility_management.html
+++ b/kalite/control_panel/templates/control_panel/facility_management.html
@@ -246,9 +246,14 @@
                                                 {% endif %}
                                             </td>
                                             <td>
-                                                {% if group.id %}
                                                 {# Translators: this is a verb; by clicking this link, the user will be able to coach students. #}
-                                                <a title="{% blocktrans with groupname=group.name %}Coach group {{ groupname }}.{% endblocktrans %}" href="{% url 'coach_reports' %}?facility={{ facility_id }}&group={{ group.id }}">
+                                                <a title="{% blocktrans with groupname=group.name %}Coach group {{ groupname }}{% endblocktrans %}" 
+                                                {% if group.id %}
+                                                    href="{% url 'coach_reports' %}?facility={{ facility_id }}&group={{ group.id }}"
+                                                {% elif group.name == ungrouped %}
+                                                    href="{% url 'coach_reports' %}?facility={{ facility_id }}&group={{ group.name }}"
+                                                {% endif %}
+                                                >
                                                 <div class="sparklines" sparkType="bar" sparkBarColor="green">
                                                 <!--
                                                     {{ group.total_logins }},
@@ -256,7 +261,6 @@
                                                     {{ group.total_exercises }}
                                                 -->
                                                 </div></a>
-                                                {% endif %}
                                             </td>
                                             <td>{{ group.total_users }}</td>
                                             <td>{{ group.total_logins }}</td>


### PR DESCRIPTION
Solves https://github.com/fle-internal/ka-lite-central/issues/198

Previously we didn't have a link to coach ungrouped students. Now, we pass in "ungrouped" as the group_id which defaults to all groups for coach reports on both central and distributed. :bamboo: 

requesting a quick peek from @jamalex 
