### PR TITLE
Don't split args on whitespace

### DIFF
--- a/kalitectl.py
+++ b/kalitectl.py
@@ -349,16 +349,17 @@ def start(debug=False, args=[], skip_job_scheduler=False):
         manage(
             'cronserver',
             in_background=True,
-            args=[
-                '--daemon', '--pid-file={0000:s}'.format(PID_FILE_JOB_SCHEDULER)]
+            args=['--daemon',
+                  '--pid-file={0000:s}'.format(PID_FILE_JOB_SCHEDULER)
+                  ]
         )
-    args = "--host={host:s} --daemonize{production:s} --pidfile={pid:s} --startup-lock-file={startup:s}".format(
-        host=LISTEN_ADDRESS,
-        pid=PID_FILE,
-        production=" --production" if not debug else "",
-        startup=STARTUP_LOCK,
-    )
-    manage('kaserve', args=args.split(" "))
+    args = ["--host=%s" % LISTEN_ADDRESS,
+            "--daemonize",
+            "--pidfile=%s" % PID_FILE,
+            "--startup-lock-file=%s" % STARTUP_LOCK,
+            ]
+    args += ["--production"] if not debug else []
+    manage('kaserve', args)
 
 
 def setting(setting_name):


### PR DESCRIPTION
Because valid paths can have whitespace in them.
Don't you like paths with whitespace in them? :(

Fixes #3330. Before we merge this, can we get @EdDixon to verify that this works on Windows 7 & XP? (And Vista now too @jamalex?) Ed, just make sure your home directory has white space in it (or if it doesn't ping me and we can just add some whitespace to one of the directories in `kalitectl.py`), pull my branch and try to run the `bin/windows/kalite.bat start` command. You should no longer get a `CommandError`, but instead the server should start normally.