### PR TITLE
Refactor so convert_urls function can be used elsewhere

### DIFF
--- a/kalite/contentload/management/commands/generate_assessment_zips.py
+++ b/kalite/contentload/management/commands/generate_assessment_zips.py
@@ -110,14 +110,15 @@ def localhosted_image_urls(items):
     # we copy so we make sure we don't modify the items passed in to this function
     newitems = copy.deepcopy(items)
 
-    url_to_replace = r'https?://[\w\.\-\/]+\/(?P<filename>[\w\.\-]+\.(png|gif|jpg))'
-
     for _, v in newitems.iteritems():
-        old_item_data = v['item_data']
-        v['item_data'] = re.sub(url_to_replace, _old_item_url_to_content_url, old_item_data)
+        v['item_data'] = convert_urls(v['item_data'])
 
     return newitems
 
+def convert_urls(string):
+    """ Convert urls in i18n strings into localhost urls. """
+    url_to_replace = r'https?://[\w\.\-\/]+\/(?P<filename>[\w\.\-]+\.(png|gif|jpg|JPEG|JPG))'
+    return re.sub(url_to_replace, _old_item_url_to_content_url, string)
 
 def _old_item_url_to_content_url(matchobj):
     return "/content/khan/%s" % matchobj.group("filename")

--- a/kalite/contentload/tests/generate_assessment_zips.py
+++ b/kalite/contentload/tests/generate_assessment_zips.py
@@ -8,6 +8,7 @@ from fle_utils.general import ensure_dir
 from mock import patch, MagicMock
 
 from django.core.management import call_command
+from django.test import TestCase
 
 import kalite.version as version
 from kalite.testing import KALiteTestCase
@@ -19,6 +20,17 @@ TEST_FIXTURES_DIR = os.path.join(os.path.dirname(__file__),
 ASSESSMENT_ITEMS_SAMPLE_PATH = os.path.join(TEST_FIXTURES_DIR,
                                             "assessment_items_sample.json")
 
+class TestUrlConversion(TestCase):
+    
+    def test_url_converted(self):
+        url_string = "A string with http://example.com/cat_pics.gif"
+        expected_string = "A string with /content/khan/cat_pics.gif"
+        self.assertEqual(expected_string, mod.convert_urls(url_string))
+    
+    def test_multiple_urls_in_one_string_converted(self):
+        url_string = "A string with http://example.com/cat_pics.JPEG http://example.com/cat_pics2.gif"
+        expected_string = "A string with /content/khan/cat_pics.JPEG /content/khan/cat_pics2.gif"
+        self.assertEqual(expected_string, mod.convert_urls(url_string))
 
 class GenerateAssessmentItemsCommandTests(KALiteTestCase):
 


### PR DESCRIPTION
Needed to resolve [an issue in the central server](https://github.com/fle-internal/ka-lite-central/issues/238).