### PR TITLE
Fix for 3105 Clicking edit teacher button on "users" changes the second level nav tab to "facilities," should stay on "users"

### DIFF
--- a/kalite/facility/templates/facility/facility_user.html
+++ b/kalite/facility/templates/facility/facility_user.html
@@ -3,7 +3,7 @@
 
 {% block title %}{% trans title %}{% endblock title %}
 
-{% block facility_active %}{% trans "facility-active active-tab active-nav" %}{% endblock facility_active %}
+{% block user_active %}{% trans "user-active active-tab active-nav" %}{% endblock user_active %}
 {% block users_active %}{% trans "active" %}{% endblock %}
 {% block signup_active %}{% trans "active" %}{% endblock signup_active %}
 


### PR DESCRIPTION
Hi @MCGallaspy- this fixed #3105  - Clicking edit teacher button on "users" changes the second level nav tab to "facilities," should stay on "users".

Screenshot is attached below:
![screen shot user](https://cloud.githubusercontent.com/assets/8664071/6342675/63317e74-bc17-11e4-85c4-d08994b196f2.png)
