### PR TITLE
Ui cleanup

### DIFF
--- a/kalite/distributed/hbtemplates/topics/sidebar.handlebars
+++ b/kalite/distributed/hbtemplates/topics/sidebar.handlebars
@@ -2,7 +2,7 @@
 
 <nav class="sidebar-panel" role="navigation">
     {{!-- TODO: Replace icon with better chevron that looks different from the one in sidebar-tab --}}
-    <div class="sidebar-back ">
+    <div class="sidebar-back">
         <button class="simple-button green icon icon-arrow-left2"></button>
     </div>
     <div class="sidebar-content"></div>

--- a/kalite/distributed/hbtemplates/topics/sidebar.handlebars
+++ b/kalite/distributed/hbtemplates/topics/sidebar.handlebars
@@ -2,8 +2,8 @@
 
 <nav class="sidebar-panel" role="navigation">
     {{!-- TODO: Replace icon with better chevron that looks different from the one in sidebar-tab --}}
-    <div class="sidebar-back">
-        <span class="icon icon-arrow-left2"></span>
+    <div class="sidebar-back ">
+        <button class="simple-button green icon icon-arrow-left2"></button>
     </div>
     <div class="sidebar-content"></div>
 </nav>

--- a/kalite/distributed/static/css/distributed/sidebar.css
+++ b/kalite/distributed/static/css/distributed/sidebar.css
@@ -141,6 +141,10 @@ div.fade {
     z-index: 10000;
 }
 
+.sidebar-back button {
+    height: 3em;
+}
+
 .sidebar-back-hover {
     background-color: #3D6663 !important;
 }

--- a/kalite/distributed/static/css/distributed/sidebar.css
+++ b/kalite/distributed/static/css/distributed/sidebar.css
@@ -141,6 +141,10 @@ div.fade {
     z-index: 10000;
 }
 
+.sidebar-back-hover {
+    background-color: #3D6663 !important;
+}
+
 /* Sidebar panel & entry styling */
 .topic-container-inner {
     float: left;

--- a/kalite/distributed/static/js/distributed/topics/views.js
+++ b/kalite/distributed/static/js/distributed/topics/views.js
@@ -195,7 +195,7 @@ window.SidebarView = BaseView.extend({
         return false;
     },
 
-    update_sidebar_visibility: function() {
+    update_sidebar_visibility: _.debounce(function() {
         if (this.state_model.get("open")) {
             // Used to get left value in number form
             var sidebarPanelPosition = this.sidebar.position();
@@ -203,7 +203,8 @@ window.SidebarView = BaseView.extend({
             this.resize_sidebar();
             this.sidebarTab.css({left: this.sidebar.width() + sidebarPanelPosition.left}).html('<span class="icon-circle-left"></span>');
             this.$(".fade").show();
-        } 
+        }
+
         else {
             this.sidebar.css({left: - this.width});
             this.sidebarTab.css({left: 0}).html('<span class="icon-circle-right"></span>');
@@ -211,11 +212,20 @@ window.SidebarView = BaseView.extend({
         }
 
         this.set_sidebar_back();
-    },
+    }, 100),
 
     set_sidebar_back: function() {
         if (!this.state_model.get("open")) {
             this.sidebarBack.offset({left: -(this.sidebarBack.width())});
+            
+            this.sidebarBack.hover(
+            function() {
+                $(this).addClass("sidebar-back-hover");
+            },
+            function() {
+                $(this).removeClass("sidebar-back-hover");
+            });
+
             return;
         }
 


### PR DESCRIPTION
Just @Antrikshy's changes from #3343, but with one amendment since I'd like to get this PR merged today. Fixes #3245 and fixes #3223. The back button is now a bootstrap button:
![ss](https://cloud.githubusercontent.com/assets/8888020/6743337/b3d7430e-ce55-11e4-8cf2-71b71be6cd8a.png)
