### PR TITLE
Escape spaces in variable, use supported start command

### DIFF
--- a/scripts/add_systemstart_task.bat
+++ b/scripts/add_systemstart_task.bat
@@ -2,4 +2,4 @@
 set "SCRIPT_DIR=%~dp0"
 
 TITLE Adding task to start KA Lite at system start
-schtasks /create /tn "KALite" /tr "%SCRIPT_DIR%\start.bat" /sc onstart & pause
+schtasks /create /tn "KALite" /tr "\"%SCRIPT_DIR%..\bin\windows\kalite.bat\" start" /sc onstart & pause


### PR DESCRIPTION
If the SCRIPT_DIR variable has spaces in it, then it needs to be escaped. Tested in Windows 7, scheduled task runs fine. This issue exists in 0.12 too.