### PR TITLE
fixing bug #2993-Adding hours as a time unit next to column name login time 

### DIFF
--- a/kalite/control_panel/templates/control_panel/partials/_coaches_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_coaches_table.html
@@ -40,7 +40,7 @@
                                 <th>{% trans "Coach" %}</th>
                                 <th>{% trans "Edit" %}</th>
                                 <th>{% trans "Logins" %}</th>
-                                <th>{% trans "Login Time" %}</th>
+                                <th>{% trans "Login Time(in hrs)" %}</th>
                                 <th>{% trans "Coach Report Views" %}</th>
                             </tr>
                         </thead>

--- a/kalite/control_panel/templates/control_panel/partials/_group_summary.html
+++ b/kalite/control_panel/templates/control_panel/partials/_group_summary.html
@@ -6,7 +6,7 @@
 <dd>{{ group_data.total_users }}</dd>
 <dt>{% trans "Logins" %}</dt>
 <dd>{{ group_data.total_logins }}</dd>
-<dt>{% trans "Login Time" %}</dt>
+<dt>{% trans "Login Time(in hrs)" %}</dt>
 <dd>{{ group_data.total_hours|floatformat }}</dd>
 <dt>{% trans "Videos Viewed" %}</dt>
 <dd>{{ group_data.total_videos }}</dd>

--- a/kalite/control_panel/templates/control_panel/partials/_groups_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_groups_table.html
@@ -38,7 +38,7 @@
                                 <th>{% trans "Coach" %}</th>
                                 <th>{% trans "# Learners" %}</th>
                                 <th>{% trans "Logins" %}</th>
-                                <th>{% trans "Login Time" %}</th>
+                                <th>{% trans "Login Time(in hrs)" %}</th>
                                 <th>{% trans "Videos Viewed" %}</th>
                                 <th>{% trans "Exercises Completed" %}</th>
                                 <th>{% trans "Mastery " %}</th>

--- a/kalite/control_panel/templates/control_panel/partials/_students_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_students_table.html
@@ -53,7 +53,7 @@
                         <th>{% trans "Coach" %}</th>
                         <th>{% trans "Group" %}</th>
                         <th>{% trans "Logins" %}</th>
-                        <th>{% trans "Login Time" %}</th>
+                        <th>{% trans "Login Time(in hrs)" %}</th>
                         <th>{% trans "Videos Viewed" %}</th>
                         <th>{% trans "Exercises Completed" %}</th>
                         <th>{% trans "Mastery" %}</th>


### PR DESCRIPTION
Bug Fix for 
No "Login Time" units #2993
Instead of appending hrs to the time and thereby violating the string freeze, i have added the words 'in hrs' to the column name 'Login time' itself. This makes the units used clear and does not violate string freeze.
I have changed the string 'Login time' to 'Login time(in hrs)' in the  files _coaches_table.html, _groups_table.html, _group_summary.html,_students_table.html located in ka-lite/control_panel/templates/control_panel/partials
![screenshot from 2015-03-08 06 02 17](https://cloud.githubusercontent.com/assets/8834964/6546180/23b3703c-c567-11e4-935f-701d8cd5b8aa.png)
![screenshot from 2015-03-08 07 47 07](https://cloud.githubusercontent.com/assets/8834964/6546185/5973de1e-c567-11e4-9174-7e191acb3565.png)
I have tested it on my local machine and the result is shown in the screenshot.

Fixes #2993 

