### PR TITLE
Move `subtitle` css styles to be used by all coach reports templates instead of just the tabular report.

### DIFF
--- a/kalite/coachreports/static/css/coachreports/base.css
+++ b/kalite/coachreports/static/css/coachreports/base.css
@@ -33,3 +33,8 @@
         margin-left: 0px;
     }
 }
+
+.subtitle {
+    font-size: 1.15em;
+    font-weight: bold;
+}

--- a/kalite/coachreports/static/css/coachreports/tabular_view.css
+++ b/kalite/coachreports/static/css/coachreports/tabular_view.css
@@ -14,11 +14,6 @@
     width: 100%;
 }
 
-.subtitle {
-    font-size: 1.15em;
-    font-weight: bold;
-}
-
 .subtitle.error {
     margin-left: 4px;
     margin-top: 15px;

--- a/kalite/coachreports/templates/coachreports/base_d3_visualization.html
+++ b/kalite/coachreports/templates/coachreports/base_d3_visualization.html
@@ -40,9 +40,6 @@
             width: 900px;
             height: 450px;
         }
-        .subtitle {
-            float: left;
-        }
         #summary {
             border: 1px black solid;
             position: absolute;


### PR DESCRIPTION
Hi @MCGallaspy - this fixes #3189.

I've moved the `subtitle` css style into the `coachreports/base.css` so that all the other reports uses the same style.  See screenshot gif below.

![ka-lite](https://cloud.githubusercontent.com/assets/175580/6539605/36ff7d2a-c4b3-11e4-92eb-8805ebd6e767.gif)

