### PR TITLE
Assessment zip file handling

### DIFF
--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -169,7 +169,7 @@ class Command(BaseCommand):
             action='store_true',
             dest='force-assessment-item-dl',
             default=False,
-            help='Downloads assessment items from the url specified by settings.ASSESSMENT_ITEM_ZIP_URL, without interaction'),
+            help='Downloads assessment items from the url specified by settings.ASSESSMENT_ITEMS_ZIP_URL, without interaction'),
     )
 
     def handle(self, *args, **options):
@@ -284,13 +284,13 @@ class Command(BaseCommand):
         # download assessment items
         # This can take a long time and lead to Travis stalling. None of this is required for tests.
         if options['force-assessment-item-dl']:
-            call_command("unpack_assessment_zip", settings.ASSESSMENT_ITEM_ZIP_URL)
+            call_command("unpack_assessment_zip", settings.ASSESSMENT_ITEMS_ZIP_URL)
         elif not settings.RUNNING_IN_TRAVIS and options['interactive']:
             print("\nStarting in version 0.13, you will need an assessment items package in order to access many of the available exercises.")
             print("If you have an internet connection, you can download the needed package. Warning: this may take a long time!")
             print("If you have already downloaded the assessment items package, you can specify the file in the next step.")
             print("Otherwise, we will download it from {url}.".format(settings.ASSESSMENT_ITEMS_ZIP_URL))
-           
+
             if raw_input_yn("Do you wish to download the assessment items package now?"):
                 ass_item_filename = settings.ASSESSMENT_ITEMS_ZIP_URL
             elif raw_input_yn("Have you already downloaded the assessment items package?"):
@@ -302,9 +302,9 @@ class Command(BaseCommand):
                 logging.error("No assessment items package file given. You will need to download and unpack it later.")
             else:
                 call_command("unpack_assessment_zip", ass_item_filename)
-        else:        
+        else:
             logging.error("No assessment items package file given. You will need to download and unpack it later.")
-                
+
 
         # Individually generate any prerequisite models/state that is missing
         if not Settings.get("private_key"):

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -152,6 +152,11 @@ class Command(BaseCommand):
             dest='interactive',
             default=True,
             help='Run in non-interactive mode'),
+        make_option('-a', '--dl-assessment-items',
+            action='store_true',
+            dest='force-assessment-item-dl',
+            default=False,
+            help='Downloads assessment items from the url specified by settings.ASSESSMENT_ITEM_ZIP_URL, without interaction'),
     )
 
     def handle(self, *args, **options):
@@ -265,7 +270,9 @@ class Command(BaseCommand):
 
         # download assessment items
         # This can take a long time and lead to Travis stalling. None of this is required for tests.
-        if not settings.RUNNING_IN_TRAVIS and options['interactive']:
+        if options['force-assessment-item-dl']:
+            call_command("unpack_assessment_zip", settings.ASSESSMENT_ITEM_ZIP_URL)
+        elif not settings.RUNNING_IN_TRAVIS and options['interactive']:
             print("\nStarting in version 0.13, you will need an assessment items package in order to access many of the available exercises.")
             print("If you have an internet connection, you can download the needed package. Warning: this may take a long time!")
             print("If you have already downloaded the assessment items package, you can specify the file in the next step.")

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -44,7 +44,7 @@ def raw_input_yn(prompt):
         ans = raw_input("%s (yes or no) " % prompt.strip()).lower()
         if ans in ["yes", "no"]:
             break
-        logging.error("Please answer yes or no.\n")
+        logging.warning("Please answer yes or no.\n")
     return ans == "yes"
 
 
@@ -116,6 +116,7 @@ def get_assessment_items_filename():
             tmp = curdir
             curdir = pardir
             pardir = os.path.abspath(os.path.join(tmp, os.pardir))
+        return ""
 
     recommended_filename = find_recommended_file()
     prompt = "Please enter the filename of the assessment items package you have downloaded (%s): " % recommended_filename
@@ -289,7 +290,7 @@ class Command(BaseCommand):
             print("\nStarting in version 0.13, you will need an assessment items package in order to access many of the available exercises.")
             print("If you have an internet connection, you can download the needed package. Warning: this may take a long time!")
             print("If you have already downloaded the assessment items package, you can specify the file in the next step.")
