### PR TITLE
fixing bug 2993 'no login time units'

### DIFF
--- a/kalite/control_panel/templates/control_panel/partials/_coaches_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_coaches_table.html
@@ -58,7 +58,7 @@
                                     </a>
                                 </td>
                                 <td>{{ coach.total_logins }}</td>
-                                <td>{{ coach.total_hours|floatformat }}</td>
+                                <td>{{ coach.total_hours|floatformat }} {% trans "hour(s)" %}</td>
                                 <td>{{ coach.total_report_views }}</td>
                             </tr>
                             {% endfor %}

--- a/kalite/control_panel/templates/control_panel/partials/_groups_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_groups_table.html
@@ -84,10 +84,10 @@
                                     </td>
                                     <td>{{ group.total_users }}</td>
                                     <td>{{ group.total_logins }}</td>
-                                    <td>{{ group.total_hours|floatformat }}</td>
+                                    <td>{{ group.total_hours|floatformat }} {% trans "hour(s)" %}</td>
                                     <td>{{ group.total_videos }}</td>
                                     <td>{{ group.total_exercises }}</td>
-                                    <td>{{ group.pct_mastery|percent:1 }}</td>
+                                    <td>{{ group.pct_mastery|percent:1 }}</td> 
                                 </tr>
                                 {% endif %}
                             {% endfor %}

--- a/kalite/control_panel/templates/control_panel/partials/_students_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_students_table.html
@@ -94,7 +94,7 @@
                                 {% endif %}
                             </td>
                             <td>{{ student.total_logins }}</td>
-                            <td>{{ student.total_hours|floatformat }}</td>
+                            <td>{{ student.total_hours|floatformat }} {% trans "hour(s)" %}</td>
                             <td>{{ student.total_videos }}</td>
                             <td>{{ student.total_exercises }}</td>
                             <td>{{ student.pct_mastery|percent:1  }}</td>


### PR DESCRIPTION
fixes #2993 
Fixed the bug with the facilities management tab not displaying a unit of time under "login time" for each user type (coach/group/student).
Went from login time : 0 
to login time : 0 hour(s)