### PR TITLE
Use correct import statement for i18n to fix error in the video management page.

### DIFF
--- a/kalite/updates/views.py
+++ b/kalite/updates/views.py
@@ -2,7 +2,7 @@ import git
 import os
 from annoying.decorators import render_to
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext as _, ugettext_lazy
 from django.contrib import messages
 
 from .models import VideoFile
@@ -26,7 +26,7 @@ def update_context(request):
 
 
 @require_admin
-@require_registration(_("video downloads"))
+@require_registration(ugettext_lazy("video downloads"))
 @render_to("updates/update_videos.html")
 def update_videos(request, max_to_show=4):
     context = update_context(request)
@@ -38,7 +38,7 @@ def update_videos(request, max_to_show=4):
 
 
 @require_admin
-@require_registration(_("language packs"))
+@require_registration(ugettext_lazy("language packs"))
 @render_to("updates/update_languages.html")
 def update_languages(request):
     # also refresh language choices here if ever updates js framework fails, but the language was downloaded anyway

--- a/kalite/updates/views.py
+++ b/kalite/updates/views.py
@@ -2,7 +2,7 @@ import git
 import os
 from annoying.decorators import render_to
 
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import ugettext_lazy as _
 from django.contrib import messages
 
 from .models import VideoFile
@@ -26,7 +26,7 @@ def update_context(request):
 
 
 @require_admin
-@require_registration(ugettext_lazy("video downloads"))
+@require_registration(_("video downloads"))
 @render_to("updates/update_videos.html")
 def update_videos(request, max_to_show=4):
     context = update_context(request)
@@ -38,7 +38,7 @@ def update_videos(request, max_to_show=4):
 
 
 @require_admin
-@require_registration(ugettext_lazy("language packs"))
+@require_registration(_("language packs"))
 @render_to("updates/update_languages.html")
 def update_languages(request):
     # also refresh language choices here if ever updates js framework fails, but the language was downloaded anyway


### PR DESCRIPTION
Fix import statement for i18n, causing error on video management page.
Fixes #3436 Video management page does not work and returns an error 

Branch: develop
Expected behavior: Display video management page
Steps to reproduce: In the main navigation click on the manage button. After that in the sub navigation, click on the Videos button.
Actual behavior: Video management page does not work and an error message is displayed
Error
Sorry, but there was an error while trying to load the page.

(NameError: global name '_' is not defined)

A previous commit for i18n, caused a missing import statement, resulting in _ not being found.

Summary of changes:
-Changed to import ugettext_lazy as _
-Changed to use _ instead of ugettext_lazy within the @require_registration decorators

Thanks, Georgy