### PR TITLE
Replace user-facing uses of teacher/student with coach/learner

### DIFF
--- a/kalite/coachreports/static/js/coachreports/base_d3_visualization.js
+++ b/kalite/coachreports/static/js/coachreports/base_d3_visualization.js
@@ -41,7 +41,7 @@ function plotJsonData(chart_div, base_url, props) {
             if (json["objects"].length > 0) {
                 drawJsonChart(chart_div, json, props["xaxis"], props["yaxis"]);
             } else {
-                show_message("error", gettext("No student accounts in this group have been created."));
+                show_message("error", gettext("No learner accounts in this group have been created."));
             }
             $("#loading").text("");
 

--- a/kalite/coachreports/templates/coachreports/landing_page.html
+++ b/kalite/coachreports/templates/coachreports/landing_page.html
@@ -52,7 +52,7 @@
                 <div class="vertical-shadow suggested-action">
                 <a class="changeable-link" href="{% url 'spending_report_view' %}">
                 <div class="suggested-action-image-link" style="background-image: url({% static 'images/coachreports/coach-report-store-spending.png' %});"></div>
-                <h2 class="suggested-action-title">{% trans "Student Spending" %}</h2>
+                <h2 class="suggested-action-title">{% trans "Learner Spending" %}</h2>
                 </a>
                 </div>
                 </div> -->

--- a/kalite/coachreports/templates/coachreports/spending_report_view.html
+++ b/kalite/coachreports/templates/coachreports/spending_report_view.html
@@ -5,7 +5,7 @@
 {% load my_filters %}
 
 {% block coachreports_active %}active{% endblock coachreports_active %}
-{% block title %}{% trans "Student spending report" %} {{ block.super }}{% endblock title %}
+{% block title %}{% trans "Learner spending report" %} {{ block.super }}{% endblock title %}
 
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/coachreports/tabular_view.css' %}" />
@@ -44,14 +44,14 @@
         </div>
         {% if not user_points %}
             <p>
-                {% trans "There are no students at this facility." %}
+                {% trans "There are no learners at this facility." %}
             </p>
         {% else %}
             <table>
                 <thead>
                     <tr>
                         <th>
-                            {% trans "Student" %}
+                            {% trans "Learner" %}
                         </th>
                         <th>
                             {% trans "Points Remaining" %}

--- a/kalite/coachreports/templates/coachreports/tabular_view.html
+++ b/kalite/coachreports/templates/coachreports/tabular_view.html
@@ -95,7 +95,7 @@
         </div>
         <div class="selection pull-left">
         {% if users and request_report_type == "student" %}
-            <div class="subtitle">{% trans "Select Student" %}</div>
+            <div class="subtitle">{% trans "Select Learner" %}</div>
             <select id="student">
                 <option {% if not request.GET.user %}selected{% endif %}>----</option>
                 {% for user in users %}
@@ -145,7 +145,7 @@
                 <div class="subtitle error" id="error_message">
                     {% if not groups.0.groups and not groups.1 and request.GET.topic %}
                         {% comment %}No groups available: then "ungrouped" is selected, and "no students" returned.{% endcomment %}
-                        {% trans "No student accounts have been created." %}
+                        {% trans "No learner accounts have been created." %}
                     {% elif request.GET.topic and request.GET.playlist %}
                         {% trans "Please select either a topic or a playlist above, but not both." %}
                     {% elif not request.GET.topic and not request.GET.playlist %}
@@ -159,7 +159,7 @@
                         {% endif %}
                     {% else %}
                         {% comment %}Everything specified, but no users fit the query.{% endcomment %}
-                        {% trans "No student accounts in this group have been created." %}
+                        {% trans "No learner accounts in this group have been created." %}
                     {% endif %}
                 </div>
             </p>
@@ -171,7 +171,7 @@
                         <tbody>
                             <tr>
                                 <th class="headrowuser">
-                                    {% trans "Student" %}
+                                    {% trans "Learner" %}
                                 </th>
                             </tr>
                             {% for student in students %}

--- a/kalite/coachreports/templates/coachreports/test_detail_view.html
+++ b/kalite/coachreports/templates/coachreports/test_detail_view.html
@@ -72,14 +72,14 @@
         <p><div class="subtitle error" id="error_message">
         {% if not groups.0.groups and not groups.1 and request.GET.topic %}
             {% comment %}No groups available: then "ungrouped" is selected, and "no students" returned.{% endcomment %}
-            {% trans "No student accounts have been created." %}
+            {% trans "No learner accounts have been created." %}
         {% elif not results_table %}
             {% comment %}Group was selected, but data not queried because a topic was not selected
             (NOTE: this required knowledge of how the view queries data){% endcomment %}
             {% trans "No exam results for this group." %}
         {% else %}
             {% comment %}Everything specified, but no users fit the query.{% endcomment %}
-            {% trans "No student accounts in this group have been created." %}
+            {% trans "No learner accounts in this group have been created." %}
         {% endif %}
         </div></p>
 
@@ -91,7 +91,7 @@
             <thead>
                 <tr>
                     <th class="student-header">
-                        {% trans "Student" %}
+                        {% trans "Learner" %}
                     </th>
                 </tr>
             </thead>

--- a/kalite/coachreports/templates/coachreports/test_view.html
+++ b/kalite/coachreports/templates/coachreports/test_view.html
@@ -45,7 +45,7 @@
     {% if not results_table.keys or not test_columns %}
         <p><div class="subtitle error" id="error_message">
         {% if not results_table.keys %}
-            {% trans "No student accounts have been created." %}
+            {% trans "No learner accounts have been created." %}
         {% else %}
             {% trans "No exam results for this group." %}
         {% endif %}
@@ -59,7 +59,7 @@
             <thead>
                 <tr>
                     <th class="student-header">
-                        {% trans "Student" %}
+                        {% trans "Learner" %}
                     </th>
                 </tr>
             </thead>

--- a/kalite/control_panel/static/js/control_panel/facility_management.js
+++ b/kalite/control_panel/static/js/control_panel/facility_management.js
@@ -121,7 +121,7 @@ $(function() {
 
         if (groups.length === 0) {
             alert(gettext("Please select groups first."));
-        } else if (!confirm(gettext("You are about to permanently delete the selected group(s). Note that any students currently in this group will now be characterized as 'Ungrouped' but their profiles will not be deleted."))) {
+        } else if (!confirm(gettext("You are about to permanently delete the selected group(s). Note that any learners currently in this group will now be characterized as 'Ungrouped' but their profiles will not be deleted."))) {
             return;
         } else {
             doRequest(DELETE_GROUPS_URL, {groups: groups})

--- a/kalite/control_panel/static/js/control_panel/zone_management.js
+++ b/kalite/control_panel/static/js/control_panel/zone_management.js
@@ -6,7 +6,7 @@ $(function () {
 
     $(".facility-delete-link").click(function(event) {
         var facilityName = $.trim($(this).parent().prevAll().find('a.facility-name').text());
-        var confirmDelete = prompt(sprintf(gettext("Are you sure you want to delete '%s'? You will lose all associated student, group, and teacher accounts. If you are sure, type the name of the facility into the box below and press OK."), facilityName));
+        var confirmDelete = prompt(sprintf(gettext("Are you sure you want to delete '%s'? You will lose all associated learner, group, and coach accounts. If you are sure, type the name of the facility into the box below and press OK."), facilityName));
         
         if (confirmDelete === null) {
             return false; // cancel

--- a/kalite/control_panel/templates/control_panel/facility_management.html
+++ b/kalite/control_panel/templates/control_panel/facility_management.html
@@ -77,14 +77,14 @@
 
 {% block buttons %}{{ block.super }}
     <li>
-        <button class="btn btn-success" data-toggle="modal" data-target="export_csv_div_id" id="top_export_button_id" value="{% trans 'Export student stats' %}">{% trans 'Export student stats' %}</button>
+        <button class="btn btn-success" data-toggle="modal" data-target="export_csv_div_id" id="top_export_button_id" value="{% trans 'Export learner stats' %}">{% trans 'Export learner stats' %}</button>
     </li>
     <div id="export_csv_div_id" class="modal fade">
         <div class="modal-dialog">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
-                    <h4 class="modal-title">{% trans "Export student stats" %}</h4>
+                    <h4 class="modal-title">{% trans "Export learner stats" %}</h4>
                 </div>
                 <div class="modal-body">
                     <form class="form" method="post" action="?format=csv" id="date_picker_form">

--- a/kalite/control_panel/templates/control_panel/partials/_coaches_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_coaches_table.html
@@ -9,7 +9,7 @@
             <div class="col-md-12">
                 <h2>{% trans "Coaches" %} 
                 <small>
-                    <span class="help-tooltip glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="right" title='{% trans "Coaches assist students to learn, and can be teachers, parents, or fellow students." %}'></span>
+                    <span class="help-tooltip glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="right" title='{% trans "Coaches assist learners to learn, and can be teachers, parents, or fellow students." %}'></span>
                 </small>
             </div>
         </div>

--- a/kalite/control_panel/templates/control_panel/partials/_facility_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_facility_table.html
@@ -6,7 +6,7 @@
         <h2>
             {% trans "Facilities" %}
             <small>
-                <span class="help-tooltip glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="right" title='{% trans "A facility is a physical location where students learn." %}'></span>
+                <span class="help-tooltip glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="right" title='{% trans "A facility is a physical location where learners learn." %}'></span>
             </small>
         </h2>
         {% if not facilities %}

--- a/kalite/control_panel/templates/control_panel/partials/_group_summary.html
+++ b/kalite/control_panel/templates/control_panel/partials/_group_summary.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 
 <dl class="dl-horizontal">
-<dt>{% trans "# Students" %}</dt>
+<dt>{% trans "# Learners" %}</dt>
 <dd>{{ group_data.total_users }}</dd>
 <dt>{% trans "Logins" %}</dt>
 <dd>{{ group_data.total_logins }}</dd>

--- a/kalite/control_panel/templates/control_panel/partials/_groups_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_groups_table.html
@@ -12,9 +12,9 @@
 
         {% else %}
             <h2>
-                {% trans "Student Groups" %}
+                {% trans "Learner Groups" %}
                 <small>
-                    <span class="help-tooltip glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="right" title="{% blocktrans %}A 'group' is set of students, such as a classroom of students or all students in one grade.{% endblocktrans %} {% trans 'Add students by selecting a group.' %}"></span>
+                    <span class="help-tooltip glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="right" title="{% blocktrans %}A 'group' is set of learners, such as a classroom of students or all students in one grade.{% endblocktrans %} {% trans 'Add learners by selecting a group.' %}"></span>
                 </small>
             </h2>
             {% if not groups %}
@@ -36,7 +36,7 @@
                                 <th>{% trans "Group" %}</th>
                                 <th>{% trans "Edit" %}</th>
                                 <th>{% trans "Coach" %}</th>
-                                <th>{% trans "# Students" %}</th>
+                                <th>{% trans "# Learners" %}</th>
                                 <th>{% trans "Logins" %}</th>
                                 <th>{% trans "Login Time" %}</th>
                                 <th>{% trans "Videos Viewed" %}</th>

--- a/kalite/control_panel/templates/control_panel/partials/_students_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_students_table.html
@@ -7,21 +7,21 @@
 <div class="row" id="students">
     <div class="col-md-12">
         <h2>
-            {% trans "Students" %}
+            {% trans "Learners" %}
             <small>
-                <span class="help-tooltip glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="right" title='{% trans "This report contains information about recent student activity." %}'></span>
+                <span class="help-tooltip glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="right" title='{% trans "This report contains information about recent learner activity." %}'></span>
             </small>
         </h2>
     </div>
     <div class="col-md-12">
         {% if not student_pages %}
-            <p class="no-data">{% trans "You currently have no student data available." %}</p>
+            <p class="no-data">{% trans "You currently have no learner data available." %}</p>
         {% else %}
             <p>
                 <div class="form-inline">
                 {% if groups %}
                     <div class="form-group">
-                        <button class="movegroup btn btn-success" disabled="disabled" value="#students">{% trans "Change Student Groups" %}</button>
+                        <button class="movegroup btn btn-success" disabled="disabled" value="#students">{% trans "Change Learner Groups" %}</button>
                     </div>
                     <div class="form-group">
                         <select class="form-control movegrouplist" value="#students">
@@ -38,7 +38,7 @@
                     </div>
                 {% endif %}
                     <div class="form-group">
-                        <button class="delete btn btn-success" disabled="disabled" value="#students">{% trans "Delete Students" %}</button>
+                        <button class="delete btn btn-success" disabled="disabled" value="#students">{% trans "Delete Learners" %}</button>
                     </div>
                 </div>
             </p>
@@ -48,7 +48,7 @@
                  <thead>
                     <tr class="success">
                         <th><input class="select-all" type="checkbox" value="#students"</th>
-                        <th>{% trans "Student Name" %}</th>
+                        <th>{% trans "Learner Name" %}</th>
                         <th>{% trans "Edit" %}</th>
                         <th>{% trans "Coach" %}</th>
                         <th>{% trans "Group" %}</th>
@@ -67,13 +67,13 @@
                                 {{ student|format_name:"last_first" }}
                             </td>
                             <td>
-                                <a class="edit-student" title="{% blocktrans with studentname=student|format_name:"last_first" %}Edit student {{ studentname }}{% endblocktrans %}" href="{% url 'edit_facility_user' facility_user_id=student.id %}?facility={{ facility_id }}&next={{ request.get_full_path|urlencode }}">
+                                <a class="edit-student" title="{% blocktrans with studentname=student|format_name:"last_first" %}Edit learner {{ studentname }}{% endblocktrans %}" href="{% url 'edit_facility_user' facility_user_id=student.id %}?facility={{ facility_id }}&next={{ request.get_full_path|urlencode }}">
                                     <span class="glyphicon glyphicon-pencil"></span>
                                 </a>
                             </td>
 
                             <td>
-                                <a  title="{% blocktrans with studentname=student|format_name:"last_first" %}Coach student {{ studentname }}{% endblocktrans %}" href="{% url 'student_view' %}?user={{ student.id }}">
+                                <a  title="{% blocktrans with studentname=student|format_name:"last_first" %}Coach learner {{ studentname }}{% endblocktrans %}" href="{% url 'student_view' %}?user={{ student.id }}">
                                 <div class="sparklines" sparkType="bar" sparkBarColor="green">
                                 <!--
                                     {{ student.total_logins }},
@@ -113,24 +113,24 @@
     <div class="col-sm-4 col-xs-12">
         <p class="add-new-table-item">
             <a class="create-student" href="{% url 'add_facility_student' %}?facility={{ facility_id }}&group={{ group_id }}&next={{ request.get_full_path|urlencode }}">
-                <span class="glyphicon glyphicon-plus-sign"></span> {% trans 'Add a new student.' %}
+                <span class="glyphicon glyphicon-plus-sign"></span> {% trans 'Add a new learner.' %}
             </a>
         </p>
     </div>
     <div class="col-sm-4 col-xs-12">
         {% if student_pages.num_listed_pages > 1 %}
             <ul class="pagination pagination-sm">
-                <li><a title="{% trans 'Browse to the previous page of students.' %}" {% if student_pages.has_previous %}href="{{ page_urls.students.prev_page }}#students"{% endif %}>&laquo;</a></li>
+                <li><a title="{% trans 'Browse to the previous page of learners.' %}" {% if student_pages.has_previous %}href="{{ page_urls.students.prev_page }}#students"{% endif %}>&laquo;</a></li>
                 {% for listed_page in student_pages.listed_pages %}
                     {% if listed_page == -1 %}
                     <li><a disabled="disabled">&hellip;</a></li>
                     {% elif listed_page == student_pages.number %}
                     <li class="active"><a disabled="disabled">{{student_pages.number}}</a></li>
                     {% else %}
-                    <li><a title="{% blocktrans %}Browse to page # {{ listed_page }} of students.{% endblocktrans %}" href="{{ page_urls.students|get_item:listed_page }}#students">{{ listed_page }}</a></li>
+                    <li><a title="{% blocktrans %}Browse to page # {{ listed_page }} of learners.{% endblocktrans %}" href="{{ page_urls.students|get_item:listed_page }}#students">{{ listed_page }}</a></li>
                     {% endif %}
                 {% endfor %}
-                <li><a title="{% trans 'Browse to the next page of students.' %}" {% if student_pages.has_next %}href="{{ page_urls.students.next_page }}#students"{% endif %}>&raquo;</a></li>
+                <li><a title="{% trans 'Browse to the next page of learners.' %}" {% if student_pages.has_next %}href="{{ page_urls.students.next_page }}#students"{% endif %}>&raquo;</a></li>
             </ul>
         {% endif %}
     </div>

--- a/kalite/control_panel/templates/control_panel/zone_form.html
+++ b/kalite/control_panel/templates/control_panel/zone_form.html
@@ -11,7 +11,7 @@
     <div>
         <h2>
             {% if form.instance.pk %}{% trans "Update Your Sharing Network" %}{% else %}{% trans "Create A Sharing Network" %}{% endif %}
-            <span class="glossary-link nudge-left" title="{% trans "A 'Sharing Network' is a set of KA Lite installations that share logins and student progress with each other through the internet (when available)." %}"></span>
+            <span class="glossary-link nudge-left" title="{% trans "A 'Sharing Network' is a set of KA Lite installations that share logins and learner progress with each other through the internet (when available)." %}"></span>
         </h2>
 
         {{ form.as_p }}

--- a/kalite/distributed/demo_middleware.py
+++ b/kalite/distributed/demo_middleware.py
@@ -34,7 +34,7 @@ class ShowAdminLogin:
         if is_static_file(request.path):
             return
         if not request.is_logged_in:
-            messages.info(request, mark_safe(_("<a href='%(sign_up_url)s'>Sign up as a student</a>, or <a href='%(log_in_url)s'>log in</a> as the site-wide admin (username=%(user_name)s, password=%(passwd)s)" % {
+            messages.info(request, mark_safe(_("<a href='%(sign_up_url)s'>Sign up as a learner</a>, or <a href='%(log_in_url)s'>log in</a> as the site-wide admin (username=%(user_name)s, password=%(passwd)s)" % {
                 "sign_up_url": reverse("facility_user_signup"),
                 "log_in_url": reverse("login"),
                 "user_name": settings.DEMO_ADMIN_USERNAME,

--- a/kalite/distributed/templates/distributed/base_teach.html
+++ b/kalite/distributed/templates/distributed/base_teach.html
@@ -12,9 +12,9 @@
 {% block subnavbar %}
 	<div class="teach-nav admin-only">
         <ul>
-            <li class="reports {% block reports_active %}{% endblock reports_active %}"><a href="{% url 'tabular_view' %}" title="{% trans 'Track the progress of your students' %}"><div class="">{% trans "Reports" %}</div></a></li>
+            <li class="reports {% block reports_active %}{% endblock reports_active %}"><a href="{% url 'tabular_view' %}" title="{% trans 'Track the progress of your learners' %}"><div class="">{% trans "Reports" %}</div></a></li>
             {% if is_config_package_nalanda %}
-                <li class="playlist {% block playlist_active %}{% endblock playlist_active %}"><a class="link-width" href="{% url 'assign_playlists' %}" title="{% trans 'Assign playlists to student groups' %}"><div>{% trans "Playlists" %}</div></a></li>
+                <li class="playlist {% block playlist_active %}{% endblock playlist_active %}"><a class="link-width" href="{% url 'assign_playlists' %}" title="{% trans 'Assign playlists to learner groups' %}"><div>{% trans "Playlists" %}</div></a></li>
                 <li class="exams {% block exams-active %}{% endblock exams-active %}"><a href="{% url 'test_list' %}" title="{% trans 'See list of available tests.' %}"><div>{% trans "Tests" %}</div></a></li>
                 <li class="teacher-only units {% block current_unit_active %}{% endblock current_unit_active %}"><a href="{% url 'current_unit' %}" id="nav_current_unit" title="{% trans 'See list of current units for the facilities.' %}"><div>{% trans "Units" %}</div></a></li>
             {% endif %}

--- a/kalite/distributed/tests/browser_tests/coachreports.py
+++ b/kalite/distributed/tests/browser_tests/coachreports.py
@@ -27,7 +27,7 @@ class TestTabularViewErrors(BrowserActionMixins, CreateAdminMixin, FacilityMixin
         self.browser_login_admin(**self.admin_data)
         self.browse_to(self.reverse("tabular_view") + "?topic=addition-subtraction")
         self.browser.find_element_by_css_selector('#error_message')
-        self.assertEqual(self.browser.find_element_by_css_selector('#error_message').text, _("No student accounts have been created."), "Error message with no users available, no topic selected.")
+        self.assertEqual(self.browser.find_element_by_css_selector('#error_message').text, _("No learner accounts have been created."), "Error message with no users available, no topic selected.")
 
     def test_no_groups_with_topic_selected(self):
         self.browser_login_admin(**self.admin_data)
@@ -56,7 +56,7 @@ class TestTabularViewErrors(BrowserActionMixins, CreateAdminMixin, FacilityMixin
         self.browser_login_admin(**self.admin_data)
         self.browse_to(self.reverse("tabular_view") + "?topic=addition-subtraction&group=" + group.id)
         self.browser.find_element_by_css_selector('#error_message')
-        self.assertEqual(self.browser.find_element_by_css_selector('#error_message').text, _("No student accounts in this group have been created."), "Error message with no users available.")
+        self.assertEqual(self.browser.find_element_by_css_selector('#error_message').text, _("No learner accounts in this group have been created."), "Error message with no users available.")
 
 
     def test_users_out_of_group(self):
@@ -68,7 +68,7 @@ class TestTabularViewErrors(BrowserActionMixins, CreateAdminMixin, FacilityMixin
         self.browser_login_admin(**self.admin_data)
         self.browse_to(self.reverse("tabular_view") + "?topic=addition-subtraction&group_id=" + group.id)
         self.browser.find_element_by_css_selector('#error_message')
-        self.assertEqual(self.browser.find_element_by_css_selector('#error_message').text, _("No student accounts in this group have been created."), "Error message with no users available.")
+        self.assertEqual(self.browser.find_element_by_css_selector('#error_message').text, _("No learner accounts in this group have been created."), "Error message with no users available.")
 
 
     def test_success_with_group(self):

--- a/kalite/distributed/tests/browser_tests/control_panel.py
+++ b/kalite/distributed/tests/browser_tests/control_panel.py
@@ -42,7 +42,7 @@ class TestUserManagement(BrowserActionMixins, CreateAdminMixin, FacilityMixins, 
         self.browse_to(self.reverse("facility_management", kwargs=params))
         self.assertEqual(self.browser.find_element_by_css_selector('div#coaches p.no-data').text, "You currently have no coaches for this facility.", "Does not report no coaches with no coaches.")
         self.assertEqual(self.browser.find_element_by_css_selector('div#groups p.no-data').text, "You currently have no group data available.", "Does not report no groups with no groups.")
-        self.assertEqual(self.browser.find_element_by_css_selector('div#students p.no-data').text, "You currently have no student data available.", "Does not report no users with no users.")
+        self.assertEqual(self.browser.find_element_by_css_selector('div#students p.no-data').text, "You currently have no learner data available.", "Does not report no users with no users.")
 
     def test_groups_one_group_no_user_in_group_no_ungrouped_no_group_selected(self):
         facility = self.facility

--- a/kalite/facility/models.py
+++ b/kalite/facility/models.py
@@ -23,7 +23,7 @@ from securesync.engine.models import DeferredCountSyncedModel
 
 
 class Facility(DeferredCountSyncedModel):
-    name = models.CharField(verbose_name=_("Name"), help_text=_("(This is the name that students/teachers will see when choosing their facility; it can be in the local language.)"), max_length=100)
+    name = models.CharField(verbose_name=_("Name"), help_text=_("(This is the name that learners/coaches will see when choosing their facility; it can be in the local language.)"), max_length=100)
     description = models.TextField(blank=True, verbose_name=_("Description"))
     address = models.CharField(verbose_name=_("Address"), help_text=_("(Please provide as detailed an address as possible.)"), max_length=400, blank=True)
     address_normalized = models.CharField(max_length=400, blank=True)
@@ -146,7 +146,7 @@ class FacilityUser(DeferredCountSyncedModel):
     # Translators: This is a label in a form.
     last_name = models.CharField(max_length=60, verbose_name=_("Last Name"), blank=True)
     # Translators: This is a label in a form.
-    is_teacher = models.BooleanField(default=False, help_text=_("(whether this user should have teacher permissions)"))
+    is_teacher = models.BooleanField(default=False, help_text=_("(whether this user should have coach permissions)"))
     notes = models.TextField(blank=True)
     password = models.CharField(max_length=128)
     default_language = models.CharField(max_length=8, blank=True, null=True); default_language.minversion="0.11.1"

--- a/kalite/facility/templates/facility/facility_selection.html
+++ b/kalite/facility/templates/facility/facility_selection.html
@@ -29,7 +29,7 @@
     <div id="facility_list_container">
         <section id="facility_list">
             <h2>{% trans "Please select a facility" %}</h2>
-            <p>{% trans "A facility is a physical location where students learn." %}</p>
+            <p>{% trans "A facility is a physical location where learners learn." %}</p>
         </section>
         <div>
             <ul>
@@ -52,7 +52,7 @@
                     {% if request.is_admin %}
                         <li>{% trans "You currently have no facilities. Would you like to create a facility?" %}</li>
                     {% else %}
-                        <li>{% trans "There are currently no facilities available, please ask an administrator or teacher to set one up." %}</li>
+                        <li>{% trans "There are currently no facilities available, please ask an administrator or coach to set one up." %}</li>
                     {% endif %}
                 {% endif %}
             </ul>

--- a/kalite/facility/views.py
+++ b/kalite/facility/views.py
@@ -69,7 +69,7 @@ def add_facility_teacher(request):
     If central, must be an org admin
     If distributed, must be superuser or a coach
     """
-    title = _("Add a new teacher")
+    title = _("Add a new coach")
     return _facility_user(request, new_user=True, is_teacher=True, title=title)
 
 
@@ -84,7 +84,7 @@ def add_facility_student(request, ds):
     if request.is_teacher and not ds["facility"].teacher_can_create_students:
         return HttpResponseForbidden()
 
-    title = _("Add a new student")
+    title = _("Add a new learner")
     return _facility_user(request, new_user=True, title=title)
 
 
@@ -97,7 +97,7 @@ def facility_user_signup(request):
 
     if settings.DISABLE_SELF_ADMIN:
         # Users cannot create/edit their own data when UserRestricted
-        raise PermissionDenied(_("Please contact a teacher or administrator to receive login information to this installation."))
+        raise PermissionDenied(_("Please contact a coach or administrator to receive login information to this installation."))
     if settings.CENTRAL_SERVER:
         raise Http404(_("You may not sign up as a facility user on the central server."))
 

--- a/kalite/playlist/templates/playlist/assign_playlists.html
+++ b/kalite/playlist/templates/playlist/assign_playlists.html
@@ -50,7 +50,7 @@
       <div class="col-xs-3">
         <table class="table table-hover" id="student-groups">
           <tr>
-            <th>{% trans "Student Groups" %}</th>
+            <th>{% trans "Learner Groups" %}</th>
           </tr>
         </table>
       </div>

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -475,9 +475,9 @@ def get_content_data(request, content_id=None):
             # TODO(bcipolli): add a link, with querystring args that auto-checks this content in the topic tree
             messages.warning(request, _("This content was not found! You can download it by going to the Update page."))
         elif request.is_logged_in:
-            messages.warning(request, _("This content was not found! Please contact your teacher or an admin to have it downloaded."))
+            messages.warning(request, _("This content was not found! Please contact your coach or an admin to have it downloaded."))
         elif not request.is_logged_in:
-            messages.warning(request, _("This content was not found! You must login as an admin/teacher to download the content."))
+            messages.warning(request, _("This content was not found! You must login as an admin/coach to download the content."))
 
     return content
 


### PR DESCRIPTION
Only changed user-facing strings in wrapped in gettext calls and django templte trans blocks. So, for example, logs and tests still use the teacher/student terminology.