### PR TITLE
Remove the css classes mistakenly translated.

### DIFF
--- a/kalite/control_panel/templates/control_panel/account_management.html
+++ b/kalite/control_panel/templates/control_panel/account_management.html
@@ -4,11 +4,13 @@
 {% load my_filters %}
 {% load include_block %}
 
-{% block username_active %}{% trans "active" %}{% endblock username_active %}
-{% block control_panel_active %}{% endblock control_panel_active %}
-{% block progress_active %}{% trans "active" %}{% endblock progress_active %}
-{% block account_management_active %}{% trans "active" %}{% endblock account_management_active %}
-
+{% block i18n_do_not_translate %}
+    {% block username_active %}active{% endblock username_active %}
+    {% block control_panel_active %}{% endblock control_panel_active %}
+    {% block progress_active %}active{% endblock progress_active %}
+    {% block account_management_active %}active{% endblock account_management_active %}
+{% endblock i18n_do_not_translate %}
+        
 {% block title %}{{ student.get_name }} - {% trans "User Management" %}{{ block.super }}{% endblock title%}
 
 {% block headjs %}

--- a/kalite/control_panel/templates/control_panel/device_management.html
+++ b/kalite/control_panel/templates/control_panel/device_management.html
@@ -5,9 +5,11 @@
 
 {% block title %}{% blocktrans with device_name=device.name %}{{ device_name }} Device Syncing History{% endblocktrans %}{{ block.super }}{% endblock title %}
 
-{% block users_active %}{% trans "active" %}{% endblock users_active %}
-{% block manage_active %}{% trans "active" %}{% endblock manage_active %}
-{% block facility_active %}{% trans "facility-active active-tab active-nav" %}{% endblock facility_active %}
+{% block i18n_do_not_translate %}
+    {% block users_active %}active{% endblock users_active %}
+    {% block manage_active %}active{% endblock manage_active %}
+    {% block facility_active %}facility-active active-tab active-nav{% endblock facility_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
     <style>

--- a/kalite/distributed/templates/admin/base.html
+++ b/kalite/distributed/templates/admin/base.html
@@ -3,7 +3,9 @@
 {% load admin_static i18n %}
 {% load url from future %}
 
-{% block admin_active %}{% trans "active" %}{% endblock admin_active %}
+{% block i18n_do_not_translate %}
+    {% block admin_active %}active{% endblock admin_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}
     <link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}" />

--- a/kalite/distributed/templates/admin/login.html
+++ b/kalite/distributed/templates/admin/login.html
@@ -2,7 +2,9 @@
 {% load i18n admin_static %}
 {% load url from future %}
 
-{% block login_active %}{% trans "active" %}{% endblock login_active %}
+{% block i18n_do_not_translate %}
+    {% block login_active %}active{% endblock login_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block bodyclass %}{% trans "login" %}{% endblock %}
 

--- a/kalite/distributed/templates/distributed/base_manage.html
+++ b/kalite/distributed/templates/distributed/base_manage.html
@@ -4,8 +4,10 @@
 {% load i18n %}
 {% load my_filters %}
 
-{% block manage_active_teachers %}{% trans "active" %}{% endblock manage_active_teachers %}
-{% block manage_active_admins %}{% trans "active" %}{% endblock manage_active_admins %}
+{% block i18n_do_not_translate %}
+    {% block manage_active_teachers %}active{% endblock manage_active_teachers %}
+    {% block manage_active_admins %}active{% endblock manage_active_admins %}
+{% endblock i18n_do_not_translate %}
 
 {% block subnavbar %}
     <div class="manage-nav logged-in-only">

--- a/kalite/distributed/templates/distributed/base_teach.html
+++ b/kalite/distributed/templates/distributed/base_teach.html
@@ -4,8 +4,10 @@
 {% load i18n %}
 {% load my_filters %}
 
-{% block teach_active_teachers %}{% trans "active" %}{% endblock teach_active_teachers %}
-{% block teach_active_admins %}{% trans "active" %}{% endblock teach_active_admins %}
+{% block i18n_do_not_translate %}
+    {% block teach_active_teachers %}active{% endblock teach_active_teachers %}
+    {% block teach_active_admins %}active{% endblock teach_active_admins %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{block.super}}{% endblock headcss %}
 

--- a/kalite/distributed/templates/distributed/exercise.html
+++ b/kalite/distributed/templates/distributed/exercise.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load kalite_staticfiles %}
 
-{% block practice_active %}{% trans "active" %}{% endblock practice_active %}
+{% block i18n_do_not_translate %}
+    {% block practice_active %}active{% endblock practice_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'perseus/ke/css/khan-exercise.css' True %}">

--- a/kalite/distributed/templates/distributed/help_admin.html
+++ b/kalite/distributed/templates/distributed/help_admin.html
@@ -2,7 +2,10 @@
 {% load i18n %}
 {% load staticfiles %}
 
