### PR TITLE
Coach can view only groups belonging to that facility in playlist assigned

### DIFF
--- a/kalite/playlist/static/js/playlist/assign_playlists.js
+++ b/kalite/playlist/static/js/playlist/assign_playlists.js
@@ -107,7 +107,7 @@ var PlaylistGroupView = Backbone.View.extend({
     render: function() {
         var dict = this.model.toJSON();
         if (groups.findWhere({id: dict.id}) != null) {
-        this.$el.html(this.template(dict));
+            this.$el.html(this.template(dict));
         }
 
         return this;


### PR DESCRIPTION
so neither they can remove any group  that doesn't belong to his/her facility , from a playlist.
