### PR TITLE
Learn navigation clean up

### DIFF
--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -337,22 +337,34 @@ window.ExerciseView = Backbone.View.extend({
 
         clear_messages();
 
-        item.fetch({
-            success: self.render_perseus_exercise,
-            error: function() {
-                self.get_assessment_item(attempts+1);
-            }});
+
+        // Do this in this way, so that if the view is closed prior to the fetch completing
+        // successfully, the listens will have been unbound, and the callbacks will not get
+        // called.
+        this.listenToOnce(item, "sync", self.render_perseus_exercise);
+        this.listenToOnce(item, "error", function() {
+            self.get_assessment_item(attempts+1);
+        });
+
+        item.fetch();
     },
 
     render_perseus_exercise: function(item) {
+        var self = this;
         require([KHAN_EXERCISES_SCRIPT_URL], function() {
-            Exercises.PerseusBridge.load().then(function() {
-                Exercises.PerseusBridge.render_item(item.get_item_data());
-                $(Exercises).trigger("newProblem", {
-                    userExercise: null,
-                    numHints: Exercises.PerseusBridge.itemRenderer.getNumHints()
+            // The exercise view can get closed before these loads finish happening, so check
+            // that it is still open before proceeding - otherwise, errors can ensue.
+            if (!self.closed) {
+                Exercises.PerseusBridge.load().then(function() {
+                    if (!self.closed) {
+                        Exercises.PerseusBridge.render_item(item.get_item_data());
+                        $(Exercises).trigger("newProblem", {
+                            userExercise: null,
+                            numHints: Exercises.PerseusBridge.itemRenderer.getNumHints()
+                        });
+                    }
                 });
-            });
+            }
         });
     },
 
@@ -431,6 +443,7 @@ window.ExerciseView = Backbone.View.extend({
             this.related_video_view.remove();
         }
         this.$("input").qtip("destroy", /* immediate */ true);
+        this.closed = true;
         this.remove();
     }
 

--- a/kalite/distributed/static/js/distributed/topics/router.js
+++ b/kalite/distributed/static/js/distributed/topics/router.js
@@ -1,4 +1,4 @@
-ChannelRouter = Backbone.Router.extend({
+TopicChannelRouter = Backbone.Router.extend({
     initialize: function(options) {
         _.bindAll(this);
         this.default_channel = options.default_channel;
@@ -33,12 +33,7 @@ ChannelRouter = Backbone.Router.extend({
             });
             this.channel = channel;
         }
-        splat = splat || "/";
-        if (splat.indexOf("/", splat.length - 1)==-1) {
-            splat += "/";
-            this.navigate(Backbone.history.getFragment() + "/", {replace: true});
-        }
-        this.control_view.navigate_paths(splat.split("/"));
+        this.navigate_splat(splat);
     },
 
     add_slug: function(slug) {
@@ -67,16 +62,3 @@ ChannelRouter = Backbone.Router.extend({
     }
 });
 
-TopicChannelRouter = ChannelRouter.extend({
-    navigate_channel: function(channel, splat) {
-        if (this.channel!==channel) {
-            this.control_view = new SidebarView({
-                channel: channel,
-                entity_key: "children",
-                entity_collection: TopicCollection
-            });
-            this.channel = channel;
-        }
-        this.navigate_splat(splat);
-    }
-});

--- a/kalite/distributed/static/js/distributed/topics/router.js
+++ b/kalite/distributed/static/js/distributed/topics/router.js
@@ -54,7 +54,7 @@ TopicChannelRouter = Backbone.Router.extend({
             splat += "/";
             this.navigate(Backbone.history.getFragment() + "/");
         }
-        this.control_view.navigate_paths(splat.split("/"));
+        this.control_view.navigate_paths(splat.split("/").slice(0,-1));
     },
 
     trigger_navigation_callback: function() {

--- a/kalite/distributed/static/js/distributed/topics/router.js
+++ b/kalite/distributed/static/js/distributed/topics/router.js
@@ -20,7 +20,7 @@ TopicChannelRouter = Backbone.Router.extend({
 
     intercept_learn_nav: function(event){
         event.preventDefault();
-        this.navigate_default_channel();
+        this.navigate(this.default_channel + "/", {trigger: true});
         return false;
     },
 

--- a/kalite/distributed/static/js/distributed/topics/router.js
+++ b/kalite/distributed/static/js/distributed/topics/router.js
@@ -57,7 +57,7 @@ TopicChannelRouter = Backbone.Router.extend({
     },
 
     set_page_title: function(title) {
-        document.title = document.title.replace(/(Learn)( |:+[^|]*)/, sprintf("$1: %s ", title));
+        document.title = document.title.replace(/(\w+)( |:[^|]*)(\|)/, sprintf("$1: %s $3", title));
     },
 
     trigger_navigation_callback: function() {

--- a/kalite/distributed/static/js/distributed/topics/router.js
+++ b/kalite/distributed/static/js/distributed/topics/router.js
@@ -54,7 +54,11 @@ TopicChannelRouter = Backbone.Router.extend({
             splat += "/";
             this.navigate(Backbone.history.getFragment() + "/");
         }
-        this.control_view.navigate_paths(splat.split("/").slice(0,-1));
+        this.control_view.navigate_paths(splat.split("/").slice(0,-1), this.set_page_title);
+    },
+
+    set_page_title: function(title) {
+        document.title = document.title.replace(/(Learn)( |:+[^|]*)/, sprintf("$1: %s ", title));
     },
 
     trigger_navigation_callback: function() {

--- a/kalite/distributed/static/js/distributed/topics/router.js
+++ b/kalite/distributed/static/js/distributed/topics/router.js
@@ -19,7 +19,6 @@ TopicChannelRouter = Backbone.Router.extend({
     },
 
     intercept_learn_nav: function(event){
-        event.preventDefault();
         this.navigate(this.default_channel + "/", {trigger: true});
         return false;
     },

--- a/kalite/distributed/static/js/distributed/topics/router.js
+++ b/kalite/distributed/static/js/distributed/topics/router.js
@@ -1,6 +1,8 @@
 ChannelRouter = Backbone.Router.extend({
     initialize: function(options) {
+        _.bindAll(this);
         this.default_channel = options.default_channel;
+        $("#nav_learn").click(this.intercept_learn_nav);
     },
 
     routes: {
@@ -14,6 +16,12 @@ ChannelRouter = Backbone.Router.extend({
 
     navigate_default_channel: function() {
         this.navigate(this.default_channel + "/", {trigger: true, replace: true});
+    },
+
+    intercept_learn_nav: function(event){
+        event.preventDefault();
+        this.navigate_default_channel();
+        return false;
     },
 
     navigate_channel: function(channel, splat) {

--- a/kalite/distributed/static/js/distributed/topics/views.js
+++ b/kalite/distributed/static/js/distributed/topics/views.js
@@ -251,8 +251,10 @@ window.SidebarView = BaseView.extend({
         this.state_model.set("open", false);
     },
 
-    navigate_paths: function(paths) {
-        this.topic_node_view.defer_navigate_paths(paths);
+    navigate_paths: function(paths, callback) {
+        // Allow callback here to let the 'title' of the node be returned to the router
+        // This will allow the title of the page to be updated during navigation events
+        this.topic_node_view.defer_navigate_paths(paths, callback);
     }
 
 });
@@ -517,16 +519,16 @@ window.TopicContainerOuterView = BaseView.extend({
         return new_topic;
     },
 
-    defer_navigate_paths: function(paths) {
+    defer_navigate_paths: function(paths, callback) {
         if (this.inner_views.length === 0){
             var self = this;
-            this.listenToOnce(this, "render_complete", function() {self.navigate_paths(paths);});
+            this.listenToOnce(this, "render_complete", function() {self.navigate_paths(paths, callback);});
         } else {
-            this.navigate_paths(paths);
+            this.navigate_paths(paths, callback);
         }
     },
 
-    navigate_paths: function(paths) {
+    navigate_paths: function(paths, callback) {
         var check_views = [];
         for (var i = this.inner_views.length - 2; i >=0; i--) {
             check_views.push(this.inner_views[i]);
@@ -562,6 +564,9 @@ window.TopicContainerOuterView = BaseView.extend({
                     this.remove_topic_views(check_views.length - i);
                 }
             }
+        }
+        if (callback) {
+            callback(this.inner_views[0].model.get("title"));
         }
     },
 

--- a/kalite/distributed/static/js/distributed/topics/views.js
+++ b/kalite/distributed/static/js/distributed/topics/views.js
@@ -567,13 +567,15 @@ window.TopicContainerOuterView = BaseView.extend({
 
     remove_topic_views: function(number) {
         for (var i=0; i < number; i++) {
-            this.inner_views[0].model.set("active", false);
-            if (_.isFunction(this.inner_views[0].close)) {
-                this.inner_views[0].close();
-            } else {
-                this.inner_views[0].remove();
+            if (this.inner_views[0]) {
+                this.inner_views[0].model.set("active", false);
+                if (_.isFunction(this.inner_views[0].close)) {
+                    this.inner_views[0].close();
+                } else {
+                    this.inner_views[0].remove();
+                }
+                this.inner_views.shift();
             }
-            this.inner_views.shift();
         }
         if (this.state_model.get("content_displayed")) {
             number--;


### PR DESCRIPTION
Fixes #3410 and fixes #3391, plus two issues I found while fixing #3410.

Summary of changes:
* Intercept click on 'nav_learn' button while on the learn tab and use the Backbone Router to resolve it.
* Do not pass the empty string that we get from splitting our URLs by "/" due to the trailing slash we have.
* The above then prevents too many inner views on the sidebar being closed when go to a higher level in the hierarchy.
* Clearing any existing callbacks from load of assessment item data, or loading Perseus files - this prevents Perseus trying to render into non-existent DOM elements if someone navigates away before it has finished loading.
* Change the title of the page as we navigate through the topic tree, now instead of always being "Learn | KA Lite", we will instead get the title of the bottom most selected node, e.g. "Learn: Basic Addition 1 | KA Lite".