### PR TITLE
Hotfix/2332-Title still says "practicing" when you are in a test.

### DIFF
--- a/kalite/distributed/hbtemplates/exercise/exercise.handlebars
+++ b/kalite/distributed/hbtemplates/exercise/exercise.handlebars
@@ -1,5 +1,6 @@
 <h2>
-    <span class="exercise-title-prefix">{{_ "Practicing" }}</span> <span class="exercise-title">{{ title }}</span>
+    <span class="exercise-title-prefix">{{#if test_id }}{{_ "Test" }}{{ else }}{{_ "Practicing" }}{{/if }}</span>
+    <span class="exercise-title">{{ title }}</span>
     {{#if description }}<br/><span class="practice-exercise-description">{{ description }}</span>{{/if }}
 </h2>
 

--- a/kalite/distributed/static/js/distributed/exercises.js
+++ b/kalite/distributed/static/js/distributed/exercises.js
@@ -737,7 +737,10 @@ window.ExerciseView = Backbone.View.extend({
 
     render: function() {
 
-        this.$el.html(this.template(this.data_model.attributes));
+        var data  = $.extend(this.data_model.attributes, {test_id: this.options.test_id});
+
+        this.$el.html(this.template(data));
+        var html = this.template(this.data_model.attributes);
 
         this.initialize_listeners();
 
@@ -1245,6 +1248,7 @@ window.ExerciseTestView = Backbone.View.extend({
                 var question_data = this.log_model.get_item_data(this.test_model);
 
                 var data = $.extend({el: this.el}, question_data);
+                data = $.extend(data, {test_id: this.options.test_id});
 
                 this.initialize_new_attempt_log(question_data);
 


### PR DESCRIPTION
Hi @aronasorman!

We already fixed the issue #2332 **Title still says "practicing" when you are in a test.**
We use **Title** `Test` when the student is taking a test and `Practice` otherwise.

Screenshots are attached below:

Practising: 
![alt text](https://raw.githubusercontent.com/djallado/Files/master/practice.png)

Taking A Test: 
![alt text](https://raw.githubusercontent.com/djallado/Files/master/test.png)
