### PR TITLE
Fixes #3235 Disable Nalanda Conditions to disable nalanda specific messages

### DIFF
--- a/kalite/ab_testing/dynamic_assets.py
+++ b/kalite/ab_testing/dynamic_assets.py
@@ -17,7 +17,7 @@ def modify_dynamic_settings(ds, request=None, user=None):
 
     user = user or request.session.get('facility_user')
 
-    if user and not user.is_teacher:
+    if user and not user.is_teacher and is_config_package_nalanda:
 
         # determine the facility and unit for the current user
         facility = user.facility


### PR DESCRIPTION
#3235 ,

Added check "is_config_package_nalanda" in ab_testing/dynamic_settings

So, not to select any unit condition until the package is nalanda.

Anyhow, we can drop the concept of unit by deleting like the file ab_testing/data/facility_unit_mappings as even nalanda-phase3 doesn't require unit