### PR TITLE
Fix Report page misaligned when viewport width <768

### DIFF
--- a/kalite/coachreports/hbtemplates/coach_nav/reports-nav.handlebars
+++ b/kalite/coachreports/hbtemplates/coach_nav/reports-nav.handlebars
@@ -21,13 +21,12 @@
             </option>
             --}}
         </select>
-    </div><br/>
+    </div>
     <div id="facility-select-container" class="form-group">
         {{!-- Insert facility select template here --}}
-    </div><br/>
+    </div>
     <div id="group-select-container" class="form-group">
         {{!-- Insert group select template here --}}
-    </div><br/>
-    <br/>
+    </div>
     <button id="display-coach-report" class="btn btn-primary btn">{{_ "Go" }}</button>
 </form>

--- a/kalite/coachreports/static/css/coachreports/base.css
+++ b/kalite/coachreports/static/css/coachreports/base.css
@@ -23,3 +23,8 @@ select.reports-select {
     margin-top: 10px;
 
 }
+@media (max-width: 768px) {
+    .form-group {
+        margin-bottom: 0px;
+    }
+}

--- a/kalite/coachreports/static/css/coachreports/base.css
+++ b/kalite/coachreports/static/css/coachreports/base.css
@@ -18,3 +18,8 @@ select.reports-select {
 #display-topic-report {
     margin-top: 22px;
 }
+
+#display-coach-report{
+    margin-top: 10px;
+
+}

--- a/kalite/coachreports/templates/coachreports/base.html
+++ b/kalite/coachreports/templates/coachreports/base.html
@@ -11,13 +11,6 @@
 
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/coachreports/base.css' %}" />
-    <style type="text/css">
-        @media (max-width: 768px) {
-            .form-group {
-                margin-bottom: 0px;
-            }
-        }
-    </style>
 {% endblock headcss %}
 
 {% block headjs %}{{ block.super }}

--- a/kalite/coachreports/templates/coachreports/base.html
+++ b/kalite/coachreports/templates/coachreports/base.html
@@ -11,6 +11,13 @@
 
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/coachreports/base.css' %}" />
+    <style type="text/css">
+        @media (max-width: 768px) {
+            .form-group {
+                margin-bottom: 0px;
+            }
+        }
+    </style>
 {% endblock headcss %}
 
 {% block headjs %}{{ block.super }}


### PR DESCRIPTION
Hi @aronasorman and @MCGallaspy - fixed #3099 

Branch : Develop
See the attach image below demonstrating the fix. The view port of the 640 x 960 DVGA - iphone via `window resizer`  
this fix work on 480 x 800 and 320 x 480
![screen shot 2015-02-24 at 11 10 39 am](https://cloud.githubusercontent.com/assets/4099119/6342797/9611ac4a-bc19-11e4-8159-f98fa0cfb380.png)

