### PR TITLE
Fix alignment for tabular reports report type and topic selector reflows...

### DIFF
--- a/kalite/coachreports/static/css/coachreports/base.css
+++ b/kalite/coachreports/static/css/coachreports/base.css
@@ -5,7 +5,7 @@
 .coach-reports-row {
     border-bottom: 3px solid #5AA685;
     padding: 20px 0;
-    margin-bottom: 5%;
+    margin-bottom: 3%;
 }
 
 #display-topic-report {

--- a/kalite/coachreports/templates/coachreports/tabular_view.html
+++ b/kalite/coachreports/templates/coachreports/tabular_view.html
@@ -74,7 +74,7 @@
 
 <div class="container">
     <div class="row">
-        <div class="col-sm-3 selection pull-left">
+        <div class="col-xs-12 col-sm-4 col-md-3 selection pull-left">
         {# Select the coach report type #}
         {% if report_types %}
             <label for="report_type">{% trans "Select Report" %}</label>
@@ -86,13 +86,13 @@
             </select>
         {% else %}
             <label for="report_type">{% trans "No report types available." %}</label>
-            <select class="form-control" id="report_type">
+            <select class="form-control" >
                 <option>Not available</option>
             </select>
         {% endif %}
         </div>
         {% if users and request_report_type == "student" %}
-            <div class="col-sm-3 selection pull-left">
+            <div class="col-xs-12 selection pull-left">
                 <label for="student">{% trans "Select Learner" %}</label>
                 <select class="form-control" id="student">
                     <option {% if not request.GET.user %}selected{% endif %}>----</option>
@@ -103,7 +103,7 @@
             </div>
         {% elif groups %}
             {% if playlists %}
-                <div class="col-sm-3 selection">
+                <div class="col-xs-12 col-sm-8 col-md-4 selection">
                     <label for="playlist">{% trans "Select Playlist" %}</label>
                     <select class="form-control" id="playlist">
                         <option {% if not request.GET.playlist %}selected{% endif %}>----</option>
@@ -113,7 +113,7 @@
                     </select>
                 </div>
             {% elif topics %}
-                <div class="col-sm-4 selection">
+                <div class="col-xs-12 col-sm-6 col-md-4 selection">
                     <label for="topic">{% trans "Select Topic" %}</label>
                     <select class="form-control" id="topic">
                         <option {% if not request.GET.topic %}selected{% endif %}>----</option>
@@ -130,7 +130,7 @@
     </div>
 
     <div class="row">
-        <div class="col-md-6 col-md-push-1 col-xs-4 col-xs-push-1">
+        <div class="col-md-6 col-xs-12">
             <ul id="legend">
                 <li class="legend"><div class="partial"></div>{% trans "In Progress" %}</li>
                 <li class="legend"><div class="complete"></div>{% trans "Completed" %}</li>

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -436,7 +436,7 @@ footer {
 }
 
 @media (max-width: 454px) {
-    .form-control {
+    #search_box {
         width: 83%;
         margin-left: 15px;
     }
@@ -450,7 +450,7 @@ footer {
 }
 
 @media only screen and (min-width: 455px) and (max-width: 600px) {
-    .form-control {
+    #search_box {
         width: 87%;
         margin-left: 15px;
 
@@ -464,7 +464,7 @@ footer {
 
 @media only screen and (min-width: 600px) and (max-width: 767px) {
 
-    .form-control{
+    #search_box{
         width: 90%;
         margin-left: 15px;
     }

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -168,7 +168,7 @@
                                   <li id="search_input">
                                       <form class="navbar-form " action="{% url 'search' %}" method="get"  role="search">
                                           {% comment %}translators: this will appear in the navigation bar. please try to keep it as short as possible.{% endcomment %}
-                                          <input type="text" name="query"  class="form-control pull-left" placeholder="{% trans 'Topic, video, exercise...' %}" />
+                                          <input type="text" name="query" id="search_box" class="form-control pull-left" placeholder="{% trans 'Topic, video, exercise...' %}" />
                                           <button class="btn btn-default" id="search_btn" type="submit"><i class="glyphicon glyphicon-search"></i></button>
                                       </form>
                                   </li>


### PR DESCRIPTION
Hi @aronasorman and @rtibbles - this fixes #3142 

The image below demonstrate 3 view ports to correspond its respective view port
```
480 × 800 WVGA - Low-end Windows Phone
640 × 960 DVGA - iPhone
1366 × 768 WXGA - Tablet
```
This will justify that our `tabular reports` `report type` and `topic selector` can adapt the view port less than 768px and the desktop view.

Mobile view `480 × 800 WVGA - Low-end Windows Phone` and `640 × 960 DVGA - iPhone`
![screen shot 2015-02-27 at 3 18 53 pm](https://cloud.githubusercontent.com/assets/4099119/6408770/8aea53ac-be95-11e4-9842-23f4d6723b30.png)

Desktop View : `1366 × 768 WXGA - Tablet`
![screen shot 2015-02-27 at 3 18 49 pm](https://cloud.githubusercontent.com/assets/4099119/6408778/a070eb3c-be95-11e4-804c-736b223d0996.png)

/review: @jesumer 