### PR TITLE
Path fix for mod_wsgi

### DIFF
--- a/kalite/ka-lite.wsgi
+++ b/kalite/ka-lite.wsgi
@@ -5,6 +5,7 @@ warnings.filterwarnings('ignore', message=r'Module .*? is being added to sys\.pa
 PROJECT_PATH = os.path.dirname(os.path.realpath(__file__))
 
 sys.path = [
+    PROJECT_PATH,
     os.path.join(PROJECT_PATH, "../"),
     os.path.join(PROJECT_PATH, "../python-packages/"),
 ] + sys.path


### PR DESCRIPTION
Quick fix!

Old path layout gave import errors for middleware not prefixed with kalite. Opening up a secondary issue to propose that all middleware is correctly prefixed with `kalite.`.