### PR TITLE
Fix: #189 on KA Lite central

### DIFF
--- a/kalite/facility/views.py
+++ b/kalite/facility/views.py
@@ -153,7 +153,7 @@ def _facility_user(request, facility, title, is_teacher=False, new_user=False, u
                     return HttpResponseRedirect(next)
 
             # New user created by admin
-            elif request.is_admin:
+            elif request.is_admin or request.is_django_user:
                 messages.success(request, _("You successfully created user '%(username)s'") % {"username": form.instance.get_name()})
                 return HttpResponseRedirect(next)
 


### PR DESCRIPTION
Fixes https://github.com/fle-internal/ka-lite-central/issues/189#issuecomment-57759064

Basically request.is_admin doesn't handle the situation where a non staff central server admin creates a new student, so we were advancing to the else, which assumes a new student was signing themselves up, so our central server code was throwing a weird error. Thanks @mikewray for catching this! 
