### PR TITLE
Don't show `manage.py update` message.

### DIFF
--- a/python-packages/securesync/templates/securesync/register_public_key_client.html
+++ b/python-packages/securesync/templates/securesync/register_public_key_client.html
@@ -81,7 +81,7 @@
     {% endif %}
     {% if error_msg %}
         {% comment %}Translators: Please do not edit the variable text: %(command)s {% endcomment %}
-        <p>{% blocktrans with command="<b>python manage.py update</b>" %}Sorry, there was an error during registration. Please make sure your device is fully up to date (run {{ command }} and then stop/start the server).{% endblocktrans %}</p>
+        <p>{% blocktrans %}Sorry, there was an error during registration.{% endblocktrans %}</p>
         <p>{% trans "The error message was:" %} <b>{{ error_msg }}</b></p>
     {% endif %}
 


### PR DESCRIPTION
Remove this. We should not let them run this command, as we don't support it.