-            print("Otherwise, we will download it from {url}.".format(settings.ASSESSMENT_ITEMS_ZIP_URL))
+            print("Otherwise, we will download it from {url}.".format(url=settings.ASSESSMENT_ITEMS_ZIP_URL))
 
             if raw_input_yn("Do you wish to download the assessment items package now?"):
                 ass_item_filename = settings.ASSESSMENT_ITEMS_ZIP_URL
@@ -299,11 +300,11 @@ class Command(BaseCommand):
                 ass_item_filename = None
 
             if not ass_item_filename:
-                logging.error("No assessment items package file given. You will need to download and unpack it later.")
+                logging.warning("No assessment items package file given. You will need to download and unpack it later.")
             else:
                 call_command("unpack_assessment_zip", ass_item_filename)
         else:
-            logging.error("No assessment items package file given. You will need to download and unpack it later.")
+            logging.warning("No assessment items package file given. You will need to download and unpack it later.")
 
 
         # Individually generate any prerequisite models/state that is missing

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -1,6 +1,7 @@
 """
 """
 import getpass
+import logging
 import os
 import re
 import shutil
@@ -43,7 +44,7 @@ def raw_input_yn(prompt):
         ans = raw_input("%s (yes or no) " % prompt.strip()).lower()
         if ans in ["yes", "no"]:
             break
-        sys.stderr.write("Please answer yes or no.\n")
+        logging.error("Please answer yes or no.\n")
     return ans == "yes"
 
 
@@ -51,11 +52,11 @@ def raw_input_password():
     while True:
         password = getpass.getpass("Password: ")
         if not password:
-            sys.stderr.write("\tError: password must not be blank.\n")
+            logging.error("\tError: password must not be blank.\n")
             continue
 
         elif password != getpass.getpass("Password (again): "):
-            sys.stderr.write("\tError: passwords did not match.\n")
+            logging.error("\tError: passwords did not match.\n")
             continue
         break
     return password
@@ -72,7 +73,7 @@ def get_username(username):
 
         username = raw_input("Username (leave blank to use '%s'): " % get_clean_default_username()) or get_clean_default_username()
         if not validate_username(username):
-            sys.stderr.write("\tError: Username must contain only letters, digits, and underscores, and start with a letter.\n")
+            logging.error("\tError: Username must contain only letters, digits, and underscores, and start with a letter.\n")
 
     return username
 
@@ -87,7 +88,7 @@ def get_hostname_and_description(hostname=None, description=None):
         prompt = "Please enter a name for this server%s: " % ("" if not default_hostname else (" (or, press Enter to use '%s')" % get_host_name()))
         hostname = raw_input(prompt) or default_hostname
         if not hostname:
-            sys.stderr.write("\tError: hostname must not be empty.\n")
+            logging.error("\tError: hostname must not be empty.\n")
         else:
             break
 
@@ -102,7 +103,7 @@ def get_assessment_items_filename():
             open(fn, "r").close()
             return True
         except IOError:
-            sys.stderr.write("Error: couldn't open the specified file: \"%s\"\n" % fn)
+            logging.error("Error: couldn't open the specified file: \"%s\"\n" % fn)
             return False
 
     prompt = "Please enter the filename of the assessment items package you have downloaded (leave blank to skip this step): "
@@ -158,46 +159,41 @@ class Command(BaseCommand):
             options["username"] = options["username"] or getattr(settings, "INSTALL_ADMIN_USERNAME", None) or get_clean_default_username()
             options["hostname"] = options["hostname"] or get_host_name()
 
-        sys.stdout.write("                                  \n")  # blank allows ansible scripts to dump errors cleanly.
-        sys.stdout.write("  _   __  ___    _     _ _        \n")
-        sys.stdout.write(" | | / / / _ \  | |   (_) |       \n")
-        sys.stdout.write(" | |/ / / /_\ \ | |    _| |_ ___  \n")
-        sys.stdout.write(" |    \ |  _  | | |   | | __/ _ \ \n")
-        sys.stdout.write(" | |\  \| | | | | |___| | ||  __/ \n")
-        sys.stdout.write(" \_| \_/\_| |_/ \_____/_|\__\___| \n")
-        sys.stdout.write("                                  \n")
-        sys.stdout.write("http://kalite.learningequality.org\n")
-        sys.stdout.write("                                  \n")
-        sys.stdout.write("         version %s\n" % VERSION)
-        sys.stdout.write("                                  \n")
+        print("                                  ")  # blank allows ansible scripts to dump errors cleanly.
+        print("  _   __  ___    _     _ _        ")
+        print(" | | / / / _ \  | |   (_) |       ")
+        print(" | |/ / / /_\ \ | |    _| |_ ___  ")
+        print(" |    \ |  _  | | |   | | __/ _ \ ")
+        print(" | |\  \| | | | | |___| | ||  __/ ")
+        print(" \_| \_/\_| |_/ \_____/_|\__\___| ")
+        print("                                  ")
+        print("http://kalite.learningequality.org")
+        print("                                  ")
+        print("         version %s" % VERSION)
+        print("                                  ")
 
         if sys.version_info >= (2,8) or sys.version_info < (2,6):
             raise CommandError("You must have Python version 2.6.x or 2.7.x installed. Your version is: %s\n" % sys.version_info)
 
         if options["interactive"]:
