### PR TITLE
Made 'show scratchpad' more prominent in exercises

### DIFF
--- a/kalite/distributed/hbtemplates/exercise/exercise.handlebars
+++ b/kalite/distributed/hbtemplates/exercise/exercise.handlebars
@@ -9,12 +9,6 @@
     <div class="exercises-body col-sm-12">
         <div class="exercises-card current-card">
             <div class="current-card-container card-type-problem">
-                <br/>
-                <div>
-                    <button class="simple-button" id="scratchpad-show" href style>{{_ "Show scratchpad" }}</button>
-                    <span id="scratchpad-not-available" style="display: none;">{{_ "Scratchpad not available" }}</span>
-                </div>
-                <br/>
                 <div class="current-card-container-inner vertical-shadow">
                     <div class="current-card-contents">
                         <div id="problem-and-answer">
@@ -53,6 +47,10 @@
                     </div>
                 </div>
             </div>
+        </div>
+        <div id="scratchpad-btn-container">
+            <button class="simple-button primary" id="scratchpad-show" href style>{{_ "Show scratchpad" }}</button>
+            <span class="simple-button disabled" id="scratchpad-not-available" style="display: none;">{{_ "Scratchpad not available" }}</span>
         </div>
     </div>
 </div>

--- a/kalite/distributed/hbtemplates/exercise/exercise.handlebars
+++ b/kalite/distributed/hbtemplates/exercise/exercise.handlebars
@@ -9,6 +9,12 @@
     <div class="exercises-body col-sm-12">
         <div class="exercises-card current-card">
             <div class="current-card-container card-type-problem">
+                <br/>
+                <div>
+                    <button class="simple-button" id="scratchpad-show" href style>{{_ "Show scratchpad" }}</button>
+                    <span id="scratchpad-not-available" style="display: none;">{{_ "Scratchpad not available" }}</span>
+                </div>
+                <br/>
                 <div class="current-card-container-inner vertical-shadow">
                     <div class="current-card-contents">
                         <div id="problem-and-answer">
@@ -46,14 +52,6 @@
                         <div class="clear"></div>
                     </div>
                 </div>
-            </div>
-            <div>
-                <ul>
-                    <li>
-                        <a id="scratchpad-show" href style>{{_ "Show scratchpad" }}</a>
-                        <span id="scratchpad-not-available" style="display: none;">{{_ "Scratchpad not available" }}</span>
-                    </li>
-                </ul>
             </div>
         </div>
     </div>

--- a/kalite/distributed/static/css/distributed/khan-site.css
+++ b/kalite/distributed/static/css/distributed/khan-site.css
@@ -543,3 +543,6 @@ a.big-button:active > div {
     width: 753px;
 }
 
+#scratchpad-btn-container {
+    margin-top: 10px;
+}


### PR DESCRIPTION
This targets part of issue #2312. The "show scratchpad" button is hard to find. Since the exercises widget is not loading correctly in the develop branch, I was not able to find a better spot to put the button inside the exercises widget. So I put it at the top, and it looks fine to me.

This is what my version looks like:

![screen shot 2015-01-14 at 3 38 41 pm](https://cloud.githubusercontent.com/assets/6601788/5750017/9554b288-9c03-11e4-98c0-5afe21199708.png)

Here's the before:

![screen shot 2015-01-14 at 3 41 58 pm](https://cloud.githubusercontent.com/assets/6601788/5750049/efac3738-9c03-11e4-8e5f-f90c806c50ec.png)
