### PR TITLE
Fix for #3094. Drawing on scratchpad sometimes selects page elements.

### DIFF
--- a/kalite/distributed/static/perseus/ke/css/khan-exercise.css
+++ b/kalite/distributed/static/perseus/ke/css/khan-exercise.css
@@ -1274,3 +1274,7 @@ body.mobile ul.inequalities-one-line-radios > li {
 .inequalities-padding#grid {
     margin-bottom: 2em;
 }
+
+.perseus-widget-radio.above-scratchpad.blank-background {
+    width: 40%;
+}


### PR DESCRIPTION
Hi @aronasorman this fixed #3094 - Drawing on scratchpad sometimes selects page elements.

I reduced the width of `perseus-widget-radio.above-scratchpad.blank-background` class to 40% so that the remaining space will be used for scratchpad.

I attached screenshot below:
![screen shot drawing](https://cloud.githubusercontent.com/assets/8664071/6367047/e8c152f2-bd08-11e4-8ceb-bd09b84cab9d.png)

/review: @amodia, @arceduardvincent.