-            sys.stdout.write("--------------------------------------------------------------------------------\n")
-            sys.stdout.write("\n")
-            sys.stdout.write("This script will configure the database and prepare it for use.\n")
-            sys.stdout.write("\n")
-            sys.stdout.write("--------------------------------------------------------------------------------\n")
-            sys.stdout.write("\n")
+            print("--------------------------------------------------------------------------------")
+            print("This script will configure the database and prepare it for use.")
+            print("--------------------------------------------------------------------------------")
             raw_input("Press [enter] to continue...")
-            sys.stdout.write("\n")
 
         # Tried not to be os-specific, but ... hey. :-/
         # benjaoming: This doesn't work, why is 502 hard coded!? Root is normally
         # '0' And let's not care about stuff like this, people can be free to
         # run this as root if they want :)
         if not is_windows() and hasattr(os, "getuid") and os.getuid() == 502:
-            sys.stdout.write("-------------------------------------------------------------------\n")
-            sys.stdout.write("WARNING: You are installing KA-Lite as root user!\n")
-            sys.stdout.write("\tInstalling as root may cause some permission problems while running\n")
-            sys.stdout.write("\tas a normal user in the future.\n")
-            sys.stdout.write("-------------------------------------------------------------------\n")
+            print("-------------------------------------------------------------------")
+            print("WARNING: You are installing KA-Lite as root user!")
+            print("\tInstalling as root may cause some permission problems while running")
+            print("\tas a normal user in the future.")
+            print("-------------------------------------------------------------------")
             if options["interactive"]:
                 if not raw_input_yn("Do you wish to continue and install it as root?"):
                     raise CommandError("Aborting script.\n")
-                sys.stdout.write("\n")
 
         # Check to see if the current user is the owner of the install directory
         if not os.access(BASE_DIR, os.W_OK):
@@ -211,19 +207,19 @@ class Command(BaseCommand):
             # We found an existing database file.  By default,
             #   we will upgrade it; users really need to work hard
             #   to delete the file (but it's possible, which is nice).
-            sys.stdout.write("-------------------------------------------------------------------\n")
-            sys.stdout.write("WARNING: Database file already exists! \n")
-            sys.stdout.write("-------------------------------------------------------------------\n")
+            print("-------------------------------------------------------------------")
+            print("WARNING: Database file already exists!")
+            print("-------------------------------------------------------------------")
             if not options["interactive"] \
                or raw_input_yn("Keep database file and upgrade to KA Lite version %s? " % VERSION) \
                or not raw_input_yn("Remove database file '%s' now? " % database_file) \
                or not raw_input_yn("WARNING: all data will be lost!  Are you sure? "):
                 install_clean = False
-                sys.stdout.write("Upgrading database to KA Lite version %s\n" % VERSION)
+                print("Upgrading database to KA Lite version %s" % VERSION)
             else:
                 install_clean = True
-                sys.stdout.write("OK.  We will run a clean install; \n")
-                sys.stdout.write("the database file will be moved to a deletable location.\n")  # After all, don't delete--just move.
+                print("OK.  We will run a clean install; ")
+                print("the database file will be moved to a deletable location.")  # After all, don't delete--just move.
 
         if not install_clean and not database_file and not kalite.is_installed():
             # Make sure that, for non-sqlite installs, the database exists.
@@ -232,11 +228,9 @@ class Command(BaseCommand):
         # Do all input at once, at the beginning
         if install_clean and options["interactive"]:
             if not options["username"] or not options["password"]:
