### PR TITLE
Creates minimum width for the dropdown username tab

### DIFF
--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -139,8 +139,11 @@ input[type="submit"] {
     border-top: 2px solid #5AA685;
     border-right: 2px solid #5AA685;
 }
-.navbar ul li.dropdown {
+.navbar ul li.dropdown,
+.navbar ul li.dropdown.open {
     padding-right: 0;
+    min-width: 130px;
+    text-align: center;
 }
 .navbar ul li.dropdown.open a {
     color: #5AA685;

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -145,6 +145,9 @@ input[type="submit"] {
     min-width: 130px;
     text-align: center;
 }
+#points {
+    text-align: left;
+}
 .navbar ul li.dropdown.open a {
     color: #5AA685;
 }

--- a/kalite/distributed/templates/distributed/base_teach.html
+++ b/kalite/distributed/templates/distributed/base_teach.html
@@ -15,13 +15,13 @@
 
 <!-- Prevents nav bar from showing up for students/guests on learn tab -->
 {% if request.is_admin %}
+{% if is_config_package_nalanda %}
 <div class="teach-nav">
     <ul>
         <div class="mobile-nav">
             <li class="reports {% block reports_active %}{% endblock reports_active %}">
                 <a href="{% url 'tabular_view' %}" title="{% trans 'Track the progress of your learners' %}"><div class=""><span class="icon icon-uniE605"></span><br/>{% trans "Reports" %}</div></a>
             </li>
-            {% if is_config_package_nalanda %}
             <li class="playlist {% block playlist_active %}{% endblock playlist_active %}">
                 <a class="link-width" href="{% url 'assign_playlists' %}" title="{% trans 'Assign playlists to learner groups' %}"><div><span class="icon icon-uniE604"></span><br/>{% trans "Playlists" %}</div></a>
             </li>
@@ -33,7 +33,6 @@
             <li class="teacher-only units {% block current_unit_active %}{% endblock current_unit_active %}">
                 <a href="{% url 'current_unit' %}" id="nav_current_unit" title="{% trans 'See list of current units for the facilities.' %}"><div style="position: relative; top: 56px;">{% trans "Units" %}</div></a>
             </li>
-            {% endif %}
         </div>  
         <!-- Jessica: Commenting out for now to put learn back in 1st level navbar
         <li class="learn {% block learn_subnav_active %}{% endblock learn_subnav_active %}">
@@ -41,6 +40,7 @@
         </li> -->
     </ul>
 </div>
+{% endif %}
 {% endif %}
 
 {% endblock subnavbar %}


### PR DESCRIPTION
To address this issue:
![](https://s3.amazonaws.com/uploads.hipchat.com/86198/1212245/z7voRZt6rodSm3p/Screen%20Shot%202015-03-20%20at%205.29.48%20PM.png)

Tested in German as well, and it works out.