### PR TITLE
Auth redirect

### DIFF
--- a/kalite/distributed/tests/browser_tests/distributed.py
+++ b/kalite/distributed/tests/browser_tests/distributed.py
@@ -345,7 +345,7 @@ class TestSessionTimeout(CreateAdminMixin, BrowserActionMixins, FacilityMixins, 
         self.student = self.create_student(username=student_username, password=student_password)
         self.browser_login_student(student_username, student_password)
         time.sleep(3)
-        self.browse_to(self.reverse("exercise_dashboard"))
+        self.browse_to(self.reverse("homepage"))
         self.browser_check_django_message(message_type="error", contains="Your session has been timed out")
         # Check if user redirects to login page after session timeout.
         self.assertEquals(self.browser.current_url, self.reverse("login") )

--- a/kalite/distributed/tests/browser_tests/quiz.py
+++ b/kalite/distributed/tests/browser_tests/quiz.py
@@ -9,8 +9,10 @@ from django.utils import unittest
 
 from kalite.testing.base import KALiteBrowserTestCase
 from kalite.testing.mixins import BrowserActionMixins, FacilityMixins
+from selenium.webdriver.common.keys import Keys
 
 PLAYLIST_ID = "g3_p1"
+
 
 @unittest.skipUnless("nalanda" in settings.CONFIG_PACKAGE, "requires Nalanda")
 class QuizTest(BrowserActionMixins, FacilityMixins, KALiteBrowserTestCase):
@@ -54,3 +56,4 @@ class QuizTest(BrowserActionMixins, FacilityMixins, KALiteBrowserTestCase):
         self.browser.execute_script("quizlog.add_response_log_item({correct: true});")
         self.assertEqual(self.browser.execute_script("return quizlog.get('total_correct')"), 1)
         self.assertEqual(self.browser.execute_script("return quizlog._response_log_cache[0]"), 1)
+

--- a/kalite/distributed/tests/browser_tests/quiz.py
+++ b/kalite/distributed/tests/browser_tests/quiz.py
@@ -9,7 +9,6 @@ from django.utils import unittest
 
 from kalite.testing.base import KALiteBrowserTestCase
 from kalite.testing.mixins import BrowserActionMixins, FacilityMixins
-from selenium.webdriver.common.keys import Keys
 
 PLAYLIST_ID = "g3_p1"
 

--- a/python-packages/django_snippets/session_timeout_middleware.py
+++ b/python-packages/django_snippets/session_timeout_middleware.py
@@ -29,7 +29,7 @@ class SessionIdleTimeout:
                     logout(request)
                     messages.add_message(request, messages.ERROR, 'Your session has been timed out')
 
-                    if request.is_ajax:
+                    if request.is_ajax():
                         response = HttpResponse(status=401)
                     else:
                         # Redirect to the login page if session has timed-out.

--- a/python-packages/django_snippets/session_timeout_middleware.py
+++ b/python-packages/django_snippets/session_timeout_middleware.py
@@ -4,7 +4,7 @@ import datetime
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect
 
 
 class SessionIdleTimeout:
@@ -29,9 +29,12 @@ class SessionIdleTimeout:
                     logout(request)
                     messages.add_message(request, messages.ERROR, 'Your session has been timed out')
 
-                    # Redirect to the login page if session has timed-out.
-                    redirect_to = reverse('login')
-                    response = HttpResponseRedirect(redirect_to)
+                    if request.is_ajax:
+                        response = HttpResponse(status=401)
+                    else:
+                        # Redirect to the login page if session has timed-out.
+                        redirect_to = reverse('login')
+                        response = HttpResponseRedirect(redirect_to)
                     return response
                 else:
                     # Set last activity time in current session.

--- a/static-libraries/js/khan-lite.js
+++ b/static-libraries/js/khan-lite.js
@@ -157,6 +157,8 @@ function handleFailedAPI(resp, error_prefix) {
             }
             break;
         case 403:
+            // Redirect to Login Page and add the current url as next
+            window.location.href = setGetParam(window.location.href, "next", USER_LOGIN_URL)
             messages = {error: sprintf(gettext("You are not authorized to complete the request.  Please <a href='%(login_url)s'>login</a> as an authorized user, then retry the request."), {
                 login_url: USER_LOGIN_URL
             })};

--- a/static-libraries/js/khan-lite.js
+++ b/static-libraries/js/khan-lite.js
@@ -158,7 +158,7 @@ function handleFailedAPI(resp, error_prefix) {
             break;
         case 403:
             // Redirect to Login Page and add the current url as next
-            window.location.href = setGetParam(window.location.href, "next", USER_LOGIN_URL)
+            window.location.href = setGetParam(USER_LOGIN_URL, "next", window.location.pathname + window.location.hash)
             messages = {error: sprintf(gettext("You are not authorized to complete the request.  Please <a href='%(login_url)s'>login</a> as an authorized user, then retry the request."), {
                 login_url: USER_LOGIN_URL
             })};

--- a/static-libraries/js/khan-lite.js
+++ b/static-libraries/js/khan-lite.js
@@ -156,6 +156,8 @@ function handleFailedAPI(resp, error_prefix) {
                 console.log(e);
             }
             break;
+        case 401:
+
         case 403:
             // Redirect to Login Page and add the current url as next
             window.location.href = setGetParam(USER_LOGIN_URL, "next", window.location.pathname + window.location.hash)


### PR DESCRIPTION
Fixes #3256

Summary of changes:
* Redirects to login page when API returns a 401/403.
* Fixes session timeout middleware to return 401 on Ajax calls.

Note: Any other reason for a session ending will not get a message.