### PR TITLE
Fixes top level navigation bug that showed "Teach" twice, also style fixes and css cleanup

### DIFF
--- a/kalite/coachreports/templates/coachreports/base.html
+++ b/kalite/coachreports/templates/coachreports/base.html
@@ -3,9 +3,11 @@
 {% load i18n %}
 {% load my_filters %}
 
-{% block reports_active %}reports-active active-tab active-nav{% endblock reports_active %}
-{% block teacher_active %}active{% endblock teacher_active %}
-{% block admin_active %}active{% endblock admin_active %}
+{% block i18n_do_not_translate %}
+    {% block reports_active %}reports-active active-tab active-nav{% endblock reports_active %}
+    {% block teacher_active %}active{% endblock teacher_active %}
+    {% block admin_active %}active{% endblock admin_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block title %}{% trans "Coach Reports" %}{% endblock title %}
 

--- a/kalite/coachreports/templates/coachreports/base_d3_visualization.html
+++ b/kalite/coachreports/templates/coachreports/base_d3_visualization.html
@@ -22,8 +22,10 @@
 {% load my_filters %}
 {% load staticfiles %}
 
-{% block teacher_active %}active{% endblock teacher_active %}
-{% block admin_active %}active{% endblock admin_active %}
+{% block i18n_do_not_translate %}
+    {% block teacher_active %}active{% endblock teacher_active %}
+    {% block admin_active %}active{% endblock admin_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %} {{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/jquery-ui/jquery-ui.min.css' %}" />

--- a/kalite/coachreports/templates/coachreports/tabular_view.html
+++ b/kalite/coachreports/templates/coachreports/tabular_view.html
@@ -4,11 +4,13 @@
 {% load kalite_staticfiles %}
 {% load my_filters %}
 
-{% block teacher_active %}active{% endblock teacher_active %}
-{% block admin_active %}active{% endblock admin_active %}
-{% block title %}{% trans "Progress by topic" %} | {{ block.super }}{% endblock title %}
-{% block coachnav %}progress-tab-active{% endblock coachnav %}
-{% block progress_active %}sub-active{% endblock progress_active %}
+{% block i18n_do_not_translate %}
+    {% block teacher_active %}active{% endblock teacher_active %}
+    {% block admin_active %}active{% endblock admin_active %}
+    {% block title %}{% trans "Progress by topic" %} | {{ block.super }}{% endblock title %}
+    {% block coachnav %}progress-tab-active{% endblock coachnav %}
+    {% block progress_active %}sub-active{% endblock progress_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/coachreports/tabular_view.css' %}" />

--- a/kalite/coachreports/templates/coachreports/test_detail_view.html
+++ b/kalite/coachreports/templates/coachreports/test_detail_view.html
@@ -4,7 +4,10 @@
 {% load kalite_staticfiles %}
 {% load my_filters %}
 
-{% block coachreports_active %}active{% endblock coachreports_active %}
+{% block i18n_do_not_translate %}
+    {% block coachreports_active %}active{% endblock coachreports_active %}
+{% endblock i18n_do_not_translate %}
+
 {% block title %}{{ test_obj.title }} {{ block.super }}{% endblock title %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/coachreports/templates/coachreports/timeline_view.html
+++ b/kalite/coachreports/templates/coachreports/timeline_view.html
@@ -4,11 +4,13 @@
 {% load my_filters %}
 {% load kalite_staticfiles %}
 
-{% block title %}{{ title }} | {{ block.super }}{% endblock title %}
-{% block report_title %}{{ title }}{% endblock report_title %}
-{% block teacher_active %}active{% endblock teacher_active %}
-{% block admin_active %}active{% endblock admin_active %}
-{% block mastery_active %}sub-active{% endblock mastery_active %}
+{% block i18n_do_not_translate %}
+    {% block title %}{{ title }} | {{ block.super }}{% endblock title %}
+    {% block report_title %}{{ title }}{% endblock report_title %}
+    {% block teacher_active %}active{% endblock teacher_active %}
+    {% block admin_active %}active{% endblock admin_active %}
+    {% block mastery_active %}sub-active{% endblock mastery_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/coachreports/timeline_view.css' %}">

--- a/kalite/control_panel/templates/control_panel/base.html
+++ b/kalite/control_panel/templates/control_panel/base.html
@@ -2,7 +2,9 @@
 {% load staticfiles %}
 {% load i18n %}
 
-{% block control_panel_active %}active{% endblock control_panel_active %}
+{% block i18n_do_not_translate %}
+    {% block control_panel_active %}active{% endblock control_panel_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/control_panel/base.css' %}" />

--- a/kalite/control_panel/templates/control_panel/data_export.html
+++ b/kalite/control_panel/templates/control_panel/data_export.html
@@ -3,7 +3,9 @@
 {% load staticfiles %}
 {% load include_block %}
 
+{% block i18n_do_not_translate %}
 {% block facility_active %}active{% endblock facility_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block title %}{{ zone.name }} - {% trans "Data Export" %} {{ block.super }}{% endblock title %}
 

--- a/kalite/control_panel/templates/control_panel/data_export.html
+++ b/kalite/control_panel/templates/control_panel/data_export.html
@@ -4,7 +4,7 @@
 {% load include_block %}
 
 {% block i18n_do_not_translate %}
-{% block facility_active %}active{% endblock facility_active %}
+    {% block facility_active %}active{% endblock facility_active %}
 {% endblock i18n_do_not_translate %}
 
 {% block title %}{{ zone.name }} - {% trans "Data Export" %} {{ block.super }}{% endblock title %}

--- a/kalite/control_panel/templates/control_panel/data_export.html
+++ b/kalite/control_panel/templates/control_panel/data_export.html
@@ -3,7 +3,7 @@
 {% load staticfiles %}
 {% load include_block %}
 
-{% block facility_active %}facility-active active-tab active-nav{% endblock facility_active %}
+{% block facility_active %}active{% endblock facility_active %}
 
 {% block title %}{{ zone.name }} - {% trans "Data Export" %} {{ block.super }}{% endblock title %}
 

--- a/kalite/control_panel/templates/control_panel/device_management.html
+++ b/kalite/control_panel/templates/control_panel/device_management.html
@@ -8,7 +8,7 @@
 {% block i18n_do_not_translate %}
     {% block users_active %}active{% endblock users_active %}
     {% block manage_active %}active{% endblock manage_active %}
-    {% block facility_active %}facility-active active-tab active-nav{% endblock facility_active %}
+    {% block facility_active %}active{% endblock facility_active %}
 {% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/control_panel/templates/control_panel/facility_management.html
+++ b/kalite/control_panel/templates/control_panel/facility_management.html
@@ -3,8 +3,10 @@
 {% load my_filters %}
 {% load staticfiles %}
 
+{% block i18n_do_not_translate %}
 {% block control_panel_active %}{% endblock %}
 {% block user_active %}active{% endblock user_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block title %}{{ facility.name }} - {% trans "Facility Management" %}{% endblock title %}
 

--- a/kalite/control_panel/templates/control_panel/facility_management.html
+++ b/kalite/control_panel/templates/control_panel/facility_management.html
@@ -4,8 +4,8 @@
 {% load staticfiles %}
 
 {% block i18n_do_not_translate %}
-{% block control_panel_active %}{% endblock %}
-{% block user_active %}active{% endblock user_active %}
+    {% block control_panel_active %}{% endblock %}
+    {% block user_active %}active{% endblock user_active %}
 {% endblock i18n_do_not_translate %}
 
 {% block title %}{{ facility.name }} - {% trans "Facility Management" %}{% endblock title %}

--- a/kalite/control_panel/templates/control_panel/facility_management.html
+++ b/kalite/control_panel/templates/control_panel/facility_management.html
@@ -4,8 +4,7 @@
 {% load staticfiles %}
 
 {% block control_panel_active %}{% endblock %}
-{% block users_active %}active{% endblock %}
-{% block user_active %}users-active active-tab active-nav{% endblock user_active %}
+{% block user_active %}active{% endblock user_active %}
 
 {% block title %}{{ facility.name }} - {% trans "Facility Management" %}{% endblock title %}
 

--- a/kalite/control_panel/templates/control_panel/zone_management.html
+++ b/kalite/control_panel/templates/control_panel/zone_management.html
@@ -5,9 +5,11 @@
 
 {% block title %}{% if zone.name %}{{ zone.name }} - {% endif %}{% trans "Sharing Network Management Console" %}{% endblock title %}
 
+{% block i18n_do_not_translate %}
 {% block users_active %}active{% endblock users_active %}
 {% block manage_active %}active{% endblock manage_active %}
 {% block facility_active %}active{% endblock facility_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
     {% if clock_set %}

--- a/kalite/control_panel/templates/control_panel/zone_management.html
+++ b/kalite/control_panel/templates/control_panel/zone_management.html
@@ -7,7 +7,7 @@
 
 {% block users_active %}active{% endblock users_active %}
 {% block manage_active %}active{% endblock manage_active %}
-{% block facility_active %}facility-active active-tab active-nav{% endblock facility_active %}
+{% block facility_active %}active{% endblock facility_active %}
 
 {% block headcss %}{{ block.super }}
     {% if clock_set %}

--- a/kalite/control_panel/templates/control_panel/zone_management.html
+++ b/kalite/control_panel/templates/control_panel/zone_management.html
@@ -6,9 +6,9 @@
 {% block title %}{% if zone.name %}{{ zone.name }} - {% endif %}{% trans "Sharing Network Management Console" %}{% endblock title %}
 
 {% block i18n_do_not_translate %}
-{% block users_active %}active{% endblock users_active %}
-{% block manage_active %}active{% endblock manage_active %}
-{% block facility_active %}active{% endblock facility_active %}
+    {% block users_active %}active{% endblock users_active %}
+    {% block manage_active %}active{% endblock manage_active %}
+    {% block facility_active %}active{% endblock facility_active %}
 {% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -119,9 +119,6 @@ input[type="submit"] {
 .nav-tabs li a:hover,
 .nav-tabs li.active a {
     background-color: white;
-    border-left: 2px solid #5AA685;
-    border-top: 2px solid #5AA685;
-    border-right: 2px solid #5AA685;
     color: #5AA685;
     -webkit-transition: all 80ms ease-out;
     -moz-transition: all 80ms ease-out;

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -101,7 +101,7 @@ input[type="submit"] {
 }
 .nav-tabs li a,
 .nav-tabs li.active a,
-.nav-tabls li a:active {
+.nav-tabs li a:active {
     border: 0;
     border-radius: 5px 15px 0 0;
     margin: 0;
@@ -114,6 +114,9 @@ input[type="submit"] {
 }
 #points {
     margin-left: 20px;
+}
+.nav-tabs li.active a:hover {
+    border: none;
 }
 .nav-tabs li.active a:hover,
 .nav-tabs li a:hover,

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -213,7 +213,6 @@ a:hover {
 .reports:hover, .reports-active {
     background-position: center 7px;
     height: 87px;
-    color: #5AA685 !important;
 }
 .playlist {
     background-position: center 7px;

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -199,9 +199,6 @@ a:hover {
     border-top-right-radius: 16px;
     font-weight: bold;
 }
-.active-tab {
-
-}
 .active-tab div {
     color: #5AA685 !important;
 }

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -279,7 +279,7 @@ a:hover {
 .manage-nav span.icon {
     font-size: 40pt;
 }
-.top-level-active {
+/*.top-level-active {
     padding-right: 0px !important;
     margin-right: 7px;
     background-color: white;
@@ -292,7 +292,7 @@ a:hover {
     -moz-transition: all 80ms ease-out;
     -o-transition: all 80ms ease-out;
     transition: all 80ms ease-out;
-} 
+} */
 .active-nav {
     color: #405D32 !important;
     background-color: white !important;

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -261,7 +261,6 @@ a:hover {
 }
 .manage-nav ul {
     padding-left: 1%;
-    margin-bottom: -4px;
     height: 87px;
 }
 .manage-nav li {
@@ -294,20 +293,10 @@ a:hover {
     border-top-left-radius: 5px;
     border-top-right-radius: 17px;
 }
-.manage-nav li div {
-    position: relative;
-    width: 110px;
-    height: 85px;
-    /*line-height: 9.5;*/
-    margin-left: -3px;
-    margin-top: 5px;
-}
 .manage-nav li div:hover {
     color: #5AA685;
 }
 .manage-nav li a:hover {
-    border-top-left-radius: 5px !important;
-    border-top-right-radius: 16px !important;
     color: #5AA685;
     font-weight: bold;
     text-decoration: none;
@@ -318,41 +307,9 @@ a:hover {
 .active-nav {
     color: #405D32 !important;
     background-color: white !important;
-    border-top-left-radius: 5px !important;
-    border-top-right-radius: 16px !important;
     font-weight: bold;
 }
-.users {
-    background-position: center 7px;
-    height: 87px;
-}
-.users:hover, .users-active {
-    background-position: center 7px;
-    height: 87px;
-}
-.video {
-    background-position: center 7px;
-    height: 87px;
-}
-.video:hover, .video-active {
-    background-position: center 7px;
-    height: 87px;
-}
-.languages {
-    background-position: center 7px;
-    height: 87px;
-}
-.languages:hover, .languages-active {
-    background-position: center 7px;
-    height: 87px;
-}
-.facility {
-    background-position: center 7px;
-    height: 87px;
-}
-.facility:hover, .facility-active {
-    background-position: center 7px;
-    height: 87px;
+
 }
 /********* End "Admin" Sub-Navigation bar **********/
 

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -200,36 +200,19 @@ a:hover {
     font-weight: bold;
 }
 .active-tab {
-    height: 89px;
-    width: 110px;
+
 }
 .active-tab div {
     color: #5AA685 !important;
 }
-.reports {
+.reports, .reports:hover, .reports-active,
+.playlist, .playlist:hover, .playlists-active,
+.exams, .exams:hover, .exams-active, 
+.learn, .learn:hover, .learn-active {
     background-position: center 7px;
     height: 87px;
 }
-.reports:hover, .reports-active {
-    background-position: center 7px;
-    height: 87px;
-}
-.playlist {
-    background-position: center 7px;
-    height: 87px;
-}
-.playlist:hover, .playlists-active {
-    background-position: center 7px;
-    height: 87px;
-}
-.exams {
-    background-position: center 7px;
-    height: 87px;
-}
-.exams:hover, .exams-active {
-    background-position: center 7px;
-    height: 87px;
-}
+
 .units {
     background: url("../../images/distributed/units-icon.png") no-repeat;
     background-position: center 7px;
@@ -240,14 +223,7 @@ a:hover {
     background-position: center 7px;
     height: 87px;
 }
-.learn {
-    background-position: center 7px;
-    height: 87px;
-}
-.learn:hover, .learn-active {
-    background-position: center 7px;
-    height: 87px;
-}
+
 /********* End Sub-Navigation bar **********/
 
 
@@ -260,7 +236,7 @@ a:hover {
 }
 .manage-nav ul {
     padding-left: 1%;
-    height: 87px;
+    margin-bottom: -1px;
 }
 .manage-nav li {
     background-color: #5AA685;
@@ -303,6 +279,20 @@ a:hover {
 .manage-nav span.icon {
     font-size: 40pt;
 }
+.top-level-active {
+    padding-right: 0px !important;
+    margin-right: 7px;
+    background-color: white;
+    color: #5AA685;
+    border-top: 2px solid #eee;
+    border-right: 2px solid #eee;
+    border-left: 2px solid #eee;
+    border-radius: 5px 15px 0 0;
+    -webkit-transition: all 80ms ease-out;
+    -moz-transition: all 80ms ease-out;
+    -o-transition: all 80ms ease-out;
+    transition: all 80ms ease-out;
+} 
 .active-nav {
     color: #405D32 !important;
     background-color: white !important;

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -276,20 +276,7 @@ a:hover {
 .manage-nav span.icon {
     font-size: 40pt;
 }
-/*.top-level-active {
-    padding-right: 0px !important;
-    margin-right: 7px;
-    background-color: white;
-    color: #5AA685;
-    border-top: 2px solid #eee;
-    border-right: 2px solid #eee;
-    border-left: 2px solid #eee;
-    border-radius: 5px 15px 0 0;
-    -webkit-transition: all 80ms ease-out;
-    -moz-transition: all 80ms ease-out;
-    -o-transition: all 80ms ease-out;
-    transition: all 80ms ease-out;
-} */
+
 .active-nav {
     color: #405D32 !important;
     background-color: white !important;

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -204,7 +204,7 @@
                                 </a>
                               </li>
                             {% endif %}
-                            {% if request.is_admin and not request.session.facility_user.facility %}
+                            {% if request.is_admin and not request.session.facility_user.facility and not is_config_package_nalanda %}
                               {# Teach for admins => coachreports #}
                               <li class="{% block teach_active_admins %}{% endblock teach_active_admins %}">
                                 <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="admin-only">

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -204,10 +204,10 @@
                                 </a>
                               </li>
                             {% endif %}
-                            {% if request.is_django_user and not is_config_package_nalanda %}
+                            {% if request.is_admin and not request.session.facility_user.facility %}
                               {# Teach for admins => coachreports #}
                               <li class="{% block teach_active_admins %}{% endblock teach_active_admins %}">
-                                <a href="{% url 'tabular_view' %}" id="nav_coachreports">
+                                <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="admin-only">
                                   {% trans "Teach" %}
                                 </a>
                               </li>
@@ -225,13 +225,11 @@
 
                             <!-- For logged in teachers -->
                             {# Teach for teachers => coachreports #}
-                            {% if request.is_admin %}
                             <li class="{% block teach_active_teachers %}{% endblock teach_active_teachers %}">
                               <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="teacher-only">
                                 {% trans "Teach" %}
                               </a>
                             </li>
-                            {% endif %}
 
                             {# Manage for teachers => facility management #}
                             {% if request.session.facility_user.facility %}

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -196,7 +196,7 @@
                             <!-- End for all users -->
 
                             <!-- For logged in admins -->
-                            {% if is_config_package_nalanda %}
+                            {% if is_config_package_nalanda and not request.session.facility_user.facility %}
                               {# Teach for admins => assigning playlists #}
                               <li class="{% block teach_active_admins-nalanda %}{% endblock teach_active_admins-nalanda %}">
                                 <a href="{% url 'assign_playlists' %}" id="nav_coachreports" class="admin-only">
@@ -204,10 +204,10 @@
                                 </a>
                               </li>
                             {% endif %}
-                            {% if request.is_django_user %}
+                            {% if request.is_django_user and not is_config_package_nalanda %}
                               {# Teach for admins => coachreports #}
                               <li class="{% block teach_active_admins %}{% endblock teach_active_admins %}">
-                                <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="admin-only">
+                                <a href="{% url 'tabular_view' %}" id="nav_coachreports">
                                   {% trans "Teach" %}
                                 </a>
                               </li>
@@ -216,7 +216,7 @@
                             {# Manage for admins => zone control panel #}
                             {% if request.is_django_user %}
                             <li class="{% block manage_active_admins %}{% endblock manage_active_admins %}">
-                              <a href="{% url 'zone_redirect' %}" id="manage" class="">
+                              <a href="{% url 'zone_redirect' %}" id="manage" class="admin-only">
                                 {% trans "Manage" %}
                               </a>
                             </li>
@@ -225,7 +225,7 @@
 
                             <!-- For logged in teachers -->
                             {# Teach for teachers => coachreports #}
-                            {% if request.is_admin and not request.is_django_admin %}
+                            {% if request.is_admin %}
                             <li class="{% block teach_active_teachers %}{% endblock teach_active_teachers %}">
                               <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="teacher-only">
                                 {% trans "Teach" %}

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -165,7 +165,7 @@
                           </div>
                       </div>
                       <div class="collapse navbar-collapse">
-                          <ul class="nav navbar-nav navbar-right nav-tabs" role="tablist">
+                          <ul class="nav navbar-nav navbar-right nav-tabs ka-nav" role="tablist">
                               <div class="visible-xs">
                                   <li id="search_input">
                                       <form class="navbar-form " action="{% url 'search' %}" method="get"  role="search">

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -196,7 +196,7 @@
                             <!-- End for all users -->
 
                             <!-- For logged in admins -->
-                            {% if is_config_package_nalanda and not request.session.facility_user.facility %}
+                            {% if request.is_admin and is_config_package_nalanda and not request.session.facility_user.facility %}
                               {# Teach for admins => assigning playlists #}
                               <li class="{% block teach_active_admins-nalanda %}{% endblock teach_active_admins-nalanda %}">
                                 <a href="{% url 'assign_playlists' %}" id="nav_coachreports" class="admin-only">

--- a/kalite/distributed/templates/distributed/base_manage.html
+++ b/kalite/distributed/templates/distributed/base_manage.html
@@ -10,14 +10,15 @@
 {% endblock i18n_do_not_translate %}
 
 {% block subnavbar %}
+    
     <div class="manage-nav logged-in-only">
-        <ul>
+        <ul class="nav nav-tabs">
             {% if request.session.facility_user.facility.id %}
-                    <li class="teacher-only users {% block user_active %}{% endblock user_active %}"><a href="{% url 'facility_management' zone_id=None facility_id=request.session.facility_user.facility.id %}" title="{% trans 'Manage Users' %}"><div><span class="icon icon-uniE606"></span><br/>{% trans "Users" %}</div></a></li>
+                    <li role="presentation" class="teacher-only users {% block user_active %}{% endblock user_active %}"><a href="{% url 'facility_management' zone_id=None facility_id=request.session.facility_user.facility.id %}" title="{% trans 'Manage Users' %}"><div><span class="icon icon-uniE606"></span><br/>{% trans "Users" %}</div></a></li>
             {% endif %}
-            <li class="facility {% block facility_active %}{% endblock facility_active %}"><a href="{% url 'zone_management' zone_id=None %}" title="{% trans 'Manage Facilities' %}"><div><span class="icon icon-uniE603"></span><br/>{% trans "Facilities" %}</div></a></li>
-            <li class="video {% block video_active %}{% endblock video_active %}"><a href="{% url 'update_videos' %}" title="{% trans 'Update this server with new videos and languages' %}"><div><span class="icon icon-uniE610"></span><br/>{% trans "Videos" %}</div></a></li>
-            <li class="languages {% block languages_active %}{% endblock languages_active %}"><a href="{% url 'update_languages' %}"><div><span class="icon icon-uniE600"></span><br/>{% trans "Language" %}</div></a></li>
+            <li role="presentation" class="facility {% block facility_active %}{% endblock facility_active %}"><a href="{% url 'zone_management' zone_id=None %}" title="{% trans 'Manage Facilities' %}"><div><span class="icon icon-uniE603"></span><br/>{% trans "Facilities" %}</div></a></li>
+            <li role="presentation" class="video {% block video_active %}{% endblock video_active %}"><a href="{% url 'update_videos' %}" title="{% trans 'Update this server with new videos and languages' %}"><div><span class="icon icon-uniE610"></span><br/>{% trans "Videos" %}</div></a></li>
+            <li role="presentation" class="languages {% block languages_active %}{% endblock languages_active %}"><a href="{% url 'update_languages' %}"><div><span class="icon icon-uniE600"></span><br/>{% trans "Language" %}</div></a></li>
         </ul>
     </div>
 {% endblock subnavbar %}

--- a/kalite/distributed/templates/distributed/base_manage.html
+++ b/kalite/distributed/templates/distributed/base_manage.html
@@ -5,13 +5,13 @@
 {% load my_filters %}
 
 {% block i18n_do_not_translate %}
-    {% block manage_active_teachers %}active top-level-active{% endblock manage_active_teachers %}
-    {% block manage_active_admins %}active top-level-active{% endblock manage_active_admins %}
+    {% block manage_active_teachers %}active{% endblock manage_active_teachers %}
+    {% block manage_active_admins %}active{% endblock manage_active_admins %}
 {% endblock i18n_do_not_translate %}
 
 {% block subnavbar %}
-    
-    <div class="manage-nav logged-in-only">
+
+    <div class="manage-nav logged-in-only admin-only">
         <ul class="nav nav-tabs">
             {% if request.session.facility_user.facility.id %}
                     <li role="presentation" class="teacher-only users {% block user_active %}{% endblock user_active %}"><a href="{% url 'facility_management' zone_id=None facility_id=request.session.facility_user.facility.id %}" title="{% trans 'Manage Users' %}"><div><span class="icon icon-uniE606"></span><br/>{% trans "Users" %}</div></a></li>

--- a/kalite/distributed/templates/distributed/base_manage.html
+++ b/kalite/distributed/templates/distributed/base_manage.html
@@ -5,8 +5,8 @@
 {% load my_filters %}
 
 {% block i18n_do_not_translate %}
-    {% block manage_active_teachers %}active{% endblock manage_active_teachers %}
-    {% block manage_active_admins %}active{% endblock manage_active_admins %}
+    {% block manage_active_teachers %}active top-level-active{% endblock manage_active_teachers %}
+    {% block manage_active_admins %}active top-level-active{% endblock manage_active_admins %}
 {% endblock i18n_do_not_translate %}
 
 {% block subnavbar %}

--- a/kalite/distributed/templates/distributed/base_teach.html
+++ b/kalite/distributed/templates/distributed/base_teach.html
@@ -5,8 +5,8 @@
 {% load my_filters %}
 
 {% block i18n_do_not_translate %}
-    {% block teach_active_teachers %}active{% endblock teach_active_teachers %}
-    {% block teach_active_admins %}active{% endblock teach_active_admins %}
+    {% block teach_active_teachers %}active top-level-active{% endblock teach_active_teachers %}
+    {% block teach_active_admins %}active top-level-active{% endblock teach_active_admins %}
 {% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{block.super}}{% endblock headcss %}

--- a/kalite/distributed/templates/distributed/base_teach.html
+++ b/kalite/distributed/templates/distributed/base_teach.html
@@ -5,8 +5,8 @@
 {% load my_filters %}
 
 {% block i18n_do_not_translate %}
-    {% block teach_active_teachers %}active top-level-active{% endblock teach_active_teachers %}
-    {% block teach_active_admins %}active top-level-active{% endblock teach_active_admins %}
+    {% block teach_active_teachers %}active{% endblock teach_active_teachers %}
+    {% block teach_active_admins %}active{% endblock teach_active_admins %}
 {% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{block.super}}{% endblock headcss %}

--- a/kalite/distributed/templates/distributed/coachreport.html
+++ b/kalite/distributed/templates/distributed/coachreport.html
@@ -6,15 +6,4 @@
 
 {% block headcss %}{{block.super}}{% endblock headcss %}
 
-{% block subnavbar %}{{block.super}}
-
-
-<div class="subnav">
-    <ul class="nav">
-        <li class="progress-tab {% block coachnav %}{% endblock coachnav %}"><a class="{% block progress_active %}{% endblock progress_active %}" href="{% url 'tabular_view' %}"><img src="{% static "images/coachreports/progress.png" %}"><span>{% trans "Progress" %}<br>by {% trans "Topic" %}</span></a></li>
-        <li class="effort-tab"><a class="{% block effort_active %}{% endblock effort_active %}" href="{% url 'scatter_view' %}"><img src="{% static "images/coachreports/effort.png" %}"><span>{% trans "Effort versus Achievement" %}</span></a></li>
-        <li class="mastery-tab"><a class="{% block mastery_active %}{% endblock mastery_active %}" href="{% url 'timeline_view' %}"><img src="{% static "images/coachreports/mastery.png" %}"><span>{% trans "Mastery" %}<br>{% trans "over Time" %}</span></a></li>
-    </ul>
-</div>
-
-{% endblock subnavbar %}
+{% block subnavbar %}{{block.super}}{% endblock subnavbar %}

--- a/kalite/distributed/templates/distributed/homepage.html
+++ b/kalite/distributed/templates/distributed/homepage.html
@@ -3,8 +3,9 @@
 {% load i18n %}
 {% load kalite_staticfiles %}
 
-{% block home_active %}active{% endblock home_active %}
-
+{% block i18n_do_not_translate %}
+    {% block home_active %}active{% endblock home_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/distributed/homepage.css' %}">

--- a/kalite/distributed/templates/distributed/learn.html
+++ b/kalite/distributed/templates/distributed/learn.html
@@ -3,9 +3,10 @@
 
 {% block title %}{% trans "Learn" %}{% endblock title %}
 
-{% block learn_active %}active{% endblock learn_active %}
-{% block learn_subnav_active %}learn-active active-tab active-nav{% endblock learn_subnav_active %}
-
+{% block i18n_do_not_translate %}
+    {% block learn_active %}active{% endblock learn_active %}
+    {% block learn_subnav_active %}learn-active active-tab active-nav{% endblock learn_subnav_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
 

--- a/kalite/distributed/templates/distributed/perseus.html
+++ b/kalite/distributed/templates/distributed/perseus.html
@@ -2,7 +2,9 @@
 {% load i18n %}
 {% load kalite_staticfiles %}
 
-{% block practice_active %}active{% endblock practice_active %}
+{% block i18n_do_not_translate %}
+    {% block practice_active %}active{% endblock practice_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'perseus/ke/css/khan-exercise.css' True %}">

--- a/kalite/facility/templates/facility/facility.html
+++ b/kalite/facility/templates/facility/facility.html
@@ -12,9 +12,7 @@
 {% endblock title %}
 
 {% block i18n_do_not_translate %}
-    {% block facility_active %}facility-active active-tab active-nav{% endblock facility_active %}
-    {% block update_active %}active{% endblock update_active %}
-    {% block users_active %}active{% endblock %}
+    {% block facility_active %}active{% endblock facility_active %}
 {% endblock i18n_do_not_translate %}
 
 {% block headcss %}
@@ -183,6 +181,7 @@
 {% block content %}
 
     {{ block.super }}
+
  
     <h3 class="no-margin-top">{% if form.instance.id %}{% trans "Edit a facility" %}{% else %}{% trans "Add a new Facility" %}{% endif %}</h3>
     <div id="id_direc_no_map">{% trans "Please enter the following information about your facility. Please enter a detailed address, because knowing where you are in the world allows us to better plan for future deployments and partnerships." %}</div>

--- a/kalite/facility/templates/facility/facility_selection.html
+++ b/kalite/facility/templates/facility/facility_selection.html
@@ -24,7 +24,8 @@
 
 
 {% block content %}
-{% block manage_nav %}{{block.super}}{% endblock manage_nav %}
+{{% block manage_nav %}{{block.super}}{% endblock manage_nav %}}
+{% block facility_active %}active{% endblock facility_active %}
     {{ path_template }}
     <div id="facility_list_container">
         <section id="facility_list">

--- a/kalite/facility/templates/facility/facility_user.html
+++ b/kalite/facility/templates/facility/facility_user.html
@@ -4,7 +4,6 @@
 {% block title %}{% trans title %}{% endblock title %}
 
 {% block i18n_do_not_translate %}
-    {% block user_active %}user-active active-tab active-nav{% endblock user_active %}
     {% block users_active %}active{% endblock %}
     {% block signup_active %}active{% endblock signup_active %}
 {% endblock i18n_do_not_translate %}

--- a/kalite/playlist/templates/playlist/assign_playlists.html
+++ b/kalite/playlist/templates/playlist/assign_playlists.html
@@ -9,7 +9,7 @@
 {% block teacher_active %}active{% endblock teacher_active %}
 {% block assign_playlists_active %}active{% endblock assign_playlists_active %}
 {% block teach_active_admins-nalanda %}active{% endblock teach_active_admins-nalanda %}
-{% block i18n_do_not_translate %}
+{% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static 'css/playlist/assign_playlists.css' %}">

--- a/kalite/playlist/templates/playlist/assign_playlists.html
+++ b/kalite/playlist/templates/playlist/assign_playlists.html
@@ -3,11 +3,12 @@
 {% load i18n %}
 {% load kalite_staticfiles %}
 
+
 {% block home_active %}active{% endblock home_active %}
 {% block playlist_active %}playlists-active active-tab active-nav{% endblock playlist_active %}
 {% block teacher_active %}active{% endblock teacher_active %}
-{% block admin_active %}active{% endblock admin_active %}
 {% block assign_playlists_active %}active{% endblock assign_playlists_active %}
+{% block teach_active_admins-nalanda %}active{% endblock teach_active_admins-nalanda %}
 
 {% block headcss %}{{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static 'css/playlist/assign_playlists.css' %}">
@@ -36,6 +37,7 @@
 {% endblock headjs %}
 
 {% block content %}
+{% block subnavbar %}{{block.super}}{% endblock subnavbar %}
   <div class="container">
     <div class="row">
       <div class="col-xs-12">

--- a/kalite/playlist/templates/playlist/assign_playlists.html
+++ b/kalite/playlist/templates/playlist/assign_playlists.html
@@ -4,11 +4,11 @@
 {% load kalite_staticfiles %}
 
 {% block i18n_do_not_translate %}
-{% block home_active %}active{% endblock home_active %}
-{% block playlist_active %}playlists-active active-tab active-nav{% endblock playlist_active %}
-{% block teacher_active %}active{% endblock teacher_active %}
-{% block assign_playlists_active %}active{% endblock assign_playlists_active %}
-{% block teach_active_admins-nalanda %}active{% endblock teach_active_admins-nalanda %}
+  {% block home_active %}active{% endblock home_active %}
+  {% block playlist_active %}playlists-active active-tab active-nav{% endblock playlist_active %}
+  {% block teacher_active %}active{% endblock teacher_active %}
+  {% block assign_playlists_active %}active{% endblock assign_playlists_active %}
+  {% block teach_active_admins-nalanda %}active{% endblock teach_active_admins-nalanda %}
 {% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/playlist/templates/playlist/assign_playlists.html
+++ b/kalite/playlist/templates/playlist/assign_playlists.html
@@ -3,12 +3,13 @@
 {% load i18n %}
 {% load kalite_staticfiles %}
 
-
+{% block i18n_do_not_translate %}
 {% block home_active %}active{% endblock home_active %}
 {% block playlist_active %}playlists-active active-tab active-nav{% endblock playlist_active %}
 {% block teacher_active %}active{% endblock teacher_active %}
 {% block assign_playlists_active %}active{% endblock assign_playlists_active %}
 {% block teach_active_admins-nalanda %}active{% endblock teach_active_admins-nalanda %}
+{% block i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static 'css/playlist/assign_playlists.css' %}">

--- a/kalite/student_testing/templates/student_testing/test_list.html
+++ b/kalite/student_testing/templates/student_testing/test_list.html
@@ -3,9 +3,11 @@
 {% load i18n %}
 {% load kalite_staticfiles %}
 
-{% block exams-active %}exams-active active-tab active-nav{% endblock exams-active %}
-{% block teacher_active %}active{% endblock teacher_active %}
-{% block admin_active %}active{% endblock admin_active %}
+{% block i18n_do_not_translate %}
+    {% block exams-active %}exams-active active-tab active-nav{% endblock exams-active %}
+    {% block teacher_active %}active{% endblock teacher_active %}
+    {% block admin_active %}active{% endblock admin_active %}
+{% endblock i18n_do_not_translate %}
 
 {% block title %}{% trans "Tests" %}{{ block.super }}{% endblock %}
 

--- a/kalite/updates/templates/updates/update_languages.html
+++ b/kalite/updates/templates/updates/update_languages.html
@@ -3,7 +3,7 @@
 {% load staticfiles %}
 
 {% block i18n_do_not_translate %}
-    {% block languages_active %}languages-active active-tab active-nav{% endblock languages_active %}
+    {% block languages_active %}active active-tab active-nav{% endblock languages_active %}
     {% block users_active %}active{% endblock users_active %}
     {% block manage_active %}active{% endblock manage_active %}
 {% endblock i18n_do_not_translate %}

--- a/kalite/updates/templates/updates/update_software.html
+++ b/kalite/updates/templates/updates/update_software.html
@@ -6,7 +6,7 @@
 {% block title %}{% trans "Update Software" %}{% endblock %}
 
 {% block i18n_do_not_translate %}
-    {% block facility_active %}facility-active active-tab active-nav{% endblock facility_active %}
+    {% block facility_active %}active{% endblock facility_active %}
 {% endblock i18n_do_not_translate %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/updates/templates/updates/update_videos.html
+++ b/kalite/updates/templates/updates/update_videos.html
@@ -6,7 +6,7 @@
 {% block i18n_do_not_translate %}
     {% block users_active %}active{% endblock users_active %}
     {% block manage_active %}active{% endblock manage_active %}
-    {% block video_active %}video-active active-tab active-nav{% endblock video_active %}
+    {% block video_active %}active{% endblock video_active %}
 {% endblock i18n_do_not_translate %}
 
 {% block title %}{% trans "Update Videos" %}{% endblock %}


### PR DESCRIPTION
Pushing these changes now so that it's easier to work with making the second level navigation under teach and manage responsive. 

Reference this issue:
https://github.com/learningequality/ka-lite/issues/3168#issuecomment-76888913