### PR TITLE
docs - screenshot directive (and management command) can take screenshot as though the device was registered

### DIFF
--- a/sphinx-docs/usermanual/userman_admin.rst
+++ b/sphinx-docs/usermanual/userman_admin.rst
@@ -496,6 +496,7 @@ To download language packs:
     :navigation-steps:
     :focus: #language-packs-selection | Select language packs to download from this menu!
     :class: screenshot
+    :registered: true
 
 .. |lp-button| screenshot::
     :user-role: admin
@@ -503,6 +504,7 @@ To download language packs:
     :navigation-steps:
     :focus: #get-language-button
     :class: screenshot
+    :registered: true
 
 Delete Language Packs
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -518,6 +520,7 @@ To delete language packs:
     :navigation-steps:
     :focus: #delete-language-button button | Use the buttons in this column to delete language packs.
     :class: screenshot
+    :registered: true
 
 
 Restarting Your Server


### PR DESCRIPTION
Because previously it couldn't. Does this by creating an associated Zone and DeviceZone for the Device, so that `Device.is_registered()` returns `True`.

Also touched up `sphinx-docs/screenshot.py` a little bit while I was in there, and added the appropriate option to a couple of screenshots.