### PR TITLE
Fix for #2787-Cannot watch video on develop branch.

### DIFF
--- a/kalite/main/api_resources.py
+++ b/kalite/main/api_resources.py
@@ -79,11 +79,19 @@ class Video:
 
         for k, v in kwargs.iteritems():
             setattr(self, k, v)
-        lang_code = kwargs.get('selected_language', lang_code)
+
+        if not lang_code:
+            lang_code = "en"
+        selected_language = kwargs.get('selected_language')
+        if not selected_language:
+            selected_language = lang_code
+        # TODO(cpauya): Get the reason why we have this `lang_code` argument or why do we
+        # have the `selected_language` argument also?!  Which one is which?
+        lang_code = selected_language
         # the computed values
         self.content_urls = kwargs.get('availability', {}).get(lang_code, {})
         self.subtitle_urls = kwargs.get('availability', {}).get(lang_code, {}).get('subtitles', {})
-        self.selected_language = kwargs.get('selected_language', lang_code)
+        self.selected_language = selected_language
         self.dubs_available = len(kwargs.get('availability', {})) > 1
         self.title = _(kwargs.get('title'))
         self.id = self.pk = self.video_id = kwargs.get('id')


### PR DESCRIPTION
Hi @aronasorman - this fixes #2787.

Branch **develop**

We made sure that the `lang_code` or `selected_language` variables have a value except `None`.

I have no idea where those variables are being used on the client-side but watching video on English or other language now works.

Just a note: I think we have introduced this bug while fixing #2717.
