### PR TITLE
Move footer tag and set overflow for #wrapper

### DIFF
--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -12,7 +12,7 @@ html, body {
     min-height: 100%;
     position: relative;
     display: block;
-    overflow: auto;
+    overflow: visible;
 }
 #content-container {
     padding-top: 20px;

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -11,6 +11,8 @@ html, body {
 #wrapper {
     min-height: 100%;
     position: relative;
+    display: block;
+    overflow: auto;
 }
 #content-container {
     padding-top: 20px;
@@ -19,7 +21,6 @@ html, body {
 footer {
     width: 100%;
     height: 90px;
-    position: absolute;
     bottom: 0;
     left: 0;
 }

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -320,10 +320,8 @@
                     {% endblock content %}
                 {% endblock outer_content %}
             </div>
-
-            {# Footer #}
-            {% include "distributed/partials/_footer.html" %}
-
         </div> {# End wrapper #}
+        {# Footer #}
+        {% include "distributed/partials/_footer.html" %}
     </body>
 </html>


### PR DESCRIPTION
Now the footer is positioned statically after the #wrapper element
If content overflows the #wrapper now instead of extending past
the footer, #wrapper will become scrollable.

Fixes #3067.