### PR TITLE
Add appropriate HTTP status codes to JSON response errors.

### DIFF
--- a/kalite/contentload/api_views.py
+++ b/kalite/contentload/api_views.py
@@ -84,7 +84,7 @@ def update_all_distributed_callback(request):
             logging.error("Could not save video log for data with missing values: %s" % video)
         except Exception as e:
             error_message = _("Unexpected error importing videos: %(err_msg)s") % {"err_msg": e}
-            return JsonResponseMessageError(error_message)
+            return JsonResponseMessageError(error_message, status=500)
 
     # Save exercises
     n_exercises_uploaded = 0
@@ -105,7 +105,7 @@ def update_all_distributed_callback(request):
             logging.error("Could not save exercise log for data with missing values: %s" % exercise)
         except Exception as e:
             error_message = _("Unexpected error importing exercises: %(err_msg)s") % {"err_msg": e}
-            return JsonResponseMessageError(error_message)
+            return JsonResponseMessageError(error_message, status=500)
 
     return JsonResponseMessageSuccess(_("Uploaded %(num_exercises)d exercises and %(num_videos)d videos") % {
         "num_exercises": n_exercises_uploaded,

--- a/kalite/distributed/api_views.py
+++ b/kalite/distributed/api_views.py
@@ -38,13 +38,13 @@ def time_set(request):
     """
 
     if not settings.ENABLE_CLOCK_SET:
-        return JsonResponseMessageError(_("Time reset can only be done on Raspberry Pi systems."))
+        return JsonResponseMessageError(_("Time reset can only be done on Raspberry Pi systems."), status=403)
 
     # Form does all the data validation - including ensuring that the data passed is a proper date time.
     # This is necessary to prevent arbitrary code being run on the system.
     form = DateTimeForm(data=simplejson.loads(request.body))
     if not form.is_valid():
-        return JsonResponseMessageError(_("Could not read date and time: Unrecognized input data format."))
+        return JsonResponseMessageError(_("Could not read date and time: Unrecognized input data format."), status=400)
 
     try:
 
@@ -53,7 +53,7 @@ def time_set(request):
 
     except PermissionDenied as e:
         return JsonResponseMessageError(
-            _("System permissions prevented time setting, please run with root permissions."))
+            _("System permissions prevented time setting, please run with root permissions."), status=500)
 
     now = datetime.datetime.now().isoformat(" ").split(".")[0]
 

--- a/kalite/facility/api_views.py
+++ b/kalite/facility/api_views.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext as _
 
 from .models import Facility, FacilityGroup, FacilityUser
 from fle_utils.internet.decorators import api_response_causes_reload
-from fle_utils.internet.classes import JsonResponseMessageSuccess
+from fle_utils.internet.classes import JsonResponseMessageSuccess, JsonResponseMessageError
 from kalite.shared.decorators.auth import require_authorized_admin
 
 
@@ -55,7 +55,7 @@ def facility_delete(request, facility_id=None):
         raise PermissionDenied("Teachers cannot delete facilities.")
 
     if request.method != 'POST':
-        return JsonResponseMessageError(_("Method is not allowed."))
+        return JsonResponseMessageError(_("Method is not allowed."), status=405)
 
     facility_id = facility_id or simplejson.loads(request.body or "{}").get("facility_id")
     fac = get_object_or_404(Facility, id=facility_id)

--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -49,7 +49,7 @@ def process_log_from_request(handler):
         if request.GET.get("process_id", None):
             # Get by ID--direct!
             if not isnumeric(request.GET["process_id"]):
-                return JsonResponseMessageError(_("process_id is not numeric."))
+                return JsonResponseMessageError(_("process_id is not numeric."), status=400)
             else:
                 process_log = get_object_or_404(UpdateProgressLog, id=request.GET["process_id"])
 
@@ -74,9 +74,9 @@ def process_log_from_request(handler):
             except Exception as e:
                 # The process finished before we started checking, or it's been deleted.
                 #   Best to complete silently, but for debugging purposes, will make noise for now.
-                return JsonResponseMessageError(unicode(e))
+                return JsonResponseMessageError(unicode(e), status=500)
         else:
-            return JsonResponseMessageError(_("Must specify process_id or process_name"))
+            return JsonResponseMessageError(_("Must specify process_id or process_name"), status=400)
 
         return handler(request, process_log, *args, **kwargs)
     return wrapper_fn_pfr

--- a/python-packages/fle_utils/internet/decorators.py
+++ b/python-packages/fle_utils/internet/decorators.py
@@ -25,7 +25,7 @@ def api_handle_error_with_json(handler):
         except Http404:
             raise
         except Exception as e:
-            return JsonResponseMessageError(_("Unexpected error: %(err)s") % {"err": e})
+            return JsonResponseMessageError(_("Unexpected error: %(err)s") % {"err": e}, status=500)
     return api_handle_error_with_json_wrapper_fn
 
 

--- a/python-packages/securesync/devices/api_views.py
+++ b/python-packages/securesync/devices/api_views.py
@@ -71,7 +71,7 @@ def register_device(request):
             # But still, good to keep track of!
             UnregisteredDevicePing.record_ping(id=client_device.id, ip=get_request_ip(request))
 
-            return JsonResponseMessageError("Failed to validate the chain of trust (%s)." % e, code=EC.CHAIN_OF_TRUST_INVALID, status=401)
+            return JsonResponseMessageError("Failed to validate the chain of trust (%s)." % e, code=EC.CHAIN_OF_TRUST_INVALID, status=500)
 
     if not zone: # old code-path
         try:
@@ -87,9 +87,9 @@ def register_device(request):
                 # A redirect loop here is also possible, if a Device exists in the central server database 
                 # corresponding to the client_device, but no corresponding RegisteredDevicePublicKey exists
                 device = Device.objects.get(public_key=client_device.public_key)
-                return JsonResponseMessageError("This device has already been registered", code=EC.DEVICE_ALREADY_REGISTERED, status=400)
+                return JsonResponseMessageError("This device has already been registered", code=EC.DEVICE_ALREADY_REGISTERED, status=409)
             except Device.DoesNotExist:
-                return JsonResponseMessageError("Device registration with public key not found; login and register first?", code=EC.PUBLIC_KEY_UNREGISTERED, status=400)
+                return JsonResponseMessageError("Device registration with public key not found; login and register first?", code=EC.PUBLIC_KEY_UNREGISTERED, status=404)
 
     client_device.save(imported=True)
 

--- a/python-packages/securesync/devices/api_views.py
+++ b/python-packages/securesync/devices/api_views.py
@@ -50,13 +50,13 @@ def register_device(request):
             raise Exception("Central server version is lower than client version.  This is ... impossible!")
         client_device = models.next().object
     except Exception as e:
-        return JsonResponseMessageError("Could not decode the client device model: %s" % e, code=EC.CLIENT_DEVICE_CORRUPTED)
+        return JsonResponseMessageError("Could not decode the client device model: %s" % e, code=EC.CLIENT_DEVICE_CORRUPTED, status=400)
 
     # Validate the loaded data
     if not isinstance(client_device, Device):
-        return JsonResponseMessageError("Client device must be an instance of the 'Device' model.", code=EC.CLIENT_DEVICE_NOT_DEVICE)
+        return JsonResponseMessageError("Client device must be an instance of the 'Device' model.", code=EC.CLIENT_DEVICE_NOT_DEVICE, status=400)
     if not client_device.verify():
-        return JsonResponseMessageError("Client device must be self-signed with a signature matching its own public key.", code=EC.CLIENT_DEVICE_INVALID_SIGNATURE)
+        return JsonResponseMessageError("Client device must be self-signed with a signature matching its own public key.", code=EC.CLIENT_DEVICE_INVALID_SIGNATURE, status=400)
 
     try:
         zone = register_self_registered_device(client_device, models, data)
@@ -71,7 +71,7 @@ def register_device(request):
             # But still, good to keep track of!
             UnregisteredDevicePing.record_ping(id=client_device.id, ip=get_request_ip(request))
 
-            return JsonResponseMessageError("Failed to validate the chain of trust (%s)." % e, code=EC.CHAIN_OF_TRUST_INVALID)
+            return JsonResponseMessageError("Failed to validate the chain of trust (%s)." % e, code=EC.CHAIN_OF_TRUST_INVALID, status=401)
 
     if not zone: # old code-path
         try:
@@ -87,9 +87,9 @@ def register_device(request):
                 # A redirect loop here is also possible, if a Device exists in the central server database 
                 # corresponding to the client_device, but no corresponding RegisteredDevicePublicKey exists
                 device = Device.objects.get(public_key=client_device.public_key)
-                return JsonResponseMessageError("This device has already been registered", code=EC.DEVICE_ALREADY_REGISTERED)
+                return JsonResponseMessageError("This device has already been registered", code=EC.DEVICE_ALREADY_REGISTERED, status=400)
             except Device.DoesNotExist:
-                return JsonResponseMessageError("Device registration with public key not found; login and register first?", code=EC.PUBLIC_KEY_UNREGISTERED)
+                return JsonResponseMessageError("Device registration with public key not found; login and register first?", code=EC.PUBLIC_KEY_UNREGISTERED, status=400)
 
     client_device.save(imported=True)
 


### PR DESCRIPTION
Adds appropriate HTTP status codes to JSON response errors.
Fixes #3177 Non-semantic HTTP Response codes

Branch: develop
Expected behavior: Provide meaningful error status codes
Steps to reproduce: User registration or login are an example. When a client device tries to register and fails to validate the chain of trust, HTTP 401 unauthorized should be returned, which is not the case.

At the moment JSON response codes are mostly 500 errors or do not contain any status message.
The changes distinguish between client and server side errors and can lead the user / developer in the right direction during the verification of returned JSON error responses.

Summary of changes:
-added missing status kwarg to JsonResponseMessageError
-added missing import of JsonResponseMessageError (kalite/facility/api_views.py)

Thanks, Georgy