### PR TITLE
Fix to remove partially watched videos from result of queryset.

### DIFF
--- a/kalite/control_panel/views.py
+++ b/kalite/control_panel/views.py
@@ -388,6 +388,7 @@ def _get_user_usage_data(users, groups=None, period_start=None, period_end=None,
     login_logs = login_logs.filter(total_seconds__gt=0)
     if period_start:
         exercise_logs = exercise_logs.filter(completion_timestamp__gte=period_start)
+        video_logs = video_logs.filter(completion_timestamp__gte=period_start)
     if period_end:
         # MUST: Fix the midnight bug where period end covers up to the prior day only because
         # period end is datetime(year, month, day, hour=0, minute=0), meaning midnight of previous day.
@@ -397,18 +398,18 @@ def _get_user_usage_data(users, groups=None, period_start=None, period_end=None,
         period_end = dateutil.parser.parse(period_end)
         period_end = period_end + dateutil.relativedelta.relativedelta(days=+1, microseconds=-1)
         exercise_logs = exercise_logs.filter(completion_timestamp__lte=period_end)
+        video_logs = video_logs.filter(completion_timestamp__lte=period_end)
     if period_start and period_end:
         exercise_logs = exercise_logs.filter(Q(completion_timestamp__gte=period_start) &
                                              Q(completion_timestamp__lte=period_end))
 
         q1 = Q(completion_timestamp__isnull=False) & \
-             Q(completion_timestamp__gte=period_start) & \
-             Q(completion_timestamp__lte=period_end)
-        q2 = Q(completion_timestamp__isnull=True)
-        video_logs = video_logs.filter(q1 | q2)
+            Q(completion_timestamp__gte=period_start) & \
+            Q(completion_timestamp__lte=period_end)
+        video_logs = video_logs.filter(q1)
 
         login_q1 = Q(start_datetime__gte=period_start) & Q(start_datetime__lte=period_end) & \
-                   Q(end_datetime__gte=period_start) & Q(end_datetime__lte=period_end)
+            Q(end_datetime__gte=period_start) & Q(end_datetime__lte=period_end)
         login_logs = login_logs.filter(login_q1)
     # Force results in a single query
     exercise_logs = list(exercise_logs.values("exercise_id", "user__pk"))


### PR DESCRIPTION
Hi @aronasorman - this is for #2271 as referenced by comments at #2762 which was already merged.

target branch == **release-0.12.0**

I've restored the previous functionality which does NOT include partially watched videos in the queryset results for CSV export.

/cc: @mikewray
