### PR TITLE
Fix displaying empty h3 tag, when no dubs available.

### DIFF
--- a/kalite/distributed/hbtemplates/content/content-wrapper.handlebars
+++ b/kalite/distributed/hbtemplates/content/content-wrapper.handlebars
@@ -12,17 +12,17 @@
                         <div class="clear"></div>
                     </div>
 
+                    {{#if dubs_available }}
                     <h3>
-                        {{#if dubs_available }}
-                            <select class="content-language-selector">
-                                {{#each availability }}
-                                <option value="{{ @key }}" {{#ifcond @key "==" ../selected_language }}selected{{/ifcond}}>
-                                    {{ language_name }}
-                                </option>
-                                {{/each}}
-                            </select>
-                        {{/if}}
+                        <select class="content-language-selector">
+                            {{#each availability }}
+                            <option value="{{ @key }}" {{#ifcond @key "==" ../selected_language }}selected{{/ifcond}}>
+                                {{ language_name }}
+                            </option>
+                            {{/each}}
+                        </select>
                     </h3>
+                    {{/if}}
 
                     <span class="title">{{ title }}</span>
                     {{#if organization}}


### PR DESCRIPTION
Fix displaying empty h3 tag, when no dubs available. This causes accessibility issues.

Fixes #3337 Accessibility : Empty h3 tag over video title

Branch: develop
Expected behavior: Display h3 tag with content when dubs are available
Steps to reproduce: Play a video in Learn
Actual behavior: An empty h3 tag is displayed.

Summary of changes:
-Display the h3 tag, only when dubs are available

For screenshots, please refer to #3337

Thanks, Georgy