### PR TITLE
Allow unit to be changed even when original value was outside range.

### DIFF
--- a/kalite/student_testing/api_resources.py
+++ b/kalite/student_testing/api_resources.py
@@ -205,7 +205,7 @@ class CurrentUnit():
 
     def _get_current_unit(self):
         # get active unit for the Facility from Settings
-        current_unit = 1
+        current_unit = 101
         if self.facility_id:
             current_unit = get_current_unit_settings_value(self.facility_id)
         return current_unit

--- a/kalite/student_testing/static/js/student_testing/current_unit.js
+++ b/kalite/student_testing/static/js/student_testing/current_unit.js
@@ -38,16 +38,28 @@ window.CurrentUnitRowView = Backbone.View.extend({
 
     increment_current_unit: function(amount) {
         var new_unit = this.model.get("current_unit") + amount;
-        if ((new_unit >= this.model.get("min_unit")) && (new_unit <= this.model.get("max_unit"))) {
-            this.set_unit(new_unit);
+        // constrain to the lower bound
+        if (new_unit < this.model.get("min_unit")) {
+            new_unit = this.model.get("min_unit");
         }
+        // constrain to the upper bound
+        if (new_unit > this.model.get("max_unit")) {
+            new_unit = this.model.get("max_unit");
+        }
+        this.set_unit(new_unit);
     },
 
     set_unit: function(unit) {
+        if (unit == this.model.get("current_unit")) {
+            // nothing to do
+            return;
+        }
+        // double-check with the user
         var check = confirm(gettext("Before changing units, make sure all students have finished purchasing items in the store, etc. Are you sure you want to change the current unit?"));
         if (!check) {
             return;
         }
+        // change and save
         this.model.set("current_unit", unit);
         this.model.save();
     }


### PR DESCRIPTION
When trying to set the unit, it will now jump to the nearest boundary value and thereby come into range. Previously, if a facility was on unit 1, which now doesn't exist, it was impossible to get it into range via the UI. 
