### PR TITLE
Progress-bar readability improvement

### DIFF
--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -407,6 +407,14 @@ div.exercises-card {
     width: 100%;
 }
 
+.attempts .incorrect {
+    color: red;
+}
+
+.attempts .correct {
+    color: green;
+}
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
 .progress-points {
     width: 90%;
     text-align: center;
@@ -414,12 +422,12 @@ div.exercises-card {
     white-space: nowrap;
     font-size: 1.1em;
     padding: 4px 8px;
-    color: #414141;
+    color: #414141                                                                                                                                                                                                                                                                                                                                                                        ;
 }
 
 .practice-exercise-description {
     opacity: 0.5;
-    font-size: 0.7em;
+    font-size: 0.7em;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
 }
 
 .current-card #problemarea {

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -414,6 +414,7 @@ div.exercises-card {
     white-space: nowrap;
     font-size: 1.1em;
     padding: 4px 8px;
+    color: #414141;
 }
 
 .practice-exercise-description {

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -1162,7 +1162,7 @@ window.ExerciseProgressView = Backbone.View.extend({
         var attempt_text = "";
 
         this.collection.forEach(function(model) {
-                attempt_text = (model.get("correct") ? "<span style='color:green;'><b>&#10003;</b></span> " : "<span style='color:red;'>&#10007;</span> ") + attempt_text;
+                attempt_text = (model.get("correct") ? "<span class='correct'><b>&#10003;</b></span> " : "<span class='incorrect'>&#10007;</span> ") + attempt_text;
         });
 
         this.$(".attempts").html(attempt_text);

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -1162,7 +1162,7 @@ window.ExerciseProgressView = Backbone.View.extend({
         var attempt_text = "";
 
         this.collection.forEach(function(model) {
-                attempt_text = (model.get("correct") ? "<span><b>&#10003;</b></span> " : "<span>&#10007;</span> ") + attempt_text;
+                attempt_text = (model.get("correct") ? "<span style='color:green;'><b>&#10003;</b></span> " : "<span style='color:red;'>&#10007;</span> ") + attempt_text;
         });
 
         this.$(".attempts").html(attempt_text);


### PR DESCRIPTION
I have improved the readability of the progress-bar by changing the color of the score and the attempt icons.
Just some simple CSS changes.

Here is a screenshot.

![screenshot from 2015-03-14 05 45 06](https://cloud.githubusercontent.com/assets/6399612/6649311/4b713dc0-ca0d-11e4-8f5b-4267325d2c65.png)
