### PR TITLE
Fixes (all?) relative imports to be absolute.

### DIFF
--- a/kalite/distributed/settings.py
+++ b/kalite/distributed/settings.py
@@ -71,7 +71,7 @@ MIDDLEWARE_CLASSES = (
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     __package__ + ".middleware.LockdownCheck",
-    "student_testing.middleware.ExamModeCheck",
+    "kalite.student_testing.middleware.ExamModeCheck",
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (

--- a/kalite/distributed/urls.py
+++ b/kalite/distributed/urls.py
@@ -18,6 +18,8 @@ import kalite.playlist.urls
 import kalite.control_panel.urls
 import kalite.facility.urls
 import kalite.updates.urls
+import kalite.student_testing.urls
+import kalite.store.urls
 import securesync.urls
 
 import fle_utils.handlebars
@@ -90,9 +92,9 @@ urlpatterns += patterns('',
 urlpatterns += patterns(__package__ + '.views',
     url(r'^$', 'homepage', {}, 'homepage'),
     url(r'^search/$', 'search', {}, 'search'),
-    url(r'^test/', include('student_testing.urls')),
+    url(r'^test/', include(kalite.student_testing.urls)),
 
-    url(r'^store/', include('store.urls')),
+    url(r'^store/', include(kalite.store.urls)),
     # the following pattern is a catch-all, so keep it last:
 
     # Allows remote admin of the distributed server

--- a/kalite/student_testing/urls.py
+++ b/kalite/student_testing/urls.py
@@ -7,7 +7,7 @@ import kalite.student_testing.api_urls
 
 if "Nalanda" in settings.CONFIG_PACKAGE:
     urlpatterns = patterns(
-        'student_testing.views',
+        'kalite.student_testing.views',
         url(r'^api/', include(kalite.student_testing.api_urls)),
         url(r'^t/(?P<test_id>.+)/$', 'test', {}, 'test'),
         url(r'^list/$', 'test_list', {}, 'test_list'),
@@ -15,7 +15,7 @@ if "Nalanda" in settings.CONFIG_PACKAGE:
     )
 else:
     urlpatterns = patterns(
-        'student_testing.views',
+        'kalite.student_testing.views',
         url(r'^/$', include(kalite.student_testing.api_urls)),
         url(r'^/$', 'test', {}, 'test'),
         url(r'^/$', 'test_list', {}, 'test_list'),

--- a/kalite/updates/api_urls.py
+++ b/kalite/updates/api_urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 
-urlpatterns = patterns('updates.api_views',
+urlpatterns = patterns('kalite.updates.api_views',
     url(r'^videos/topic_tree$', 'get_annotated_topic_tree', {}, 'get_annotated_topic_tree'),
     url(r'^videos/start$', 'start_video_download', {}, 'start_video_download'),
     url(r'^videos/delete$', 'delete_videos', {}, 'delete_videos'),


### PR DESCRIPTION
When running ./manage.py from the root of the KA Lite directory, any relative imports fail. This fixes (hopefully) all relative imports to be absolute by prepending kalite.

@MCGallaspy 