### PR TITLE
fix for #2980 - Answer box highlighting is missing left border.

### DIFF
--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -987,3 +987,7 @@ to items you want to have the icon appear with.
     -ms-user-select: none;
     user-select: none;
 }
+
+#workarea .perseus-widget-container.widget-highlight {
+    box-shadow: -4px 0 9px 5px #ffa500;
+}

--- a/kalite/distributed/templates/distributed/learn.html
+++ b/kalite/distributed/templates/distributed/learn.html
@@ -31,6 +31,13 @@
         <link rel="stylesheet" type="text/css" href="{% static "perseus/lib/katex/katex.css" %}" />
         <link rel="stylesheet" type="text/css" href="{% static "perseus/lib/mathquill/mathquill.css" %}" />
         <link rel="stylesheet" type="text/css" href="{% static "perseus/stylesheets/exercise-content-package/perseus.css" %}" />
+
+        <style type="text/css">
+            /* Overridding perseus.css to make answer box highlighted in four sides */
+            .perseus-widget-container.widget-highlight {
+                box-shadow: -4px 0 9px 5px #ffa500;
+            }
+        </style>
         <!-- END PERSEUS STUFF -->
     {% endif %}
     

--- a/kalite/distributed/templates/distributed/learn.html
+++ b/kalite/distributed/templates/distributed/learn.html
@@ -31,13 +31,6 @@
         <link rel="stylesheet" type="text/css" href="{% static "perseus/lib/katex/katex.css" %}" />
         <link rel="stylesheet" type="text/css" href="{% static "perseus/lib/mathquill/mathquill.css" %}" />
         <link rel="stylesheet" type="text/css" href="{% static "perseus/stylesheets/exercise-content-package/perseus.css" %}" />
-
-        <style type="text/css">
-            /* Overridding perseus.css to make answer box highlighted in four sides */
-            .perseus-widget-container.widget-highlight {
-                box-shadow: -4px 0 9px 5px #ffa500;
-            }
-        </style>
         <!-- END PERSEUS STUFF -->
     {% endif %}
     


### PR DESCRIPTION
Hi. @MCGallaspy. This fixed #2980 - Answer box highlighting is missing left border.

Milestone: 0.14.x
No test for now because this is a simple box-shawdow in css.

Screenshot below:
![screen shot high-light](https://cloud.githubusercontent.com/assets/8664071/6460028/bf803a28-c1ce-11e4-9057-7675f7ac20fb.png)
 