### PR TITLE
enable Gzip system-wide

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -117,6 +117,7 @@ else:
     INSTALLED_APPS += getattr(local_settings, 'INSTALLED_APPS', tuple())
 
 MIDDLEWARE_CLASSES = (
+    "django.middleware.gzip.GZipMiddleware", # gzip has to be placed at the top, before others
     "django.contrib.messages.middleware.MessageMiddleware",  # needed for django admin
     "django_snippets.session_timeout_middleware.SessionIdleTimeout",
 ) + getattr(local_settings, 'MIDDLEWARE_CLASSES', tuple())


### PR DESCRIPTION
Compress all server response data in Gzip format, which all of our targeting browsers support.
This will significantly reduce the data size to be transferred between the server and client, but since this is dynamic compression, will use some CPU cycle on the server side, and unpack Gzip will have some impact on the client side. For low power devices, we need more benchmarking to find out the balance, perhaps only apply GZip to individual views using the gzip_page() decorator.

if we have lots of binary files to serve, might need to watch out for Gzip backfire