### PR TITLE
Search Autocomplete navigation fixes

### DIFF
--- a/kalite/distributed/static/js/distributed/search_autocomplete.js
+++ b/kalite/distributed/static/js/distributed/search_autocomplete.js
@@ -118,6 +118,8 @@ $(document).ready(function() {
             } else {
                 show_message("error", gettext("Unexpected error: no search data found for selected item. Please select another item."));
             }
+            $("#search-box input").val("");
+            return false;
         }
 
     });


### PR DESCRIPTION
Fixes #2629, resolves #2638.

Summary of changes:
- If channel_router exists, delegate navigation to it.
- On selecting an item in the list, prevent autocomplete-ui from autocompleting.
