### PR TITLE
Hide button when the device is registered.

### DIFF
--- a/kalite/control_panel/templates/control_panel/partials/_device_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_device_table.html
@@ -73,7 +73,7 @@
                                             </a>
                                         {% endif %}
                                     {% if not device.is_registered %}
-                                        <a class="btn btn-success not-registered-only" href="{% url 'register_public_key' %}">
+                                        <a class="btn btn-success not-registered-only" id="not-registered" href="{% url 'register_public_key' %}">
                                             {% trans "Register device" %}
                                         </a>
                                     {% endif %}

--- a/kalite/control_panel/templates/control_panel/partials/_device_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_device_table.html
@@ -66,15 +66,17 @@
                                     {% if device.is_own_device %}
                                         <a href="#" id="force-sync" class="registered-only">
                                             {% trans "Sync Now!" %}
-                                        </a></br> 
+                                        </a></br>
                                         {% if is_config_package_nalanda %}
                                             <a href="{% url 'update_software' %}" id="update-link" class=" registered-only">
                                                 {% trans "Update" %}
                                             </a>
                                         {% endif %}
+                                    {% if not device.is_registered %}
                                         <a class="btn btn-success not-registered-only" href="{% url 'register_public_key' %}">
                                             {% trans "Register device" %}
                                         </a>
+                                    {% endif %}
                                         {% if clock_set %}
                                         /
                                             <a onclick="$('#clock_set').show()">

--- a/kalite/control_panel/tests/control_panel.py
+++ b/kalite/control_panel/tests/control_panel.py
@@ -8,6 +8,12 @@ from selenium.common.exceptions import NoSuchElementException
 from kalite.testing.base import KALiteBrowserTestCase, KALiteClientTestCase, KALiteTestCase
 from kalite.testing.mixins import BrowserActionMixins, FacilityMixins, CreateZoneMixin, StudentProgressMixin, CreateAdminMixin, StoreMixins
 
+from selenium.webdriver.common.by import By
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+import time
+
 logging = settings.LOG
 
 
@@ -34,10 +40,12 @@ class DeviceRegistrationTests(FacilityMixins,
         self.fac = self.create_facility(name=facility_name)
         self.browser_login_admin(**self.admin_data)
         self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
-
-        device_status = self.browser.find_elements_by_class_name("not-registered-only")
-        expected_result = "Register Now!"
-        self.assertEqual(device_status[0].text, expected_result)
+        element = self.browser.find_element_by_id('not-registered')
+        try:
+             WebDriverWait(self.browser, 0.7).until(EC.visibility_of(element))
+        except TimeoutException:
+             pass
+        self.assertTrue(element.is_displayed())
 
 
     def test_device_already_register(self):
@@ -51,9 +59,13 @@ class DeviceRegistrationTests(FacilityMixins,
         self.fac = self.create_facility(name=facility_name)
         self.browser_login_admin(**self.admin_data)
         self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
-        device_status = self.browser.find_elements_by_class_name("registered-only")
-        expected_result = "Sync Now!"
-        self.assertEqual(device_status[0].text, expected_result)
+        element = self.browser.find_element_by_id('force-sync')
+        try:
+             WebDriverWait(self.browser, 0.7).until(EC.visibility_of(element))
+        except TimeoutException:
+            pass
+
+        self.assertTrue(element.is_displayed())
 
 
 class FacilityControlTests(FacilityMixins,

--- a/kalite/control_panel/tests/control_panel.py
+++ b/kalite/control_panel/tests/control_panel.py
@@ -11,6 +11,51 @@ from kalite.testing.mixins import BrowserActionMixins, FacilityMixins, CreateZon
 logging = settings.LOG
 
 
+class DeviceRegistrationTests(FacilityMixins,
+                       StudentProgressMixin,
+                       BrowserActionMixins,
+                       CreateZoneMixin,
+                       CreateAdminMixin,
+                       KALiteBrowserTestCase):
+
+    def setUp(self):
+        self.admin_data = {"username": "admin", "password": "admin"}
+        self.admin = self.create_admin(**self.admin_data)
+
+        super(DeviceRegistrationTests, self).setUp()
+
+
+    def test_device_registration_availability(self):
+        """
+        This test simulate the device registration availability.
+        The Registration button must appear else the test will fail.
+        """
+        facility_name = 'default'
+        self.fac = self.create_facility(name=facility_name)
+        self.browser_login_admin(**self.admin_data)
+        self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
+
+        device_status = self.browser.find_elements_by_class_name("not-registered-only")
+        expected_result = "Register Now!"
+        self.assertEqual(device_status[0].text, expected_result)
+
+
+    def test_device_already_register(self):
+        """
+        This test will simulate the device that has already registered and the only option is available is update
+        the software else the test will fail.
+        """
+        facility_name = 'default'
+        self.zone = self.create_zone()
+        self.device_zone = self.create_device_zone(self.zone)
+        self.fac = self.create_facility(name=facility_name)
+        self.browser_login_admin(**self.admin_data)
+        self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
+        device_status = self.browser.find_elements_by_class_name("registered-only")
+        expected_result = "Sync Now!"
+        self.assertEqual(device_status[0].text, expected_result)
+
+
 class FacilityControlTests(FacilityMixins,
                            CreateAdminMixin,
                            BrowserActionMixins,


### PR DESCRIPTION
Hi @aronasorman this fix this issue #3002

Fix: If the device is registered hide the register button else show the button for unregistered device.
Reference: you can identify if the device is registered or not by device.is_registered() method. 

you can see the image below the button is not showing if the device is already registered.
![screen shot 2015-02-11 at 12 11 31 pm](https://cloud.githubusercontent.com/assets/4099119/6141918/f2256a76-b1e7-11e4-9493-7751e571ac8c.png)




