### PR TITLE
Checkbox Autocomplete Off

### DIFF
--- a/kalite/control_panel/templates/control_panel/partials/_groups_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_groups_table.html
@@ -32,7 +32,7 @@
                     <table class="table selectable-table">
                         <thead>
                             <tr class="success">
-                                <th><input class="select-all" type="checkbox" value="#groups"></th>
+                                <th><input class="select-all" type="checkbox" value="#groups" autocomplete="off"/></th>
                                 <th>{% trans "Group" %}</th>
                                 <th>{% trans "Edit" %}</th>
                                 <th>{% trans "Coach" %}</th>
@@ -48,7 +48,7 @@
                             {% for group in groups %}
                                 {% if group.name != ungrouped or group.total_users != 0 %}
                                 <tr {% if group.id %}class="selectable"{% endif %} value="{{ group.id }}" type="groups">
-                                    <td>{% if group.id %}<input type="checkbox" value="#groups">{% endif %}</td>
+                                    <td>{% if group.id %}<input type="checkbox" value="#groups" autocomplete="off"/>{% endif %}</td>
                                     <td>
                                         {# Translators: this is a verb; by clicking this link, the user will be able to coach students. #}
                                         <a title="{% blocktrans with groupname=group.name %}Manage group {{ groupname }}.{% endblocktrans %}"

--- a/kalite/control_panel/templates/control_panel/partials/_students_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_students_table.html
@@ -47,7 +47,7 @@
             <table class="table selectable-table">
                  <thead>
                     <tr class="success">
-                        <th><input class="select-all" type="checkbox" value="#students"</th>
+                        <th><input class="select-all" type="checkbox" value="#students" autocomplete="off"/></th>
                         <th>{% trans "Learner Name" %}</th>
                         <th>{% trans "Edit" %}</th>
                         <th>{% trans "Coach" %}</th>
@@ -62,7 +62,7 @@
                 <tbody>
                     {% for student in student_pages %}
                         <tr class="selectable" value="{{ student.id }}" type="students">
-                            <td><input type="checkbox" value="#students"></td>
+                            <td><input type="checkbox" value="#students" autocomplete="off"/></td>
                             <td>
                                 {{ student|format_name:"last_first" }}
                             </td>

--- a/kalite/control_panel/tests/control_panel.py
+++ b/kalite/control_panel/tests/control_panel.py
@@ -108,6 +108,24 @@ class GroupControlTests(FacilityMixins,
         with self.assertRaises(NoSuchElementException):
             self.browser.find_element_by_xpath('//button[@id="delete-coaches"]')
 
+    def test_checkbox_not_autocompleted(self):
+        # This is a regression test for issue #2929
+        # Firefox aggressively autocompletes form elements, meaning if a checkbox is checked
+        # upon page refresh, it will stay checked. This then disrupts our checkbox/highlight
+        # UI and makes them desynchronized.
+        # N.B. This assumes that our browser tests are running on Firefox, otherwise, this test is moot.
+        self.browser_login_admin(**self.admin_data)
+
+        self.browse_to(self.reverse('facility_management', kwargs={'facility_id': self.facility.id, 'zone_id': None}))
+
+        group_row = self.browser.find_element_by_xpath('//tr[@value="%s"]' % self.group.id)
+        group_delete_checkbox = group_row.find_element_by_xpath('.//input[@type="checkbox" and @value="#groups"]')
+        group_delete_checkbox.click()
+
+        self.browser.refresh()
+
+        self.assertNotEqual(self.browser.find_element_by_xpath('.//input[@type="checkbox" and @value="#groups"]').get_attribute("checked"), u'true')
+
 
 @override_settings(RESTRICTED_TEACHER_PERMISSIONS=True)
 class RestrictedTeacherTests(FacilityMixins,


### PR DESCRIPTION
Fixes #2929 

Summary of changes:
* Adds 'autocomplete="off"' to checkbox type inputs to prevent students from being checked (but not highlighted) on page refresh.
* Regression test for bug.