### PR TITLE
Fixes 3227 get_uuid error on video exit

### DIFF
--- a/kalite/distributed/static/js/distributed/content/views.js
+++ b/kalite/distributed/static/js/distributed/content/views.js
@@ -181,7 +181,7 @@ window.ContentBaseView = BaseView.extend({
     },
 
     close: function() {
-        if (window.statusModel.get("is_logged_in")) {
+        if (window.statusModel.get("is_logged_in") && !window.statusModel.get("is_admin") ) {
             this.log_model.saveNow();
         }
         this.remove();


### PR DESCRIPTION
#3227 
When we exit from the video page, a video log is saved and we don't save that for admin.
So, added a check using window status model, if is_admin is true then don't save.