-                sys.stdout.write("\n")
-                sys.stdout.write("Please choose a username and password for the admin account on this device.\n")
-                sys.stdout.write("\tYou must remember this login information, as you will need\n")
-                sys.stdout.write("\tto enter it to administer this installation of KA Lite.\n")
-                sys.stdout.write("\n")
+                print("Please choose a username and password for the admin account on this device.")
+                print("\tYou must remember this login information, as you will need")
+                print("\tto enter it to administer this installation of KA Lite.")
             (username, password) = get_username_password(options["username"], options["password"])
             email = options["email"]
             (hostname, description) = get_hostname_and_description(options["hostname"], options["description"])
@@ -259,7 +253,7 @@ class Command(BaseCommand):
         if install_clean and database_file and os.path.exists(database_file):
             # This is an overwrite install; destroy the old db
             dest_file = tempfile.mkstemp()[1]
-            sys.stdout.write("(Re)moving database file to temp location, starting clean install.  Recovery location: %s\n" % dest_file)
+            print("(Re)moving database file to temp location, starting clean install.  Recovery location: %s" % dest_file)
             shutil.move(database_file, dest_file)
 
         # Should clean_pyc for (clean) reinstall purposes
@@ -272,21 +266,23 @@ class Command(BaseCommand):
         # download assessment items
         # This can take a long time and lead to Travis stalling. None of this is required for tests.
         if not settings.RUNNING_IN_TRAVIS and options['interactive']:
-            sys.stdout.write("\nStarting in version 0.13, you will need an assessment items package in order to access many of the available exercises.\n")
-            sys.stdout.write("If you have an internet connection, you can download the needed package. Warning: this may take a long time!\n")
-            sys.stdout.write("If you have already downloaded the assessment items package, you can specify the file in the next step.\n")
-            
+            print("\nStarting in version 0.13, you will need an assessment items package in order to access many of the available exercises.")
+            print("If you have an internet connection, you can download the needed package. Warning: this may take a long time!")
+            print("If you have already downloaded the assessment items package, you can specify the file in the next step.")
+           
             if raw_input_yn("Do you wish to download the assessment items package now?"):
                 ass_item_fn = settings.ASSESSMENT_ITEMS_ZIP_URL
             elif raw_input_yn("Have you already downloaded the assessment items package?"):
                 ass_item_fn = get_assessment_items_filename()
+            else:
+                ass_item_fn = None
 
             if not ass_item_fn:
-                sys.stderr.write("No assessment items package file given. You will need to download and unpack it later.\n")
+                logging.error("No assessment items package file given. You will need to download and unpack it later.")
             else:
                 call_command("unpack_assessment_zip", ass_item_fn)
         else:        
-            sys.stderr.write("No assessment items package file given. You will need to download and unpack it later.\n")
+            logging.error("No assessment items package file given. You will need to download and unpack it later.")
                 
 
         # Individually generate any prerequisite models/state that is missing
@@ -311,7 +307,7 @@ class Command(BaseCommand):
             #
             #if os.path.exists(InitCommand.data_json_file):
             #    # This is a pathway to install zone-based data on a software upgrade.
-            #    sys.stdout.write("Loading zone data from '%s'\n" % InitCommand.data_json_file)
+            #    print("Loading zone data from '%s'\n" % InitCommand.data_json_file)
             #    load_data_for_offline_install(in_file=InitCommand.data_json_file)
 
         #    confirm_or_generate_zone()
@@ -338,7 +334,7 @@ class Command(BaseCommand):
                 try:
                     shutil.copystat(os.path.join(src_dir, script_file), os.path.join(dest_dir, script_file))
                 except OSError:  # even if we have write permission, we might not have permission to change file mode
-                    sys.stdout.write("WARNING: Unable to set file permissions on %s! \n" % script_file)
+                    print("WARNING: Unable to set file permissions on %s! " % script_file)
 
             kalite_executable = 'kalite'
             if not spawn.find_executable('kalite'):
@@ -350,11 +346,9 @@ class Command(BaseCommand):
                 start_script_path = kalite_executable
 
             # Run videoscan, on the distributed server.
-            sys.stdout.write("Scanning for video files in the content directory (%s)\n" % settings.CONTENT_ROOT)
+            print("Scanning for video files in the content directory (%s)" % settings.CONTENT_ROOT)
             call_command("videoscan")
 
             # done; notify the user.
