### PR TITLE
smart_translate_item_data: translate strings automatically

### DIFF
--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -517,15 +517,18 @@ def smart_translate_item_data(item_data):
     item_data and translates only the content field.
 
     """
-    if isinstance(item_data, dict):
-        if 'content' in item_data:
-            item_data['content'] = _(item_data['content']) if item_data['content'] else ""
+    # just translate strings immediately
+    if isinstance(item_data, basestring):
+        return _(item_data)
 
-        for field, field_data in item_data.iteritems():
-            if isinstance(field_data, dict):
-                item_data[field] = smart_translate_item_data(field_data)
-            elif isinstance(field_data, list):
-                item_data[field] = map(smart_translate_item_data, field_data)
+    if 'content' in item_data:
+        item_data['content'] = _(item_data['content']) if item_data['content'] else ""
+
+    for field, field_data in item_data.iteritems():
+        if isinstance(field_data, dict):
+            item_data[field] = smart_translate_item_data(field_data)
+        elif isinstance(field_data, list):
+            item_data[field] = map(smart_translate_item_data, field_data)
 
 
     return item_data

--- a/kalite/topic_tools/tests/utils_tests.py
+++ b/kalite/topic_tools/tests/utils_tests.py
@@ -44,3 +44,12 @@ class SmartTranslateItemDataTests(KALiteTestCase):
         ugettext_dummy.assert_called_once_with(TRANS_STRING)
 
         self.assertEqual(result, expected_data)
+
+    def test_simple_string(self):
+        test_data = TRANS_STRING
+        expected_data = DUMMY_STRING
+
+        result = mod.smart_translate_item_data(test_data)
+        ugettext_dummy.assert_called_once_with(TRANS_STRING)
+
+        self.assertEqual(result, expected_data)

--- a/kalite/topic_tools/tests/utils_tests.py
+++ b/kalite/topic_tools/tests/utils_tests.py
@@ -37,7 +37,6 @@ class SmartTranslateItemDataTests(KALiteTestCase):
         self.assertEqual(result, expected_data)
 
     def test_content_inside_radio_field(self):
-        pass
         test_data = {'radio 1': {'widgets': {'content': TRANS_STRING}}}
         expected_data = {'radio 1': {'widgets': {'content': DUMMY_STRING}}}
 


### PR DESCRIPTION
Fixes https://github.com/learningequality/ka-lite/issues/3413.

Upon reading [KA's code](https://gist.github.com/aronasorman/e8f77ad7444d55c5a5e1#file-models-py-L127) we apparently don't translate a list of strings inside an assessment item properly. The symptom of this is the 500 error code which @EdDixon caught. So now, when we see a string (perhaps passed as an argument in `item_data[field] = map(smart_translate_item_data, field_data)`, we now just translate that string directly.

Now also features tests! (tm)