### PR TITLE
Translate the text inside the question area

### DIFF
--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -37,16 +37,6 @@ CONTENT_FILEPATH = os.path.join(settings.CHANNEL_DATA_PATH, "contents.json")
 
 CACHE_VARS = []
 
-ASSESSMENT_DATA_TRANSLATABLE_FIELDS = [
-    'widgets',
-    'hints',
-    'question',
-    'answerArea',
-    'radio 1',
-    'choices',
-    'options',
-]
-
 
 if not os.path.exists(settings.CHANNEL_DATA_PATH):
     logging.warning("Channel {channel} does not exist.".format(channel=settings.CHANNEL))
@@ -523,19 +513,18 @@ def smart_translate_item_data(item_data):
 
     An assessment item doesn't have the same fields; they change
     depending on the question. Instead of manually specifying the
-    fields to translate, this function loops over all the relevant
-    fields of item_data and translates only the content field.
+    fields to translate, this function loops over all fields of
+    item_data and translates only the content field.
+
     """
     if 'content' in item_data:
         item_data['content'] = _(item_data['content'])
 
-    for field in ASSESSMENT_DATA_TRANSLATABLE_FIELDS:
-        if field in item_data:
-            field_data = item_data[field]
-            if isinstance(field_data, dict):
-                item_data[field] = smart_translate_item_data(field_data)
-            elif isinstance(field_data, list):
-                item_data[field] = map(smart_translate_item_data, field_data)
+    for field, field_data in item_data.iteritems():
+        if isinstance(field_data, dict):
+            item_data[field] = smart_translate_item_data(field_data)
+        elif isinstance(field_data, list):
+            item_data[field] = map(smart_translate_item_data, field_data)
 
     return item_data
 

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -25,7 +25,7 @@ from django.contrib import messages
 from django.utils import translation
 from django.utils.translation import ugettext as _
 
-from fle_utils.general import softload_json
+from fle_utils.general import softload_json, json_ascii_decoder
 from kalite import i18n
 
 TOPICS_FILEPATHS = {
@@ -496,7 +496,7 @@ def get_assessment_item_data(request, assessment_item_id=None):
 
     # Enable internationalization for the assessment_items.
     try:
-        item_data = json.loads(assessment_item['item_data'])
+        item_data = json.loads(assessment_item['item_data'], object_hook=json_ascii_decoder)
         question_content = _(item_data['question']['content'])
         answerarea_content = item_data['answerArea']['options']['content']
         if answerarea_content:  # Not an empty string

--- a/kalite/topic_tools/tests/utils_tests.py
+++ b/kalite/topic_tools/tests/utils_tests.py
@@ -1,0 +1,47 @@
+from mock import patch, MagicMock
+
+import kalite.topic_tools as mod
+from kalite.testing.base import KALiteTestCase
+
+
+DUMMY_STRING = "maize"
+TRANS_STRING = "trans"
+
+
+ugettext_dummy = MagicMock(return_value=DUMMY_STRING)
+
+
+@patch.object(mod, '_', new=ugettext_dummy)
+class SmartTranslateItemDataTests(KALiteTestCase):
+
+    def tearDown(self):
+        ugettext_dummy.reset_mock()
+
+    def test_simple_content_dict(self):
+        # ugettext_method.return_value = DUMMY_STRING
+        test_data = {'content': TRANS_STRING}
+        expected_data = {'content': DUMMY_STRING}
+
+        result = mod.smart_translate_item_data(test_data)
+        ugettext_dummy.assert_called_once_with(TRANS_STRING)
+
+        self.assertEqual(result, expected_data)
+
+    def test_content_in_widgets_field(self):
+        test_data = {'widgets': {'content': TRANS_STRING}}
+        expected_data = {'widgets': {'content': DUMMY_STRING}}
+
+        result = mod.smart_translate_item_data(test_data)
+        ugettext_dummy.assert_called_once_with(TRANS_STRING)
+
+        self.assertEqual(result, expected_data)
+
+    def test_content_inside_radio_field(self):
+        pass
+        test_data = {'radio 1': {'widgets': {'content': TRANS_STRING}}}
+        expected_data = {'radio 1': {'widgets': {'content': DUMMY_STRING}}}
+
+        result = mod.smart_translate_item_data(test_data)
+        ugettext_dummy.assert_called_once_with(TRANS_STRING)
+
+        self.assertEqual(result, expected_data)

--- a/python-packages/accenting.py
+++ b/python-packages/accenting.py
@@ -68,7 +68,8 @@ class Converter(object):
         (%\([\w]+\)\w)      |       # %(tag)s
         (&\w+;)             |       # &entity;
         (&\#\d+;)           |       # &#1234;
-        (&\#x[0-9a-f]+;)            # &#xABCD;
+        (&\#x[0-9a-f]+;)    |       # &#xABCD;
+        (\[\[.*\]\])                # [[snowman radio]];
         ''',
         re.IGNORECASE | re.VERBOSE
     )

--- a/python-packages/fle_utils/general.py
+++ b/python-packages/fle_utils/general.py
@@ -215,12 +215,12 @@ def _decode_list(data):
         elif isinstance(item, list):
             item = _decode_list(item)
         elif isinstance(item, dict):
-            item = _decode_dict(item)
+            item = json_ascii_decoder(item)
         rv.append(item)
     return rv
 
 
-def _decode_dict(data):
+def json_ascii_decoder(data):
     rv = {}
     for key, value in data.iteritems():
         if isinstance(key, unicode):
@@ -230,7 +230,7 @@ def _decode_dict(data):
         elif isinstance(value, list):
             value = _decode_list(value)
         elif isinstance(value, dict):
-            value = _decode_dict(value)
+            value = json_ascii_decoder(value)
         rv[key] = value
     return rv
 
@@ -240,7 +240,7 @@ def softload_json(json_filepath, default={}, raises=False, logger=None, errmsg="
         default = {}
     try:
         with open(json_filepath, "r") as fp:
-            return json.load(fp, object_hook=_decode_dict)
+            return json.load(fp, object_hook=json_ascii_decoder)
     except Exception as e:
         if logger:
             logger("%s %s: %s" % (errmsg, json_filepath, e))

--- a/python-packages/fle_utils/general.py
+++ b/python-packages/fle_utils/general.py
@@ -221,6 +221,13 @@ def _decode_list(data):
 
 
 def json_ascii_decoder(data):
+    """A custom JSON decoder that can be passed to json.load/s.  This
+    parses strings into str instead of unicode. To use this, pass this
+    function to the object_hook keyword param in json.load/s.
+
+    Mainly used to help in encoding issues and memory efficiency.
+
+    """
     rv = {}
     for key, value in data.iteritems():
         if isinstance(key, unicode):


### PR DESCRIPTION
Fixes #2729. 

Before, the actual questions aren't getting translated.
![screen shot 2015-03-19 at 9 18 17 am](https://cloud.githubusercontent.com/assets/191955/6743308/6165f836-ce55-11e4-9e28-d0179bc610ca.png)

This was due to an encoding issue. PO files are read as ascii, but we are passing unicode strings to `gettext`, and hence they are not getting matched. With this fix (+ a couple of others) we now have this:
![screen shot 2015-03-19 at 12 38 30 pm](https://cloud.githubusercontent.com/assets/191955/6743325/98c79f50-ce55-11e4-9a57-d641c5e622bd.png)

To test:
1. Run `bin/kalite manage create_dummy_language_pack --traceback`
2. Run the server, and change your language to `Esperanto`.
3. Go to a perseus exercise, preferably some of the early math ones (as the later ones don't even have entries in the PO file).

Remaining issues:
- Need to get `backbone.js` strings translated.
