### PR TITLE
Hotfix/2465 keyerror exception on generaterealdata command

### DIFF
--- a/kalite/coachreports/management/commands/generaterealdata.py
+++ b/kalite/coachreports/management/commands/generaterealdata.py
@@ -35,7 +35,7 @@ from django.db import transaction
 from fle_utils.general import datediff
 from kalite.facility.models import Facility, FacilityUser, FacilityGroup
 from kalite.main.models import ExerciseLog, VideoLog, UserLog
-from kalite.topic_tools import get_topic_videos, get_topic_exercises
+from kalite.topic_tools import get_topic_videos, get_topic_exercises, get_video_cache
 
 
 firstnames = ["Vuzy", "Liz", "Ben", "Richard", "Kwame", "Jamie", "Alison", "Nadia", "Zenab", "Guan", "Dylan", "Vicky",
@@ -359,6 +359,9 @@ def generate_fake_video_logs(facility_user=None, topics=topics, start_date=datet
 
         date_diff_started = datetime.timedelta(seconds=datediff(date_diff, units="seconds") * user_settings["time_in_program"])  # when this user started in the program, relative to NOW
 
+        # contains the video duration key
+        video_cache = get_video_cache()
+
         for topic in topics:
             videos = get_topic_videos(topic_id=topic)
 
@@ -400,8 +403,16 @@ def generate_fake_video_logs(facility_user=None, topics=topics, start_date=datet
                     pct_completed = 100.
                 else:      # Slower students will use videos more.  Effort also important.
                     pct_completed = 100. * min(1., sqrt(random.random() * sqrt(user_settings["effort_level"] * user_settings["time_in_program"] / sqrt(user_settings["speed_of_learning"]))))
+
+                # get the video duration on the video cache
+                video_id = video.get("id", "")
+                video_duration = 0
+                if video_id and video_cache:
+                    video_item = video_cache.get(video_id, None)
+                    if video_item:
+                        video_duration = video_item.get("duration", 0)
+
                 # Compute quantities based on sample
-                video_duration = video.get("duration", 0)
                 total_seconds_watched = int(video_duration * pct_completed / 100.)
                 points = int(750 * pct_completed / 100.)
 
@@ -419,7 +430,6 @@ def generate_fake_video_logs(facility_user=None, topics=topics, start_date=datet
                     time_delta_completed = datetime.timedelta(seconds=random.randint(int(time_for_watching), int(datediff(date_diff_started, units="seconds"))))
                     date_completed = datetime.datetime.now() - time_delta_completed
 
-                video_id = video.get("id", "")
                 try:
                     vlog = VideoLog.objects.get(user=facility_user, video_id=video_id)
                 except VideoLog.DoesNotExist:


### PR DESCRIPTION
Hi @aronasorman - this fixes #2465.
- We now get the video duration from the video cache.  The duration value defaults to zero.
- The `youtube_id` also defaults to the `video_id` to prevent the KeyError exception too.
