### PR TITLE
Prevents user text selection on work area where exercises are rendered

### DIFF
--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -1008,3 +1008,12 @@ div#fade {
   border-color: rgba(81, 203, 238, 1);
   border-style: solid;
 }
+
+#workarea {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}


### PR DESCRIPTION
Fixes #3094 without messing with any other styles.

Summary of changes:
* Prevent text selection in the work area (note, that this still allows for clicking of radio buttons when scratchpad is open, it just prevents inadvertent text selection).

@Antrikshy @MCGallaspy