### PR TITLE
Disabled reports tab for teachers

### DIFF
--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -16,7 +16,7 @@ html, body {
 }
 #content-container {
     padding-top: 20px;
-    padding-bottom: 90px;  /* Must be same height as footer */
+    /*padding-bottom: 90px; Must be same height as footer */
 }
 footer {
     width: 100%;
@@ -106,7 +106,7 @@ input[type="submit"] {
     border: 0;
     border-radius: 5px 15px 0 0;
     margin: 0;
-    background-color: #5AA685;
+    background: #5AA685;
     color: #5AA685;
     -webkit-transition: all 80ms ease-out;
     -moz-transition: all 80ms ease-out;

--- a/kalite/distributed/templates/distributed/base_teach.html
+++ b/kalite/distributed/templates/distributed/base_teach.html
@@ -15,13 +15,15 @@
 
 <!-- Prevents nav bar from showing up for students/guests on learn tab -->
 {% if request.is_admin %}
+{% if is_config_package_nalanda %}
 <div class="teach-nav">
     <ul>
         <div class="mobile-nav">
+
             <li class="reports {% block reports_active %}{% endblock reports_active %}">
                 <a href="{% url 'tabular_view' %}" title="{% trans 'Track the progress of your learners' %}"><div class=""><span class="icon icon-uniE605"></span><br/>{% trans "Reports" %}</div></a>
             </li>
-            {% if is_config_package_nalanda %}
+            
             <li class="playlist {% block playlist_active %}{% endblock playlist_active %}">
                 <a class="link-width" href="{% url 'assign_playlists' %}" title="{% trans 'Assign playlists to learner groups' %}"><div><span class="icon icon-uniE604"></span><br/>{% trans "Playlists" %}</div></a>
             </li>
@@ -33,8 +35,8 @@
             <li class="teacher-only units {% block current_unit_active %}{% endblock current_unit_active %}">
                 <a href="{% url 'current_unit' %}" id="nav_current_unit" title="{% trans 'See list of current units for the facilities.' %}"><div style="position: relative; top: 56px;">{% trans "Units" %}</div></a>
             </li>
-            {% endif %}
         </div>  
+        {% endif %}
         <!-- Jessica: Commenting out for now to put learn back in 1st level navbar
         <li class="learn {% block learn_subnav_active %}{% endblock learn_subnav_active %}">
             <a href="{% url 'learn' %}" title="{% trans 'KA Lite Home' %}"><div><span class="icon icon-uniE601"></span><br/>{% trans "Learn" %}</div></a>


### PR DESCRIPTION
No need for it since it's the only page that teachers need to access on the screen

![no more reports](https://cloud.githubusercontent.com/assets/6668144/6762773/fea616a2-cf23-11e4-8689-03031baaa9b0.PNG)
