### PR TITLE
fixes bug 3204

### DIFF
--- a/kalite/coachreports/static/js/coachreports/student_progress.js
+++ b/kalite/coachreports/static/js/coachreports/student_progress.js
@@ -94,6 +94,7 @@ var PlaylistProgressView = Backbone.View.extend({
         this.$(".playlist-progress-details").slideToggle();
     }
 });
+var count=0;  //A variable to keep a count of the number of reports of quizes/videos that would be present in the student's progress report.
 
 var StudentProgressContainerView = Backbone.View.extend({
     // The containing view
@@ -101,10 +102,24 @@ var StudentProgressContainerView = Backbone.View.extend({
 
     initialize: function() {
         this.listenTo(this.collection, 'add', this.add_one);
+        this.count=0;
+        var self=this;
 
         this.render();
 
-        this.collection.fetch();
+        this.collection.fetch({
+                success: function() {
+                   
+                    self.count=self.collection.length;    //number of reports of quizes/videos
+                
+                     if(self.count==0)                    //if the student visits the my progress page before attempting any quizes/videos
+                          {
+				self.$el.html("<h>You have not started your learning journey yet.</h><br>Click on the LEARN button above to 						get started");
+				 
+                          }
+                    
+                }
+            });
     },
 
     render: function() {

--- a/kalite/coachreports/static/js/coachreports/student_progress.js
+++ b/kalite/coachreports/static/js/coachreports/student_progress.js
@@ -94,7 +94,6 @@ var PlaylistProgressView = Backbone.View.extend({
         this.$(".playlist-progress-details").slideToggle();
     }
 });
-var count=0;  //A variable to keep a count of the number of reports of quizes/videos that would be present in the student's progress report.
 
 var StudentProgressContainerView = Backbone.View.extend({
     // The containing view
@@ -102,24 +101,19 @@ var StudentProgressContainerView = Backbone.View.extend({
 
     initialize: function() {
         this.listenTo(this.collection, 'add', this.add_one);
-        this.count=0;
+        
         var self=this;
 
         this.render();
 
         this.collection.fetch({
                 success: function() {
-                   
-                    self.count=self.collection.length;    //number of reports of quizes/videos
-                
-                     if(self.count==0)                    //if the student visits the my progress page before attempting any quizes/videos
+                     if(self.collection.length==0)            //if the student visits the my progress page before attempting any quizes/videos
                           {
-				self.$el.html("<h>You have not started your learning journey yet.</h><br>Click on the LEARN button above to 						get started");
-				 
-                          }
-                    
-                }
-            });
+			      self.$el.html("<h>You have not started your learning journey yet.</h><br>Click on the LEARN button above to 						get started");
+		          }
+                       }
+                   });
     },
 
     render: function() {

--- a/kalite/coachreports/static/js/coachreports/student_progress.js
+++ b/kalite/coachreports/static/js/coachreports/student_progress.js
@@ -108,8 +108,7 @@ var StudentProgressContainerView = Backbone.View.extend({
 
         this.collection.fetch({
                 success: function() {
-                     if (self.collection.length == 0)         //if the student visits the my progress page before attempting any quizes/videos
-                          {
+                     if (self.collection.length == 0) {       //if the student visits the my progress page before attempting any quizes/videos
                               show_message("info", gettext("Click on the LEARN button above to get started on your learning journey."));
                               self.$el.html("");             //this is done to remove the 'Progress Report' header 
                           }

--- a/kalite/coachreports/static/js/coachreports/student_progress.js
+++ b/kalite/coachreports/static/js/coachreports/student_progress.js
@@ -108,10 +108,11 @@ var StudentProgressContainerView = Backbone.View.extend({
 
         this.collection.fetch({
                 success: function() {
-                     if(self.collection.length==0)            //if the student visits the my progress page before attempting any quizes/videos
+                     if (self.collection.length == 0)         //if the student visits the my progress page before attempting any quizes/videos
                           {
-			      self.$el.html("<h>You have not started your learning journey yet.</h><br>Click on the LEARN button above to 						get started");
-		          }
+                              show_message("info", gettext("Click on the LEARN button above to get started on your learning journey."));
+                              self.$el.html("");             //this is done to remove the 'Progress Report' header 
+                          }
                        }
                    });
     },


### PR DESCRIPTION
fixes this bug -https://github.com/learningequality/ka-lite/issues/3204
When a new student clicks on the progress report section without completing any quizes or videos, currently a blank screen is shown
![screenshot 114](https://cloud.githubusercontent.com/assets/8834964/6629773/bb65dda6-c937-11e4-8cd1-126b2561b90b.png)
I have checked to see if number of collections are zero are not after successful fetching..If number is zero, then i render a message to make it look better.
![screenshot 110](https://cloud.githubusercontent.com/assets/8834964/6629795/06428342-c938-11e4-8acc-b9a6b8ee3f1b.png)
if it is not zero then nothing is changed 
![screenshot 111](https://cloud.githubusercontent.com/assets/8834964/6629807/1cb8d072-c938-11e4-9281-db79cb53dedb.png)

