### PR TITLE
#2192 Registration process (possibly) not marking status correctly / immediately 

### DIFF
--- a/kalite/control_panel/templates/control_panel/zone_management.html
+++ b/kalite/control_panel/templates/control_panel/zone_management.html
@@ -164,8 +164,13 @@
                                 </td>
                                 <td>
                                     {% if device.is_own_device %}
-                                        <button id="force-sync" class="btn btn-primary registered-only">{% trans "Sync Now!" %}</button>
-                                        <a class="btn btn-success not-registered-only" href="{% url 'register_public_key' %}">{% trans "Register device" %}</a>
+
+                                        {% if device.is_registered %}
+                                            <button id="force-sync" class="btn btn-primary">{% trans "Sync Now!" %}</button>
+                                        {% else %}
+                                            <a class="btn btn-success not-registered-only" href="{% url 'register_public_key' %}">{% trans "Register device" %}</a>
+                                        {% endif %}
+
                                         {% if clock_set %}
                                         /
                                         <a onclick="$('#clock_set').show()">set clock</a>


### PR DESCRIPTION
Hi @aronasorman this is an initial fix for #2192.

Fixed:
1. Register button which still shows after user has registered.

I removed the `class=registered-only` attribute of the **Sync Now!** button.

I used the context variable `device.is_registered` to know if the device is already registered. 

Todos:
1. Replicate the registration process that is not marking status correctly.
