### PR TITLE
Destroys any existing tooltips when exercise view is closed.

### DIFF
--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -422,6 +422,7 @@ window.ExerciseView = Backbone.View.extend({
         if (this.related_video_view) {
             this.related_video_view.remove();
         }
+        this.$("input").qtip("destroy", /* immediate */ true);
         this.remove();
     }
 


### PR DESCRIPTION
Fixes #3286

Destroys any existing tooltips when an exercise_view is closed, and hence prevents phantom tooltips from floating around the screen.