### PR TITLE
Prevents videoscan.py from invalidating cache

### DIFF
--- a/kalite/updates/management/commands/videoscan.py
+++ b/kalite/updates/management/commands/videoscan.py
@@ -100,6 +100,3 @@ class Command(CronCommand):
                 self.stdout.write("Deleted %d VideoFile models (because the videos didn't exist in the filesystem)\n" % len(deleted_video_ids))
             return deleted_video_ids
         touched_video_ids += delete_objects_for_missing_videos(youtube_ids_in_filesystem, videos_marked_at_all)
-
-        if len(touched_video_ids):
-            caching.initialize_content_caches()


### PR DESCRIPTION
Fixes #2873 

Videoscan does not actually touch any files, so will not change the status of the cache anyway. It only modifies VideoObjects in the repo.

What this does mean, however, is that our availability stamping might show partially downloaded videos(?)