### PR TITLE
Inherit from the `distributed/base_manage.html` template to fix the navigation links.

### DIFF
--- a/kalite/control_panel/views.py
+++ b/kalite/control_panel/views.py
@@ -379,6 +379,10 @@ def facility_management(request, ds, facility, group_id=None, zone_id=None, per_
         },
         "ungrouped_id": ungrouped_id
     })
+
+    if not settings.CENTRAL_SERVER:
+        context["base_template"] = "distributed/base_manage.html"
+
     return context
 
 


### PR DESCRIPTION
Hi @MCGallaspy / @aronasorman - this fixes #3133.

I just copied the way the `base_template` context variable is added to the `context` dictionary to be used by the `control_panel/base.html` template `if not settings.CENTRAL_SERVER`.

Here's a screenshot of the facility management page for the coach user now:
![screenshot 2015-02-26 18 02 06](https://cloud.githubusercontent.com/assets/175580/6389729/a48a2cd8-bde1-11e4-8a33-7fb83ba7a186.png)
