### PR TITLE
fixed the multiple tabs at coach logged.

### DIFF
--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -203,15 +203,7 @@
 
                             {# Manage for admins => zone control panel #}
                             <!-- End for logged in admins -->
-
-                            <!-- For logged in teachers -->
-                            {# Teach for teachers => coachreports #}
-{#                            <li class="{% block teach_active_teachers %}{% endblock teach_active_teachers %}">#}
-{#                              <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="teacher-only">#}
-{#                                {% trans "Teach" %}#}
-{#                              </a>#}
-{#                            </li>#}
-
+                              
                             {# Manage for teachers => facility management #}
                               {% if request.session.facility_user.facility %}
                                   <li class="{% block manage_active_teachers %}{% endblock manage_active_teachers %}">

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -202,29 +202,31 @@
                             {% endif %}
 
                             {# Manage for admins => zone control panel #}
-                            <li class="{% block manage_active_admins %}{% endblock manage_active_admins %}">
-                              <a href="{% url 'zone_redirect' %}" class="admin-only">
-                                {% trans "Manage" %}
-                              </a>
-                            </li>
                             <!-- End for logged in admins -->
 
                             <!-- For logged in teachers -->
                             {# Teach for teachers => coachreports #}
-                            <li class="{% block teach_active_teachers %}{% endblock teach_active_teachers %}">
-                              <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="teacher-only">
-                                {% trans "Teach" %}
-                              </a>
-                            </li>
+{#                            <li class="{% block teach_active_teachers %}{% endblock teach_active_teachers %}">#}
+{#                              <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="teacher-only">#}
+{#                                {% trans "Teach" %}#}
+{#                              </a>#}
+{#                            </li>#}
 
                             {# Manage for teachers => facility management #}
-                            {% if request.session.facility_user.facility %}
-                              <li class="{% block manage_active_teachers %}{% endblock manage_active_teachers %}">
-                                <a href="{% url 'facility_management' zone_id=None facility_id=request.session.facility_user.facility.id %}" class="teacher-only">
-                                  {% trans "Manage" %}
-                                </a>
-                              </li>
-                            {% endif %}
+                              {% if request.session.facility_user.facility %}
+                                  <li class="{% block manage_active_teachers %}{% endblock manage_active_teachers %}">
+                                      <a href="{% url 'facility_management' zone_id=None facility_id=request.session.facility_user.facility.id %}"
+                                         class="teacher-only">
+                                          {% trans "Manage" %}
+                                      </a>
+                                  </li>
+                              {% else %}
+                                  <li class="{% block manage_active_admins %}{% endblock manage_active_admins %}">
+                                      <a href="{% url 'zone_redirect' %}" class="admin-only">
+                                          {% trans "Manage" %}
+                                      </a>
+                                  </li>
+                              {% endif %}
                             <!-- End for logged in teachers -->
 
                             <!-- For logged out users  -->


### PR DESCRIPTION
hi @aronasorman this will fixed #2990 and #2997

i refactor the `teach and manage` navigation link to display only once. 

i have attached a screenshot. 

![screen shot 2015-02-10 at 1 48 03 pm](https://cloud.githubusercontent.com/assets/8663934/6122688/3acb85c8-b132-11e4-9fe9-5be98bfa8db9.png)

![screen shot 2015-02-10 at 1 47 35 pm](https://cloud.githubusercontent.com/assets/8663934/6122693/47ffac38-b132-11e4-8c4e-da2b93e9e79d.png)

