### PR TITLE
Handle function or list from psutil

### DIFF
--- a/python-packages/fle_utils/set_process_priority.py
+++ b/python-packages/fle_utils/set_process_priority.py
@@ -55,6 +55,11 @@ def _set_linux_mac_priority(priority, logging=logging):
         return False
 
     this_process = psutil.Process(os.getpid())
+    # Psutil is builtin to some python installations, and the versions
+    # may differ across devices. It affects the code below, b/c for the 
+    # 2.x psutil version. 'this_process.cmdline is a function that 
+    # returns a list; in the 1.x version it's just a list. 
+    # So we check what kind of cmdline we have, and go from there.
     if isinstance(this_process.cmdline, list):
         cmdline = this_process.cmdline
     else:


### PR DESCRIPTION
@aronasorman gets credit for debugging this, basically I was having trouble syncing locally and we found that my version of psutil (1.2.1) provided the cmdline attribute as a list, and @cpauya 's version was expecting a function. So we now handle both cases. 
