### PR TITLE
Don't access settings from __init__ this gives circularity

### DIFF
--- a/kalite/testing/__init__.py
+++ b/kalite/testing/__init__.py
@@ -1,4 +1,0 @@
-from django.conf import settings
-
-if settings.USE_DEBUG_TOOLBAR:
-    assert settings.CACHE_TIME == 0, "Debug toolbar must be set in conjunction with CACHE_TIME=0"

--- a/kalite/testing/settings.py
+++ b/kalite/testing/settings.py
@@ -49,6 +49,9 @@ if USE_DEBUG_TOOLBAR:
         'HIDE_DJANGO_SQL': False,
         'ENABLE_STACKTRACES' : True,
     }
+    # Debug toolbar must be set in conjunction with CACHE_TIME=0
+    CACHE_TIME = 0
+
 
 if getattr(local_settings, "DEBUG", False):
     INSTALLED_APPS += (


### PR DESCRIPTION
I'm currently refactoring how settings are loaded so they are not loaded using `execfile()` but just by resolving the module name.

This is all just a dumb quick fix, but it does show some other problems along the way....