### PR TITLE
Fix to use backslash character when platform is windows.

### DIFF
--- a/python-packages/fle_utils/handlebars/loader.py
+++ b/python-packages/fle_utils/handlebars/loader.py
@@ -13,8 +13,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils._os import safe_join
 from django.utils.importlib import import_module
 
-from fle_utils.platforms import is_windows
-
 
 # At compile time, cache the directories to search.
 fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
@@ -58,13 +56,13 @@ def load_template_sources(module_name):
 
     templates = []
 
-    if is_windows():
-        slash_character = "\\"
-    else:
-        slash_character = "/"
-
     for filepath in get_template_module_paths(module_name):
-        template_name = filepath.split(slash_character)[-1].split(".handlebars")[0]
+        # REF: http://stackoverflow.com/a/14334768/845481
+        # How to split a dos path into its components in Python
+        # On Windows, we might encounter path like c:\python2.7/python.exe, so using `normpath`.
+        filepath = os.path.normpath(filepath)
+        # Use specific path separator for the OS.
+        template_name = filepath.split(os.sep)[-1].split(".handlebars")[0]
         try:
             with open(filepath) as f:
                 # load the template text

--- a/python-packages/fle_utils/handlebars/loader.py
+++ b/python-packages/fle_utils/handlebars/loader.py
@@ -13,6 +13,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils._os import safe_join
 from django.utils.importlib import import_module
 
+from fle_utils.platforms import is_windows
+
+
 # At compile time, cache the directories to search.
 fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
 app_hbtemplates_dirs = []
@@ -27,6 +30,7 @@ for app in settings.INSTALLED_APPS:
 
 # It won't change, so convert it to a tuple to save memory.
 app_hbtemplates_dirs = tuple(app_hbtemplates_dirs)
+
 
 def get_template_module_paths(module_name):
     """
@@ -49,12 +53,18 @@ def get_template_module_paths(module_name):
 
     return paths
 
+
 def load_template_sources(module_name):
 
     templates = []
 
+    if is_windows():
+        slash_character = "\\"
+    else:
+        slash_character = "/"
+
     for filepath in get_template_module_paths(module_name):
-        template_name = filepath.split("/")[-1].split(".handlebars")[0]
+        template_name = filepath.split(slash_character)[-1].split(".handlebars")[0]
         try:
             with open(filepath) as f:
                 # load the template text


### PR DESCRIPTION
Hi @aronasorman - this fix is for #2843.

I have re-used the `fle_utils.platforms.is_windows()` function and did some minor PEP-8 fixes.