-{% block help_active %}{% trans "active" %}{% endblock help_active %}
+{% block i18n_do_not_translate %}
+    {% block help_active %}active{% endblock help_active %}
+{% endblock i18n_do_not_translate %}
+
 {% block title %}{% trans "Administration Panel" %}{{ block.super }}{% endblock title %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/distributed/templates/distributed/help_student.html
+++ b/kalite/distributed/templates/distributed/help_student.html
@@ -2,7 +2,10 @@
 {% load i18n %}
 {% load staticfiles %}
 
-{% block help_active %}{% trans "active" %}{% endblock help_active %}
+{% block i18n_do_not_translate %}
+    {% block help_active %}active{% endblock help_active %}
+{% endblock i18n_do_not_translate %}
+
 {% block title %}{% trans "Administration Panel" %}{{ block.super }}{% endblock title %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/facility/templates/facility/facility.html
+++ b/kalite/facility/templates/facility/facility.html
@@ -10,9 +10,12 @@
     {% endif %}
     {% trans "Facility" %}
 {% endblock title %}
-{% block facility_active %}{% trans "facility-active active-tab active-nav" %}{% endblock facility_active %}
-{% block update_active %}{% trans "active" %}{% endblock update_active %}
-{% block users_active %}{% trans "active" %}{% endblock %}
+
+{% block i18n_do_not_translate %}
+    {% block facility_active %}facility-active active-tab active-nav{% endblock facility_active %}
+    {% block update_active %}active{% endblock update_active %}
+    {% block users_active %}active{% endblock %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}
     <style>

--- a/kalite/facility/templates/facility/facility_user.html
+++ b/kalite/facility/templates/facility/facility_user.html
@@ -3,9 +3,11 @@
 
 {% block title %}{% trans title %}{% endblock title %}
 
-{% block user_active %}{% trans "user-active active-tab active-nav" %}{% endblock user_active %}
-{% block users_active %}{% trans "active" %}{% endblock %}
-{% block signup_active %}{% trans "active" %}{% endblock signup_active %}
+{% block i18n_do_not_translate %}
+    {% block user_active %}user-active active-tab active-nav{% endblock user_active %}
+    {% block users_active %}active{% endblock %}
+    {% block signup_active %}active{% endblock signup_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
     <style>

--- a/kalite/facility/templates/facility/login.html
+++ b/kalite/facility/templates/facility/login.html
@@ -1,7 +1,9 @@
 {% extends base_template %}
 {% load i18n %}
 
-{% block login_active %}{% trans "active" %}{% endblock login_active %}
+{% block i18n_do_not_translate %}
+    {% block login_active %}active{% endblock login_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block title %}{% trans "Log in" %}{% endblock title %}
 

--- a/kalite/updates/templates/updates/update_languages.html
+++ b/kalite/updates/templates/updates/update_languages.html
@@ -2,9 +2,11 @@
 {% load i18n %}
 {% load staticfiles %}
 
-{% block languages_active %}{% trans "languages-active active-tab active-nav" %}{% endblock languages_active %}
-{% block users_active %}{% trans "active" %}{% endblock users_active %}
-{% block manage_active %}{% trans "active" %}{% endblock manage_active %}
+{% block i18n_do_not_translate %}
+    {% block languages_active %}languages-active active-tab active-nav{% endblock languages_active %}
+    {% block users_active %}active{% endblock users_active %}
+    {% block manage_active %}active{% endblock manage_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block title %}{% trans "Update Languages" %}{% endblock %}
 

--- a/kalite/updates/templates/updates/update_software.html
+++ b/kalite/updates/templates/updates/update_software.html
@@ -5,7 +5,9 @@
 
 {% block title %}{% trans "Update Software" %}{% endblock %}
 
-{% block facility_active %}{% trans "facility-active active-tab active-nav" %}{% endblock facility_active %}
+{% block i18n_do_not_translate %}
+    {% block facility_active %}facility-active active-tab active-nav{% endblock facility_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/bootstrap.min.css' %}" />

--- a/kalite/updates/templates/updates/update_videos.html
+++ b/kalite/updates/templates/updates/update_videos.html
@@ -3,9 +3,11 @@
 {% load staticfiles %}
 {% load i18n_filters %}
 
-{% block users_active %}{% trans "active" %}{% endblock users_active %}
-{% block manage_active %}{% trans "active" %}{% endblock manage_active %}
-{% block video_active %}{% trans "video-active active-tab active-nav" %}{% endblock video_active %}
+{% block i18n_do_not_translate %}
+    {% block users_active %}active{% endblock users_active %}
+    {% block manage_active %}active{% endblock manage_active %}
+    {% block video_active %}video-active active-tab active-nav{% endblock video_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block title %}{% trans "Update Videos" %}{% endblock %}
 


### PR DESCRIPTION
Hi @aronasorman and @MCGallaspy -this fixes #3075

> I remove the css classes mistakenly translated and revert it to the intended purpose. 
> I wrapped the css classes in a maker `block` that can mark this this blocks ` {% block i18n_do_not_translate %}` as not to be translated.
> As long as this `css classes` are mark within this block it will not be translated.

See the implementation and the fix here https://github.com/fle-internal/i18nize_templates/pull/3


/review: @jesumer 