### PR TITLE
Notify the user, when no learning progress has been made yet.

### DIFF
--- a/kalite/coachreports/static/js/coachreports/student_progress.js
+++ b/kalite/coachreports/static/js/coachreports/student_progress.js
@@ -105,6 +105,14 @@ var StudentProgressContainerView = Backbone.View.extend({
         this.render();
 
         this.collection.fetch();
+        this.collection.fetch({
+            success: function(collection) {
+                // Display a message, when there is no progress
+                if(!collection.length) {
+                    this.$("#playlists-container").append("Your learning progress will be reported here, once you have started by clicking on LEARN.");
+                }
+            }
+       });
     },
 
     render: function() {


### PR DESCRIPTION
Notifies the user, when no learning progress has been made yet on the progress report page.
Fixes #3397 Blank Page on Progress Report 

Branch: develop
Expected behavior: Display information to the user, instead of a blank progress report page. The user should know, that it is possible to make progress by starting to learn and that later on the information will be displayed here.
Steps to reproduce: Logging in as student, click on your name to display a hover menu and then click on My Progress.
Actual behavior: A blank page, that is not intuitive to the user, is displayed.

Summary of changes:
-verify the size of the returned collection with progress data
-if empty, append a message for the user to the playlists-container

Showing the blank page before this pull request:
![progress_error_without_message](https://cloud.githubusercontent.com/assets/67566/6888431/fc211552-d67c-11e4-995d-d25866b042a7.png)

Showing the message displayed to the user, when there is no progress yet:
![progress_error_with_message_after_fix](https://cloud.githubusercontent.com/assets/67566/6888433/01a5e458-d67d-11e4-86d1-f4c8e231b3e1.png)

Normal display, when there is progress:
![progress_report_display](https://cloud.githubusercontent.com/assets/67566/6888434/0a5f44fe-d67d-11e4-9cc0-87fd3b38beed.png)

Thanks, Georgy