### PR TITLE
Use kalite binary for setup_unix script instead of deprecated manage.py

### DIFF
--- a/setup_unix.sh
+++ b/setup_unix.sh
@@ -3,7 +3,7 @@ current_dir=`dirname "${BASH_SOURCE[0]}"`
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )/scripts"
 pyexec=`"$SCRIPT_DIR"/python.sh`
 
-"$pyexec" "$current_dir/kalite/manage.py" setup
+"$pyexec" "$current_dir/bin/kalite" manage setup
 
 # TODO: make a check to see if we're running the rpi
 we_are_rpi="False"


### PR DESCRIPTION
Address #2975. Just changes the command used by the setup script, the instructions in INSTALL.md are fine, and will be removed once we merge in the new docs and/or get added to package repositories.