### PR TITLE
Fix #3438 - remove syncdb and migrate from travis.yml because it's redundant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ script:
 - bin/kalite status
 - bin/kalite stop --traceback -v 2
 - python python-packages/fle_utils/tests.py
-- bin/kalite manage syncdb --migrate --noinput --traceback
 - coverage run --source=kalite --omit="kalite/testing/*,*/tests/*" manage.py test --traceback -v 2
 - grunt jshint
 - bin/kalite manage bundleassets


### PR DESCRIPTION
It's already run by `kalite start` earlier in the travis file.