### PR TITLE
Puts content-area above sidebar-container in html flow for accessibility improvements

### DIFF
--- a/kalite/distributed/templates/distributed/learn.html
+++ b/kalite/distributed/templates/distributed/learn.html
@@ -136,8 +136,8 @@
 
 {% block content %}
     {{ block.super }}
-    <div id="sidebar-container">
-    </div>
     <div id="content-area">
+    </div>
+    <div id="sidebar-container">
     </div>
 {% endblock content %}

--- a/kalite/playlist/templates/playlist/view_playlist.html
+++ b/kalite/playlist/templates/playlist/view_playlist.html
@@ -99,9 +99,9 @@
 
 {% block content %}
 
-    <div id="sidebar-container"></div>
-
     <div id="content-area">
+    </div>
+    <div id="sidebar-container">
     </div>
 
 {% endblock content %}


### PR DESCRIPTION
Fixes issue #3365 .
Puts content-area above sidebar-container in html flow for better accessibility using screen readers.
The navigation links are put below the main content.
Screenshot using fangs Screen Reader:
![screenshot from 2015-03-20 17 48 25](https://cloud.githubusercontent.com/assets/6399612/6751452/e538c8a8-cf29-11e4-8d19-ac3fe52e0bf9.png)
