### PR TITLE
Enable the language selector for students and teachers.

### DIFF
--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -256,17 +256,6 @@
                                 </a>
                               </li>
                             {% endif %}
-                            <li class="not-logged-in-only">
-                              {% if num_language_choices > 1 %}
-                              <select id="language_selector">
-                              {% for lang_code, lang_meta in language_choices.iteritems %}
-                                <option value="{{ lang_code }}" {% if lang_code == current_language %}selected{% endif %}>
-                                    {{ lang_code|get_language_name }}
-                                </option>
-                              {% endfor %}
-                              </select>
-                              {% endif %}
-                            </li>
                             <!-- Farthest right nav is logged in user dropdown -->
                             <li class="dropdown {% block help_active %}{% endblock help_active %}{% block progress_active %}{% endblock progress_active %}" id="user-name">
                               <a href="#" class="logged-in-only dropdown-toggle" data-toggle="dropdown">
@@ -301,6 +290,22 @@
                                   </a>
                                 </li>
                               </ul>
+                            </li>
+                            <!-- Language selection -->
+                            {% if request.session.facility_user.is_teacher %}
+                            <li class="teacher-only">
+                            {% else %}
+                            <li class="not-admin-only">
+                            {% endif %}
+                              {% if num_language_choices > 1 %}
+                              <select id="language_selector">
+                              {% for lang_code, lang_meta in language_choices.iteritems %}
+                                <option value="{{ lang_code }}" {% if lang_code == current_language %}selected{% endif %}>
+                                    {{ lang_code|get_language_name }}
+                                </option>
+                              {% endfor %}
+                              </select>
+                              {% endif %}
                             </li>
                           </ul>
                         </div>

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -291,13 +291,13 @@
                                 </li>
                               </ul>
                             </li>
-                            <!-- Language selection -->
+                            <!-- Language selection, admins do not need to see this. -->
                             {% if request.session.facility_user.is_teacher %}
-                            <li class="teacher-only">
+                              <li class="teacher-only">
                             {% else %}
-                            <li class="not-admin-only">
+                              <li class="not-admin-only">
                             {% endif %}
-                              {% if num_language_choices > 1 %}
+                            {% if num_language_choices > 1 %}
                               <select id="language_selector">
                               {% for lang_code, lang_meta in language_choices.iteritems %}
                                 <option value="{{ lang_code }}" {% if lang_code == current_language %}selected{% endif %}>
@@ -305,8 +305,9 @@
                                 </option>
                               {% endfor %}
                               </select>
-                              {% endif %}
+                            {% endif %}
                             </li>
+                            <!-- End: Language selection -->
                           </ul>
                         </div>
                   </div>


### PR DESCRIPTION
Hi @aronasorman - this fixes #3239 to Enable the language selector for students and teachers.

See .gif how it works:

![ka-lite](https://cloud.githubusercontent.com/assets/175580/6594476/a5cb4f88-c81c-11e4-8dea-1bd41ccfd57d.gif)
