### PR TITLE
Increased the height of exercise name column in exam reports

### DIFF
--- a/kalite/coachreports/static/css/coachreports/test_view.css
+++ b/kalite/coachreports/static/css/coachreports/test_view.css
@@ -14,7 +14,6 @@ th, td {
     max-width: 80px;
     min-width: 60px;
     font-weight: bold;
-    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     line-height: 1.1em;
@@ -82,4 +81,7 @@ th, td {
     width: 15px;
     top: 3px;
     left: 10px;
+}
+.data-header, .student-header  {
+    height: 80px;
 }


### PR DESCRIPTION
Earlier : 
![screenshot from 2015-02-10 16 16 00](https://cloud.githubusercontent.com/assets/4207886/6125897/1c9d8010-b141-11e4-96ab-90cba0d65fcc.png)

Now: 
![screenshot from 2015-02-10 16 17 27](https://cloud.githubusercontent.com/assets/4207886/6125894/152929ce-b141-11e4-97c5-fa9d89a0322a.png)


