### PR TITLE
Fix redirect loop issue in one case

### DIFF
--- a/python-packages/securesync/__init__.py
+++ b/python-packages/securesync/__init__.py
@@ -13,3 +13,13 @@ except:
 
 from .devices.__init__ import *
 from .engine.__init__ import *
+
+# JsonResponseMessageError codes
+class ERROR_CODES:
+    CLIENT_DEVICE_CORRUPTED = "client_device_corrupted"
+    CLIENT_DEVICE_NOT_DEVICE = "client_device_not_device"
+    CLIENT_DEVICE_INVALID_SIGNATURE = "client_device_invalid_signature"
+    CHAIN_OF_TRUST_INVALID = "chain_of_trust_invalid"
+    DEVICE_ALREADY_REGISTERED = "device_already_registered"
+    PUBLIC_KEY_UNREGISTERED = "public_key_unregistered"
+


### PR DESCRIPTION
Minimum to reproduce seems to be:
An entry in `securesync_device` but not `securesync_devicezone` corresponding to the client_device (on the central server)
No `securesync_zone` or `securesync_devicezone` in the client database
But so what? If the registration object exists, then we'll just get the zone there and create a new DeviceZone.
There's another redirect loop possible, see comment in api_view.py, however I've been assured
it shouldn't be reachable without some serious database deletions. Disregarding for now to avoid further time sink.