### PR TITLE
Hotfix/#2288 awesome keypad repeats last character if you hit return

### DIFF
--- a/kalite/distributed/static/js/distributed/software-keyboard.js
+++ b/kalite/distributed/static/js/distributed/software-keyboard.js
@@ -65,8 +65,10 @@ window.SoftwareKeyboardView = Backbone.View.extend({
                 this.field.val(this.field.val() + key);
             }
         }
-
         this.field.trigger("keypress");
+
+        // on key pressed change the focus to check answer button.
+        this.$el.parent("#answercontent.info-box").find("#check-answer-button").focus();
 
         return false;
     },


### PR DESCRIPTION
Hi @aronasorman 

Fixed issue #2288 awesome keypad repeats last character if you hit return.

Create `jquery` statement on **keypad button** `click event` to change the focus to **check answer** button.
