### PR TITLE
Allow word-breaking on student progress reports.

### DIFF
--- a/kalite/control_panel/static/css/control_panel/student-report.css
+++ b/kalite/control_panel/static/css/control_panel/student-report.css
@@ -25,6 +25,7 @@
 
 .progress-item-title {
     font-size: 0.8em;
+    word-wrap: break-word;
 }
 
 .icon-label {


### PR DESCRIPTION
Finally fixes #3077