### PR TITLE
Fixed issue #2888: 'Show keypad' button floating around

### DIFF
--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -850,10 +850,6 @@ a.disabled {
     font-size: 26px;
 }
 
-#software-keyboard div .key-bs {
-    font-size: 16px;
-}
-
 /* TODO-BLOCKER (rtibbles): 0.13 - Remove extraneous css added here to make styling work without Bootstrap */
 
 #software-keyboard-container {

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -3,7 +3,16 @@
 .simple-button.green,
 .simple-button.primary {
     background-color: #5AA685 !important;
-    background-image: none !important;
+    background-image: -moz-linear-gradient(top, #5AA685, #47856A);
+    background-image: -ms-linear-gradient(top, #5AA685, #47856A);
+    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#5AA685), to(#47856A));
+    background-image: -webkit-linear-gradient(top, #5AA685, #47856A);
+    background-image: -o-linear-gradient(top, #5AA685, #47856A);
+    background-image: linear-gradient(top, #5AA685, #47856A);
+    background-repeat: repeat-x;
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#5AA685', endColorstr='#47856A', GradientType=0);
+    filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+    color: #ffffff !important;
     border-color: rgba(0, 0, 0, 0.6) !important;
 }
 
@@ -816,12 +825,6 @@ a.disabled {
     border-bottom-right-radius: 6px;
 }
 
-#show-keyboard {
-    font-size: 10px;
-    width: 90px;
-    float: right;
-}
-
 #software-keyboard {
     border: 2px solid #cfcfcf;
     background: #c3c3c3;
@@ -853,18 +856,25 @@ a.disabled {
 
 /* TODO-BLOCKER (rtibbles): 0.13 - Remove extraneous css added here to make styling work without Bootstrap */
 
-#show-keyboard {
-    font-size: 10px;
-    width: 90px;
-    float: right;
+#software-keyboard-container {
+    width: 100%;
+    position: relative;
+    display: inline-block;
+}
+
+button#show-keyboard {
+    /*height: 30px;*/
+    width: 100%;
+    font-size: 14px;
+    padding: 0;
+    /*float: right;
     -webkit-border-radius: 5px;
     -moz-border-radius: 5px;
     border-radius: 5px;
     background-color: #816fba;
     font-family: Arial, Helvetica, sans-serif;
     color: #ffffff;
-    padding: 5px 20px;
-    border:0px;
+    border: 0px;*/
 }
 
 div .row {

--- a/kalite/distributed/static/js/distributed/exercises/models.js
+++ b/kalite/distributed/static/js/distributed/exercises/models.js
@@ -218,17 +218,14 @@ window.AttemptLogCollection = Backbone.Collection.extend({
     model: AttemptLogModel,
 
     initialize: function(models, options) {
-        this.exercise_id = options.exercise_id;
-        this.context_type = options.context_type;
+        this.filters = $.extend({
+            "user": window.statusModel.get("user_id"),
+            "limit": ExerciseParams.STREAK_WINDOW
+        }, options);
     },
 
     url: function() {
-        return "/api/attemptlog/?" + $.param({
-            "exercise_id": this.exercise_id,
-            "user": window.statusModel.get("user_id"),
-            "limit": ExerciseParams.STREAK_WINDOW,
-            "context_type": this.context_type
-        });
+        return "/api/attemptlog/?" + $.param(this.filters, true);
     },
 
     add_new: function(attemptlog) {

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -121,7 +121,9 @@ window.ExerciseView = Backbone.View.extend({
 
     render: function() {
 
-        this.$el.html(this.template(this.data_model.attributes));
+        var data = $.extend(this.data_model.attributes, {test_id: this.options.test_id});
+
+        this.$el.html(this.template(data));
 
         this.initialize_listeners();
 
@@ -392,7 +394,7 @@ window.ExercisePracticeView = Backbone.View.extend({
                 var log_collection_deferred = self.log_collection.fetch();
 
                 // load the last 10 (or however many) specific attempts the user made on self exercise
-                self.attempt_collection = new AttemptLogCollection([], {exercise_id: self.options.exercise_id, context_type: self.options.context_type});
+                self.attempt_collection = new AttemptLogCollection([], {exercise_id: self.options.exercise_id, context_type__in: ["playlist", "exercise"]});
                 var attempt_collection_deferred = self.attempt_collection.fetch();
 
                 // wait until both the exercise and attempt logs have been loaded before continuing
@@ -730,6 +732,7 @@ window.ExerciseTestView = Backbone.View.extend({
                 var question_data = this.log_model.get_item_data(this.test_model);
 
                 var data = $.extend({el: this.el}, question_data);
+                data = $.extend(data, {test_id: this.options.test_id});
 
                 this.initialize_new_attempt_log(question_data);
 

--- a/kalite/distributed/static/js/distributed/software-keyboard.js
+++ b/kalite/distributed/static/js/distributed/software-keyboard.js
@@ -96,8 +96,7 @@ window.SoftwareKeyboardView = Backbone.View.extend({
                 .appendTo(self.software_keyboard);
 
             jQuery.each(row, function(j, key) {
-                var keySpan = $("<div class='.col-xs-4'><button class='key simple-button " + (key === "bs" ? "key-bs" : "") + "' value='" + key + "'>" + (key === "bs" ? "Del" : key) + "</button></div>").appendTo(rowDiv);
-
+                var keySpan = $("<div class='.col-xs-4'><button class='key simple-button' value='" + key + "'>" + (key === "bs" ? "Del" : key) + "</button></div>").appendTo(rowDiv);
             });
         });
 

--- a/kalite/distributed/static/js/distributed/software-keyboard.js
+++ b/kalite/distributed/static/js/distributed/software-keyboard.js
@@ -74,7 +74,7 @@ window.SoftwareKeyboardView = Backbone.View.extend({
 
         // TODO-BLOCKER (rtibbles): 0.13 - Turn this into a handlebars template, conditionally render templates based on exercise types.
 
-        this.$el.append("<button id='show-keyboard'>" + gettext("Hide Keypad") + "</button>");
+        this.$el.append("<button class='simple-button orange' id='show-keyboard'>" + gettext("Hide Keypad") + "</button>");
 
         this.$el.append("<div class='container-fluid' id='software-keyboard'></div>");
 
@@ -96,7 +96,7 @@ window.SoftwareKeyboardView = Backbone.View.extend({
                 .appendTo(self.software_keyboard);
 
             jQuery.each(row, function(j, key) {
-                var keySpan = $("<div class='.col-xs-4'><button class='key green_button " + (key === "bs" ? "key-bs" : "") + "' value='" + key + "'>" + (key === "bs" ? "Del" : key) + "</button></div>").appendTo(rowDiv);
+                var keySpan = $("<div class='.col-xs-4'><button class='key simple-button " + (key === "bs" ? "key-bs" : "") + "' value='" + key + "'>" + (key === "bs" ? "Del" : key) + "</button></div>").appendTo(rowDiv);
 
             });
         });


### PR DESCRIPTION
This should fix issue #2888. The 'show keypad' button now sits where it should and matches the hint and scratchpad buttons. Software keyboard has been tweaked slightly. The buttons are now `simple-button`s instead of the weird `green_button` class (which had no CSS styling anywhere LOL).

![screen shot 2015-01-26 at 11 48 43 pm](https://cloud.githubusercontent.com/assets/6601788/5915207/a9e4e868-a5b7-11e4-89ad-f59a1f164778.png)

Things are now pixel-perfect!

I have also improved the coloring on the main green buttons that I edited with the recent overhaul. They match the orange buttons better.

> I had some trouble with my local clone and had to fiddle around a bit. Ignore the "changes" to `models.js` and `views.js`. Unless I'm missing something, the changes it shows for both those files match the current versions of those files in the develop branch. Nothing should change. Sorry if it causes any trouble.