### PR TITLE
Properly forms URL for individual exercises in tabular coach report header

### DIFF
--- a/kalite/coachreports/templates/coachreports/partials/_tabular_exercises_report.html
+++ b/kalite/coachreports/templates/coachreports/partials/_tabular_exercises_report.html
@@ -7,7 +7,7 @@
             <tr>
                 {% for exercise in exercises %}
                     <th class="headrow data">
-                        <div><a href="{{ exercise.path }}" title='"{% trans exercise.display_name %}"{% if exercise.description %} ({% trans exercise.description %}){% endif %}'>{% trans exercise.title %}</a></div>
+                        <div><a href="{% url 'learn' %}{{ exercise.path }}" title='"{% trans exercise.display_name %}"{% if exercise.description %} ({% trans exercise.description %}){% endif %}'>{% trans exercise.title %}</a></div>
                     </th>
                 {% endfor %}
             </tr>

--- a/kalite/coachreports/templates/coachreports/partials/_tabular_videos_report.html
+++ b/kalite/coachreports/templates/coachreports/partials/_tabular_videos_report.html
@@ -7,7 +7,7 @@
             <tr>
                 {% for video in videos %}
                     <th class="headrow data">
-                        <div><a href="{{ video.path }}"><span title='"{% trans video.title %}"{% if video.description %} ({% trans video.description %}){% endif %}'>{% trans video.title %}</span></a></div>
+                        <div><a href="{% url 'learn' %}{{ video.path }}"><span title='"{% trans video.title %}"{% if video.description %} ({% trans video.description %}){% endif %}'>{% trans video.title %}</span></a></div>
                     </th>
                 {% endfor %}
             </tr>


### PR DESCRIPTION
Fixes #3384 

Summary of changes:
* Add learn url before exercise or video path on table header link.