### PR TITLE
"by:" shown on content when no author or organization designated.

### DIFF
--- a/kalite/distributed/hbtemplates/content/content-wrapper.handlebars
+++ b/kalite/distributed/hbtemplates/content/content-wrapper.handlebars
@@ -25,7 +25,9 @@
                     </h3>
 
                     <span class="title">{{ title }}</span>
-                    <span class="organization">{{_ "by:" }} {{ organization }}</span>
+                    {{#if organization}}
+                        <span class="organization">{{_ "by:" }} {{ organization }}</span>
+                    {{/if}}
                     {{#if description }}
                     <div class="content-description">{{ description }}</div>
                     {{/if}}


### PR DESCRIPTION
Hi @aronasorman  this fixed #2962 

I add if statement on `organization context variable` to determine the variable is not empty.

I attached a screenshot.
![screen shot 2015-02-11 at 10 27 13 am](https://cloud.githubusercontent.com/assets/8663934/6141016/791238ce-b1da-11e4-8565-ac550b3831c5.png)
