### PR TITLE
Set statusModel points attributes default for coaches

### DIFF
--- a/kalite/distributed/api_views.py
+++ b/kalite/distributed/api_views.py
@@ -140,7 +140,7 @@ def status(request):
         # TODO-BLOCKER(jamalex): re-enable this conditional once tastypie endpoints invalidate cached session value
         # if "points" not in request.session:
         request.session["points"] = compute_total_points(user)
-        data["points"] = request.session["points"]
+        data["points"] = request.session["points"] if request.session["points"] else 0
         data["user_id"] = user.id
         data["user_uri"] = reverse("api_dispatch_detail", kwargs={"resource_name": "user", "pk": user.id})
         data["facility_id"] = user.facility.id

--- a/kalite/distributed/tests/browser_tests/distributed.py
+++ b/kalite/distributed/tests/browser_tests/distributed.py
@@ -453,12 +453,10 @@ class PointsDisplayUpdatesCorrectlyTest(KALiteBrowserTestCase, BrowserActionMixi
         self.browser.execute_script(log_model_object + ".set(\"points\", 9000);" )
         self.browser.execute_script(log_model_object + ".saveNow();" )
 
-class CoachHasLogoutLinkTest(KALiteBrowserTestCase, BrowserActionMixins, CreateAdminMixin, FacilityMixins):
+class CoachHasLogoutLinkTest(BrowserActionMixins, CreateAdminMixin, FacilityMixins, KALiteBrowserTestCase):
     """
     A regression test for issue 3000. Note the judicious use of waits and expected conditions to account for
-    various browser sizes and potential server hiccups. Even though no TimeoutException or NoSuchElementException
-    is expected, I still catch it so I can have my say, dangit, given that the test server likes to throw these
-    for apparently nondeterministic reasons sometimes.
+    various browser sizes and potential server hiccups. 
     """
 
     def setUp(self):

--- a/kalite/distributed/tests/browser_tests/distributed.py
+++ b/kalite/distributed/tests/browser_tests/distributed.py
@@ -470,26 +470,19 @@ class CoachHasLogoutLinkTest(KALiteBrowserTestCase, BrowserActionMixins, CreateA
 
     def test_logout_link_visible(self):
         self.browse_to(self.reverse("homepage"))
+        nav_logout = WebDriverWait(self.browser, 10).until(
+            expected_conditions.presence_of_element_located((By.ID, "nav_logout"))
+        )
+        dropdown_menu = self.browser.find_element_by_xpath("//*[@id=\"wrapper\"]/div[1]/div/div/div[2]/ul/li[10]")
         try:
-            nav_logout = WebDriverWait(self.browser, 10).until(
-                expected_conditions.presence_of_element_located((By.ID, "nav_logout"))
+            self.browser_activate_element(elem=dropdown_menu)
+        except ElementNotVisibleException:
+            # Possible if the browser window is too small and the dropdown menu is collapsed.
+            expand_menus_button = self.browser.find_element_by_xpath("//*[@id=\"wrapper\"]/div[1]/div/div/div[1]/button")
+            self.browser_activate_element(elem=expand_menus_button)
+            # Wait for the animation to finish
+            WebDriverWait(self.browser, 3).until(
+                expected_conditions.visibility_of(dropdown_menu)
             )
-            dropdown_menu = self.browser.find_element_by_xpath("//*[@id=\"wrapper\"]/div[1]/div/div/div[2]/ul/li[10]")
-            try:
-                self.browser_activate_element(elem=dropdown_menu)
-            except ElementNotVisibleException:
-                # Possible if the browser window is too small and the dropdown menu is collapsed.
-                expand_menus_button = self.browser.find_element_by_xpath("//*[@id=\"wrapper\"]/div[1]/div/div/div[1]/button")
-                self.browser_activate_element(elem=expand_menus_button)
-                # Wait for the animation to finish
-                WebDriverWait(self.browser, 3).until(
-                    expected_conditions.visibility_of(dropdown_menu)
-                )
-                self.browser_activate_element(elem=dropdown_menu)
-            self.assertTrue(nav_logout.is_displayed(), "The dropdown menu logout item is not displayed!")
-        except NoSuchElementException as e:
-            self.assertTrue(False, "Test raised a NoSuchElementException... probably an issue with `setUp` method? Exception: %s" % repr(e))
-            raise
-        except TimeoutException as e:
-            self.assertTrue(False, "Test raised a TimeoutException. Maybe the test server is tired? Exception: %s" % repr(e))
-            raise
+            self.browser_activate_element(elem=dropdown_menu)
+        self.assertTrue(nav_logout.is_displayed(), "The dropdown menu logout item is not displayed!")


### PR DESCRIPTION
After `fetch`ing `window.statusModel` returns among other
things a value of `null` for `points` when logged in as a
coach. In some sort of tangled javascript fashion, this prevented
the `success` callback of the `StausModel.fetch` method from being
executed.

Solves #3000.