### PR TITLE
Input highlighting for exercises

### DIFF
--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -397,6 +397,13 @@ div.exercises-card {
     background-color: #5BDB44;
 }
 
+#selected-input {
+    border-color: #66afe9;
+    outline: 0;
+    -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6);
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075),0 0 8px rgba(102,175,233,.6);
+}
+
 .exercise-title-prefix {
     opacity: 0.3;
 }

--- a/kalite/distributed/static/js/distributed/software-keyboard.js
+++ b/kalite/distributed/static/js/distributed/software-keyboard.js
@@ -55,7 +55,7 @@ window.SoftwareKeyboardView = Backbone.View.extend({
         var inputIndex = 0;
 
         $(this.inputs).each(function (index) {
-            if ( $(this).attr("id") ) {
+            if ( $(this).attr("id") == "selected-input" ) {
                 input = $(this);
                 inputIndex = index;
             }


### PR DESCRIPTION
Fixes #3283 

Adds input highlighting for Perseus exercises so that keypad users will know which input they are entering.

![image](https://cloud.githubusercontent.com/assets/1680573/6643208/517b665e-c95f-11e4-94f0-b7f646c6c617.png)
