### PR TITLE
Hotfix/2961 - Refactored some template classes, fixed pesky .faded-green-bg

### DIFF
--- a/kalite/control_panel/templates/control_panel/device_management.html
+++ b/kalite/control_panel/templates/control_panel/device_management.html
@@ -132,7 +132,7 @@
 
                 <table class="table">
                     <thead>
-                        <tr class="success">
+                        <tr class="header-footer-bg">
                             <th width="250px">{% trans "Sync Date" %}</th>
                             <th width="250px">{% trans "Device IP Address" %}</th>
                             <th width="200px">{% trans "# Models Uploaded" %}</th>

--- a/kalite/control_panel/templates/control_panel/partials/_coaches_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_coaches_table.html
@@ -35,7 +35,7 @@
                 <div class="table-responsive">
                     <table class="table selectable-table">
                         <thead>
-                            <tr class="success">
+                            <tr class="header-footer-bg">
                                 <th><input class="select-all" type="checkbox" value="#coaches"></th>
                                 <th>{% trans "Coach" %}</th>
                                 <th>{% trans "Edit" %}</th>

--- a/kalite/control_panel/templates/control_panel/partials/_device_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_device_table.html
@@ -20,7 +20,7 @@
         <div class="table-responsive">
             <table class="table table-hover table-bordered">
                 <thead>
-                    <tr class="success">
+                    <tr class="header-footer-bg">
                         <th>{% trans "Device name" %}</th>
                         <th>{% trans "# Times Synced" %}</th>
                         <th>{% trans "Last Sync" %}</th>

--- a/kalite/control_panel/templates/control_panel/partials/_facility_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_facility_table.html
@@ -17,7 +17,7 @@
             <div class="table-responsive">
                 <table class="table table-hover table-bordered">
                     <thead>
-                        <tr class="success">
+                        <tr class="header-footer-bg">
                             <th>{% trans "Facility Name" %}</th>
                             <th>{% trans "# Users" %}</th>
                             <th>{% trans "# Groups" %}</th>

--- a/kalite/control_panel/templates/control_panel/partials/_groups_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_groups_table.html
@@ -31,7 +31,7 @@
                 <div class="table-responsive">
                     <table class="table selectable-table">
                         <thead>
-                            <tr class="success">
+                            <tr class="header-footer-bg">
                                 <th><input class="select-all" type="checkbox" value="#groups" autocomplete="off"/></th>
                                 <th>{% trans "Group" %}</th>
                                 <th>{% trans "Edit" %}</th>

--- a/kalite/control_panel/templates/control_panel/partials/_students_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_students_table.html
@@ -46,7 +46,7 @@
         <div class="table-responsive">
             <table class="table selectable-table">
                  <thead>
-                    <tr class="success">
+                    <tr class="header-footer-bg">
                         <th><input class="select-all" type="checkbox" value="#students" autocomplete="off"/></th>
                         <th>{% trans "Learner Name" %}</th>
                         <th>{% trans "Edit" %}</th>

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -67,10 +67,9 @@ input[type="submit"] {
     border-top: 1px solid #999;
     border-bottom: none;
 }
-.faded-green-bg {
-    /*background: #c6d1ad; Previous color */
-    /*background: #CDE4B7; */ /* Also controls footer color */
-    /* temporary bloue from the footer */
+/* Controls background of header, footer and all elements with
+   the same colors across the site. */
+.header-footer-bg {
     background: #C4D7E3;
 }
 .kalite-navbar {

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -148,7 +148,7 @@
         <div id="wrapper">
 
             {# Header & Navbar #}
-            <div class="navbar kalite-navbar faded-green-bg">
+            <div class="navbar kalite-navbar header-footer-bg">
               <div class="container">
                   <div class="row">
                       <div class="navbar-header">

--- a/kalite/distributed/templates/distributed/partials/_footer.html
+++ b/kalite/distributed/templates/distributed/partials/_footer.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load i18n_filters %}
 
-<footer class="faded-green-bg">
+<footer class="header-footer-bg">
     <div class="container">
         <div class="row">
             <div class="col-xs-12">


### PR DESCRIPTION
#2961 can finally be closed. This PR contains some minor changes to the CSS. The light green table headers in the Manage tab now match the light blue header and footer. Took me a while to understand that the green color came from Bootstrap's CSS.

Now, changing the light blue in one CSS file will change the light blues across the entire site. Be sure to use the `.header-footer-bg` class wherever you want a background that matches the site header and footer. That's all it adds.