### PR TITLE
Whitelist /api/ and /data/ requests for LOCKDOWN mode.

### DIFF
--- a/kalite/distributed/middleware.py
+++ b/kalite/distributed/middleware.py
@@ -11,6 +11,8 @@ class LockdownCheck:
         if (settings.LOCKDOWN
             and not request.is_logged_in
             and request.path not in [reverse("login"), reverse("facility_user_signup"), reverse("dynamic_js"), reverse("dynamic_css")]
+            and not request.path.startswith("/api/")
+            and not request.path.startswith(settings.CONTENT_DATA_URL)
             and not request.path.startswith(settings.STATIC_URL)):
 
             raise PermissionDenied()


### PR DESCRIPTION
The /api/ exception is needed for /api/status, so it properly renders the top nav items.

The /data/ exception is needed to render channel resources like the logo.
