### PR TITLE
Properly update statusModel points

### DIFF
--- a/kalite/distributed/static/js/distributed/content/views.js
+++ b/kalite/distributed/static/js/distributed/content/views.js
@@ -199,7 +199,7 @@ window.ContentPointsView = BaseView.extend({
 
     render: function() {
         this.$el.html(this.template(this.model.attributes));
-        statusModel.set("newpoints", this.model.get("points") - this.starting_points);
+        statusModel.update_total_points(this.model.get("points") - this.starting_points);
         this.starting_points = this.model.get("points");
     }
 });

--- a/kalite/distributed/static/js/distributed/distributed-server.js
+++ b/kalite/distributed/static/js/distributed/distributed-server.js
@@ -101,7 +101,7 @@ var StatusModel = Backbone.Model.extend({
     },
 
     update_total_points: function(points) {
-        points = points || 0
+        points = points || 0;
         // add the points that existed at page load and the points earned since page load, to get the total current points
         this.set("points", this.get("points") + points);
     }

--- a/kalite/distributed/static/js/distributed/distributed-server.js
+++ b/kalite/distributed/static/js/distributed/distributed-server.js
@@ -56,7 +56,6 @@ var StatusModel = Backbone.Model.extend({
 
     defaults: {
         points: 0,
-        newpoints: 0,
         client_server_time_diff: 0
     },
 
@@ -70,8 +69,6 @@ var StatusModel = Backbone.Model.extend({
         this.loaded = this.fetch();
 
         this.loaded.then(this.after_loading);
-
-        this.listenTo(this, "change:newpoints", this.update_total_points);
 
     },
 
@@ -101,13 +98,12 @@ var StatusModel = Backbone.Model.extend({
             $('.navbar-right').show();
         });
 
-        this.update_total_points();
-
     },
 
-    update_total_points: function() {
+    update_total_points: function(points) {
+        points = points || 0
         // add the points that existed at page load and the points earned since page load, to get the total current points
-        this.set("points", this.get("points") + this.get("newpoints"));
+        this.set("points", this.get("points") + points);
     }
 
 });

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -972,7 +972,7 @@ window.ExerciseQuizView = Backbone.View.extend({
                 });
                 purchased_model.save();
 
-                statusModel.set("newpoints", statusModel.get("newpoints") + this.points);
+                statusModel.update_total_points(statusModel.get("newpoints") + this.points);
             }
         }
 

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -530,7 +530,7 @@ window.ExercisePracticeView = Backbone.View.extend({
 
         // store the number of points that are currently in the ExerciseLog, so we can calculate the difference
         // once it changes, for updating the "total points" in the nav bar display
-        this.starting_points = this.log_model.get("points");
+        this.status_points = this.log_model.get("points");
 
         this.progress_view = new ExerciseProgressView({
             el: this.$(".exercise-progress-wrapper"),
@@ -651,7 +651,8 @@ window.ExercisePracticeView = Backbone.View.extend({
             this.log_model.save()
                 .then(function(data) {
                     // update the top-right point display, now that we've saved the points successfully
-                    window.statusModel.set("newpoints", self.log_model.get("points") - self.starting_points);
+                    window.statusModel.update_total_points(self.log_model.get("points") - self.status_points);
+                    self.status_points = self.log_model.get("points");
                 });
 
             this.$(".hint-reminder").hide(); // hide message about hints

--- a/kalite/store/static/js/store/views.js
+++ b/kalite/store/static/js/store/views.js
@@ -78,7 +78,7 @@ window.StoreWrapperView = Backbone.View.extend({
         this.purchased_items.add(purchased_model);
 
         // decrement the visible number of remaining points
-        statusModel.set("newpoints", statusModel.get("newpoints") - cost);
+        statusModel.update_total_points(-cost);
 
     }
 


### PR DESCRIPTION
Fixes #3186 

Summary of changes:
* Track how many points have been piled onto statusModel points
* Directly increase 'points' on statusModel

This seems to be a robust way of doing it (I thought it might be problematic when switching to and from different exercises, but this way of tracking it accounts for that).