### PR TITLE
Partially Fixes 3197/3302 -- After the fix Server can be registered but will fail is DEBUG is True

### DIFF
--- a/python-packages/securesync/devices/views.py
+++ b/python-packages/securesync/devices/views.py
@@ -92,7 +92,7 @@ def central_server_down_or_error(error_msg):
     error_msg: a string
     """
     if error_msg:
-        if urllib.urlopen(settings.CENTRAL_SERVER).getcode() != 200:
+        if urllib.urlopen(settings.CENTRAL_SERVER_HOST).getcode() != 200:
             return {"error_msg": "Central Server is not reachable, Please try after sometime."}
         else:
             return {"error_msg": error_msg}


### PR DESCRIPTION
#3197 
#3302 

We are getting a error while trying to open a url:
because we are using settings.CENTRAL_SERVER , which is a bool not a url
instead we have to use settings.CENTRAL_SERVER_HOST which points to the correct url.