### PR TITLE
Bat script no input fix

### DIFF
--- a/scripts/add_systemstart_task.bat
+++ b/scripts/add_systemstart_task.bat
@@ -2,4 +2,4 @@
 set "SCRIPT_DIR=%~dp0"
 
 TITLE Adding task to start KA Lite at system start
-schtasks /create /tn "KALite" /tr "\"%SCRIPT_DIR%..\bin\windows\kalite.bat\" start" /sc onstart & pause
+schtasks /create /tn "KALite" /tr "\"%SCRIPT_DIR%..\bin\windows\kalite.bat\" start" /sc onstart

--- a/scripts/add_systemstart_task.bat
+++ b/scripts/add_systemstart_task.bat
@@ -2,4 +2,4 @@
 set "SCRIPT_DIR=%~dp0"
 
 TITLE Adding task to start KA Lite at system start
-schtasks /create /tn "KALite" /tr "\"%SCRIPT_DIR%..\bin\windows\kalite.bat\" start" /sc onstart
+schtasks /create /tn "KALite" /tr "\"%SCRIPT_DIR%..\bin\windows\kalite.bat\" start" /sc onstart /ru SYSTEM

--- a/scripts/remove_systemstart_task.bat
+++ b/scripts/remove_systemstart_task.bat
@@ -1,3 +1,3 @@
 @echo off
 TITLE Removing task to start KA Lite at system start
-schtasks /delete /tn "KALite"
+schtasks /delete /tn "KALite" /ru SYSTEM

--- a/scripts/remove_systemstart_task.bat
+++ b/scripts/remove_systemstart_task.bat
@@ -1,3 +1,3 @@
 @echo off
 TITLE Removing task to start KA Lite at system start
-schtasks /delete /tn "KALite" & pause
+schtasks /delete /tn "KALite"


### PR DESCRIPTION
Now the script requires no input to complete and the task is owned by the appropriate user. This should be merged before a fix to the installer, so that the included submodule can be updated.