### PR TITLE
Add timestamp to html docs output format

### DIFF
--- a/sphinx-docs/conf.py
+++ b/sphinx-docs/conf.py
@@ -16,7 +16,7 @@ import sys
 import os
 
 # Will use pyvirtualdisplay if "true", but if unset or for any other value will not
-# os.environ['SPHINX_SS_USE_PVD'] = "true"
+#os.environ['SPHINX_SS_USE_PVD'] = "true"
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -157,7 +157,7 @@ html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = "%a, %d %b %Y %T %z"
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.


### PR DESCRIPTION
So that if we build the docs and distribute them separately, there's a clear version.