### PR TITLE
Hotfix/2729 fetch translated exercises part 2

### DIFF
--- a/kalite/main/api_resources.py
+++ b/kalite/main/api_resources.py
@@ -2,14 +2,13 @@ import json
 from tastypie import fields
 from tastypie.resources import ModelResource, Resource
 from tastypie.exceptions import NotFound
-from django.utils.translation import ugettext as _
 from django.conf.urls import url
 from django.conf import settings
 
 from .models import VideoLog, ExerciseLog, AttemptLog, ContentLog
 
 from kalite.distributed.api_views import get_messages_for_api_calls
-from kalite.topic_tools import get_exercise_data, get_assessment_item_cache, get_content_data
+from kalite.topic_tools import get_exercise_data, get_assessment_item_data, get_content_data
 from kalite.shared.api_auth import UserObjectsOnlyAuthorization
 from kalite.facility.api_resources import FacilityUserResource
 
@@ -72,6 +71,7 @@ class ContentLogResource(ModelResource):
         }
         authorization = UserObjectsOnlyAuthorization()
 
+
 class VideoLogResource(ModelResource):
 
     user = fields.ForeignKey(FacilityUserResource, 'user')
@@ -84,6 +84,7 @@ class VideoLogResource(ModelResource):
             "user": ('exact', ),
         }
         authorization = UserObjectsOnlyAuthorization()
+
 
 class Exercise():
 
@@ -205,7 +206,8 @@ class AssessmentItemResource(Resource):
 
     def obj_get(self, bundle, **kwargs):
         id = kwargs.get("id", None)
-        assessment_item = get_assessment_item_cache().get(id, None)
+        # assessment_item = get_assessment_item_cache().get(id, None)
+        assessment_item = get_assessment_item_data(bundle.request, id)
         if assessment_item:
             return AssessmentItem(**assessment_item)
         else:

--- a/kalite/main/api_resources.py
+++ b/kalite/main/api_resources.py
@@ -205,13 +205,12 @@ class AssessmentItemResource(Resource):
         raise NotImplemented("Operation not implemented yet for assessment_items.")
 
     def obj_get(self, bundle, **kwargs):
-        id = kwargs.get("id", None)
-        # assessment_item = get_assessment_item_cache().get(id, None)
-        assessment_item = get_assessment_item_data(bundle.request, id)
+        assessment_item_id = kwargs.get("id", None)
+        assessment_item = get_assessment_item_data(bundle.request, assessment_item_id)
         if assessment_item:
             return AssessmentItem(**assessment_item)
         else:
-            raise NotFound('AssessmentItem with id %s not found' % id)
+            raise NotFound('AssessmentItem with id %s not found' % assessment_item_id)
 
     def obj_create(self, bundle, **kwargs):
         raise NotImplemented("Operation not implemented yet for assessment_items.")

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -514,8 +514,8 @@ def get_assessment_item_data(request, assessment_item_id=None):
         # dump the data for a proper json format.
         assessment_item['item_data'] = json.dumps(item_data)
 
-    except KeyError:
-        logging.error("There is something wrong with the format of the assessment items:%s" % KeyError)
+    except KeyError as e:
+        logging.error("Assessment item did not have the expected key %s. Assessment item: \n %s" % (e, assessment_item))
 
     return assessment_item
 

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -492,8 +492,27 @@ def get_assessment_item_data(request, assessment_item_id=None):
         return None
 
     # TODO (rtibbles): Enable internationalization for the assessment_items.
+    # logging.info('Assessment Item =>%s' % assessment_item)
+    # logging.info('Assessment Item type%s' % type(assessment_item["item_data"]))
+
+    item_data = json.loads(assessment_item['item_data'])
+    # logging.info("Json Loads Item Data =>%s" % item_data)
+    question_content = _(item_data['question']['content'])
+    answerarea_content = _(item_data['answerArea']['options']['content'])
+    hints_content = _(item_data['hints'][0]['content'])
+
+    item = item_data
+    item['question']['content'] = question_content
+    item['answerArea']['options']['content'] = answerarea_content
+    item['hints'][0]['content'] = hints_content
+
+    item = json.dumps(item)
+    assessment_item['item_data'] = item
+
+    # logging.info('New Assessment Item =>%s' % assessment_item)
 
     return assessment_item
+
 
 def get_content_data(request, content_id=None):
 
@@ -513,7 +532,6 @@ def get_content_data(request, content_id=None):
             messages.warning(request, _("This content was not found! You must login as an admin/coach to download the content."))
 
     return content
-
 
 
 def video_dict_by_video_id(flat_topic_tree=None):

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -492,9 +492,6 @@ def get_assessment_item_data(request, assessment_item_id=None):
         return None
 
     # TODO (rtibbles): Enable internationalization for the assessment_items.
-    # logging.info('Assessment Item =>%s' % assessment_item)
-    # logging.info('Assessment Item type%s' % type(assessment_item["item_data"]))
-
     item_data = json.loads(assessment_item['item_data'])
     # logging.info("Json Loads Item Data =>%s" % item_data)
     question_content = _(item_data['question']['content'])

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -496,7 +496,7 @@ def get_assessment_item_data(request, assessment_item_id=None):
         item_data = json.loads(assessment_item['item_data'])
         question_content = _(item_data['question']['content'])
         answerarea_content = item_data['answerArea']['options']['content']
-        if answerarea_content != "":
+        if answerarea_content:  # Not an empty string
             answerarea_content = _(answerarea_content)
 
         # Loop over contents for multiple hints.


### PR DESCRIPTION
Hi @aronasorman - this fixes #2729 with these notes from @jesumer 

**Central Server Requirements**

1. [Include the .po files from Khan Academy's Crowdin account during "update_language_packs".](https://github.com/fle-internal/ka-lite-central/pull/226)
1. This is required to get the latest translations but the above should do for our test
    * [Issue fix by adding --rebuild make option into update_language_packs command](https://github.com/fle-internal/ka-lite-central/pull/230)
1. make sure it's the same version as distributed

**Distributed Server Requirements**

1. make sure it's the same version as central

**To test**

At Central server:

1. Run `python manage.py update_language_packs -l de --no-srts --no-dubbed --no-kalite-trans --rebuild` command.
1. Check if this will get the proper updated mo.files from CrowdIn.(we can check this out to centralserver/_crowdin_cache zip file).

At Distributed:

1. If it is successful then go to the distributed browser.(NOTE: Make sure you've done the "setup" already).
1. Run `python manage.py languagepackdownload -l de --commandline`.
1. Go to the language page and set the language code to `de`.
1. Go to the exercises and try to test on some of the exercises.
1. Check the translated words.

**To test thru the Python shell** 
This is taken from https://github.com/fle-internal/ka-lite-central/pull/226#issuecomment-75382550

```python
from django.utils.translation import activate, ugettext as _

activate("de")
s = "What is <code>X</code>?"
_(s)
```

Which should display this:

```python
>>> from django.utils.translation import activate, ugettext as _
>>>
>>> activate("de")
>>> s = "What is <code>X</code>?"
>>> _(s)
'Was ist <code>X</code>?'
>>>
```

References:

1. [Official Khan Academy German translations on CrowdIn](https://crowdin.com/project/khanacademy/de)
2. [learn.math.algebra-basics.exercises.pot - 43%](https://crowdin.com/translate/khanacademy/30006/enus-de) -- Search for `What is <code>X</code>?` text as per example above.