### PR TITLE
Move the translation codes inside the `custom` function.

### DIFF
--- a/kalite/distributed/custom_context_processors.py
+++ b/kalite/distributed/custom_context_processors.py
@@ -6,18 +6,20 @@ These include:
 * App settings, including version / build ID
 """
 from django.conf import settings
+from django.utils.translation import ugettext as _
 
 from kalite import version
 
-from django.utils.translation import ugettext as _
-
 channel_data = {}
-
-for key, value in settings.CHANNEL_DATA.items():
-    channel_data[key] = _(value)
 
 
 def custom(request):
+
+    # MUST: Translation must happen inside this function because it will NOT work if it is outside
+    # because that part of the code only runs once when this module is loaded/imported.
+    for key, value in settings.CHANNEL_DATA.items():
+        channel_data[key] = _(value)
+
     return {
         "central_server_host": settings.CENTRAL_SERVER_HOST,
         "securesync_protocol": settings.SECURESYNC_PROTOCOL,


### PR DESCRIPTION
Hi @aronasorman / @MCGallaspy - this fixes #3238.

I just moved the for loop to translate the channel data items inside the function so that translation happens for every function call.

Here's a .gif screenshot of it:
![ka-lite](https://cloud.githubusercontent.com/assets/175580/6593311/8408e586-c812-11e4-9fba-34d1b863b782.gif)
