### PR TITLE
#2798 - Removed cell-content class which was giving dot ellipsis

### DIFF
--- a/kalite/distributed/static/css/distributed/homepage.css
+++ b/kalite/distributed/static/css/distributed/homepage.css
@@ -88,7 +88,7 @@ a:visited.topic-unavailable {
 }
 
 .table {
-    width: 84%;
+    width: 100%;
 }
 
 .block {

--- a/kalite/playlist/hbtemplates/playlists/homepage-playlists-table-cell.handlebars
+++ b/kalite/playlist/hbtemplates/playlists/homepage-playlists-table-cell.handlebars
@@ -1,5 +1,5 @@
 <li class="playlist-list-item pull-left">
-  <span class="block cell-content">
+  <span class="block">
     <a href="{{ playlist_link }}">
       {{ title }}
     </a>


### PR DESCRIPTION
#2798

Removed cell-content class which was giving dot ellipsis in viewing the playlist on homepage and assigned playlist table width increased to 100%
