### PR TITLE
Video availability

### DIFF
--- a/kalite/distributed/static/css/distributed/sidebar.css
+++ b/kalite/distributed/static/css/distributed/sidebar.css
@@ -66,6 +66,7 @@ div.fade {
 
 .missing {
     opacity: 0.4;
+    background: #93BFAC;
 }
 
 .sidebar-panel a:link,

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -233,6 +233,8 @@ def get_content_cache(force=False, annotate=False, language=settings.LANGUAGE_CO
                             "stream_type": "{kind}/{format}".format(kind=content.get("kind", "").lower(), format=format),
                             "thumbnail": thumbnail,
                         }
+                    else:
+                        content["available"] = False
                 else:
                     content["available"] = False
             else:

--- a/kalite/updates/management/commands/videodownload.py
+++ b/kalite/updates/management/commands/videodownload.py
@@ -177,7 +177,6 @@ class Command(UpdatesDynamicCommand, CronCommand):
 
                     # If we got here, we downloaded ... somehow :)
                     handled_youtube_ids.append(video.youtube_id)
-                    caching.initialize_content_caches()
                     self.stdout.write(_("Download is complete!") + "\n")
 
                 except DownloadCancelled:
@@ -216,6 +215,7 @@ class Command(UpdatesDynamicCommand, CronCommand):
                 "num_handled_videos": len(handled_youtube_ids),
                 "num_total_videos": len(handled_youtube_ids) + len(failed_youtube_ids),
             })
+            caching.initialize_content_caches()
 
         except Exception as e:
             self.cancel(stage_status="error", notes=_("Error: %(error_msg)s") % {"error_msg": e})


### PR DESCRIPTION
Fixes #2965 and fixes #2976.

Summary of changes:
* Move cache invalidation during video download to *after* all files have been attempted/handled.
* Add extra 'available' False flag addition during content_cache availability checking.
* Restyle sidebar slightly to make missing content more contrasting.