-            sys.stdout.write("\n")
-            sys.stdout.write("CONGRATULATIONS! You've finished setting up the KA Lite server software.\n")
-            sys.stdout.write("You can now start KA Lite with the following command:\n\n\t%s start\n\n" % start_script_path)
-            sys.stdout.write("\n")
+            print("CONGRATULATIONS! You've finished setting up the KA Lite server software.")
+            print("You can now start KA Lite with the following command:\n\n\t%s start\n\n" % start_script_path)

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -289,6 +289,7 @@ class Command(BaseCommand):
             print("\nStarting in version 0.13, you will need an assessment items package in order to access many of the available exercises.")
             print("If you have an internet connection, you can download the needed package. Warning: this may take a long time!")
             print("If you have already downloaded the assessment items package, you can specify the file in the next step.")
+            print("Otherwise, we will download it from {url}.".format(settings.ASSESSMENT_ITEMS_ZIP_URL))
            
             if raw_input_yn("Do you wish to download the assessment items package now?"):
                 ass_item_filename = settings.ASSESSMENT_ITEMS_ZIP_URL

--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -219,7 +219,7 @@ UNIT_POINTS = 2000
 
 # for extracting assessment item resources
 ASSESSMENT_ITEMS_RESOURCES_DIR = os.path.join(PROJECT_PATH, "..", "content", "khan")
-
+ASSESSMENT_ITEMS_ZIP_URL = "http://eslgenie.com/media/assessment_item_resources.zip"
 
 if package_selected("UserRestricted"):
     LOG.info("UserRestricted package selected.")

--- a/sphinx-docs/installguide/release_notes.rst
+++ b/sphinx-docs/installguide/release_notes.rst
@@ -16,7 +16,12 @@ On Windows, use the ``bin\windows\kalite.bat`` in the cmd.exe prompt::
 
     bin\windows\kalite.bat manage setup
 
-When you are asked whether or not to delete your database, you should choose to keep your database!
+When you are asked whether or not to delete your database, you should choose to keep your database! You will also be prompted to download an assessment items package, or to specify the location if you have already downloaded it. If you wish to download the package and specify the location during the setup process: 
+
+* Download the assessment items package `here <http://eslgenie.com/media/assessment_item_resources.zip>`_. Save it in the same folder as the setup script. Take note of the filename, as you will need to enter it exactly!
+* During the setup process you will see the prompt "Do you wish to download the assessment items package now?". Type "no" and press enter to continue.
+* You will then see the prompt "Have you already downloaded the assessment items package?". Type "yes" and press enter.
+* Finally, you will see the prompt "Please enter the filename of the assessment items package you have downloaded (leave blank to skip this step): ". Enter the filename of the assessment items package that you downloaded earlier.
 
 Windows
 ^^^^^^^

--- a/sphinx-docs/installguide/release_notes.rst
+++ b/sphinx-docs/installguide/release_notes.rst
@@ -18,10 +18,10 @@ On Windows, use the ``bin\windows\kalite.bat`` in the cmd.exe prompt::
 
 When you are asked whether or not to delete your database, you should choose to keep your database! You will also be prompted to download an assessment items package, or to specify the location if you have already downloaded it. If you wish to download the package and specify the location during the setup process: 
 
-* Download the assessment items package `here <http://eslgenie.com/media/assessment_item_resources.zip>`_. Save it in the same folder as the setup script. Take note of the filename, as you will need to enter it exactly!
+* Download the assessment items package `here <http://eslgenie.com/media/assessment_item_resources.zip>`_. Save it in the same folder as the setup script.
 * During the setup process you will see the prompt "Do you wish to download the assessment items package now?". Type "no" and press enter to continue.
 * You will then see the prompt "Have you already downloaded the assessment items package?". Type "yes" and press enter.
-* Finally, you will see the prompt "Please enter the filename of the assessment items package you have downloaded (leave blank to skip this step): ". Enter the filename of the assessment items package that you downloaded earlier.
+* Finally, you will see a prompt that begins with "Please enter the filename of the assessment items package you have downloaded". A recommened file may appear in parentheses -- if this is the file you downloaded, then press enter. Otherwise, enter the name of the file you downloaded. (Absolute paths are okay, as are paths relative to the directory you are running the setup script from.)
 
 Windows
 ^^^^^^^


### PR DESCRIPTION
Fixes #3275. Is the language in the docs sufficiently clear? Should we take the opportunity in the release notes to explain what exactly the assessment items are and the various options users have to download them or unpack them later with the `contentload` management commands?