### PR TITLE
Don't error out in case we don't recognize the OS

### DIFF
--- a/python-packages/fle_utils/internet/functions.py
+++ b/python-packages/fle_utils/internet/functions.py
@@ -96,6 +96,8 @@ def get_ip_addresses(include_loopback=True):
         # on Windows, run ipconfig and parse the output
         ipconfig = os.popen("ipconfig /all").read()
         ips = [match[1] for match in re.findall("IP(v4)? Address[\.\: ]+([\d\.]+)", ipconfig)]
+    else:
+        ips = []
 
     # remove empty values for adapters without an IP
     ips = set(ips) - set([None, ""])
@@ -106,4 +108,3 @@ def get_ip_addresses(include_loopback=True):
         ips = ips - set(["127.0.0.1"])
 
     return list(ips)
-


### PR DESCRIPTION
Fixes #3023. We error out whenever we try to retrieve the external IP address of the computer, since we hardcode the OS values we're looking for. This just sets a default so we don't error out.

A proper fix for the given issue would be to make `ifcfg` work for *BSD.