### PR TITLE
Fixed z-index of search results dropdown #2626

### DIFF
--- a/kalite/distributed/static/css/distributed/search_autocomplete.css
+++ b/kalite/distributed/static/css/distributed/search_autocomplete.css
@@ -2,12 +2,12 @@
     cursor: pointer;
     display: block;
 }
-
 ul.ui-autocomplete  {
     padding-left: 0;
     padding-right: 0;
     padding-top: 1px;
     padding-bottom: 1px;
+    z-index: 1500;
 }
 .ui-state-hover,
 .ui-widget-content .ui-state-hover,
@@ -20,12 +20,12 @@ ul.ui-autocomplete  {
     border-radius: 0;
     color: white;
 }
-
 a.ui-corner-all.ui-state-focus span.autocomplete.icon-topic.available,
-a.ui-corner-all.ui-state-focus span.autocomplete.icon-exercise.available {
+a.ui-corner-all.ui-state-focus span.autocomplete.icon-exercise.available,
+a.ui-corner-all.ui-state-focus span.autocomplete.icon-video.available,
+a.ui-corner-all.ui-state-focus span.autocomplete.icon-document.available {
     color: white;
 }
-
 .ui-menu .ui-menu-item a{
     outline: 0;
     padding-top: 6px;
@@ -37,7 +37,6 @@ a.ui-corner-all.ui-state-focus span.autocomplete.icon-exercise.available {
     font-size: 1em;
     padding-right: 0;
 }
-
 .available {
     color: black;
 }


### PR DESCRIPTION
Fixed the z-index of search results dropdown menu #2626.
Also fixed the inconsistent hover-state over the search results so that the text is white for all results.
![search dropdown menu](https://cloud.githubusercontent.com/assets/2066060/4946803/6764c018-6619-11e4-9879-df1b5b01395c.png)
