### PR TITLE
Titles and descriptions are identically styled in sidebar

### DIFF
--- a/kalite/distributed/static/css/distributed/sidebar.css
+++ b/kalite/distributed/static/css/distributed/sidebar.css
@@ -164,6 +164,8 @@ div.fade {
 }
 .topic-container-inner .sidebar-topic-description {
     display: none;
+    font-size: 0.9em;
+    margin-top: 15px;
 }
 /* applied to all in outermost expanded panel */
 .topic-container-inner:last-child .sidebar-description {


### PR DESCRIPTION
Hi @aronasorman this fixed #2974 

I adjust the `sidebar topic description font size to 0.9em` and  add `margin top 15px`.

i attached a screenshot.
![screen shot 2015-02-11 at 1 54 47 pm](https://cloud.githubusercontent.com/assets/8663934/6142847/a8602144-b1f9-11e4-9565-d5e7207c3b76.png)
