### PR TITLE
Fixes issue #3320: Removes the empty title being displayed with 'Test prep' in side-bar

### DIFF
--- a/data/khan/topic_hierarchy.json
+++ b/data/khan/topic_hierarchy.json
@@ -7158,7 +7158,7 @@
                     "title": "AP Art History"
                 }
             ], 
-            "description": " ", 
+            "description": "", 
             "id": "test-prep", 
             "title": "Test prep"
         }, 


### PR DESCRIPTION
Modifies the description to NULL from space (" "->"") for Test prep in the side-bar