### PR TITLE
Fix for issue #2358 gracefully handle exercise interactions for admin users

### DIFF
--- a/kalite/main/api_resources.py
+++ b/kalite/main/api_resources.py
@@ -28,10 +28,8 @@ class ExerciseLogResource(ModelResource):
     def obj_create(self, bundle, **kwargs):
         is_admin = getattr(bundle.request, "is_admin", False)
         user = getattr(bundle.request, "user", None)
-        print '==> ExerciseLogResource.obj_create --> is_admin ==', is_admin
         if is_admin:
             if user and getattr(user, 'is_superuser', False):
-                print '==> ExerciseLogResource.obj_create --> super user'
                 return None
         return super(ExerciseLogResource, self).obj_create(bundle, **kwargs)
 
@@ -53,10 +51,8 @@ class AttemptLogResource(ModelResource):
     def obj_create(self, bundle, **kwargs):
         is_admin = getattr(bundle.request, "is_admin", False)
         user = getattr(bundle.request, "user", None)
-        print '==> AttemptLogResource.obj_create --> is_admin ==', is_admin
         if is_admin:
             if user and getattr(user, 'is_superuser', False):
-                print '==> AttemptLogResource.obj_create --> super user'
                 return None
         return super(AttemptLogResource, self).obj_create(bundle, **kwargs)
 


### PR DESCRIPTION
Fix for issue #2358.

Admin users can take exercise without raising an error.
Use the method `obj_create` in `ExerciseLogResource` and `AttemptLogResource` classes at `main/api_resources.py` 

Refactored method signature of classes at `main/api_resources.py` to follow the method signature of its base tastypie classes  like `Resource` and `ModelResource`.
