### PR TITLE
More i18n fixes

### DIFF
--- a/data/khan/channel_data.json
+++ b/data/khan/channel_data.json
@@ -1,7 +1,7 @@
 {
     "channel_name": "KA Lite",
     "head_line": "A free world-class education for anyone anywhere.",
-    "tag_line": "KA Lite is a lightweight web server for viewing and interacting with core Khan Academy content (videos and exercises) without needing an Internet connection.",
+    "tag_line": "KA Lite is a light-weight web server for viewing and interacting with core Khan Academy content (videos and exercises) without needing an Internet connection.",
     "channel_license": "CC-BY-NC-SA",
     "footer_text": "Videos © 2015 Khan Academy (Creative Commons) // Exercises © 2015 Khan Academy"
 }

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -397,7 +397,7 @@ window.ExerciseView = Backbone.View.extend({
     },
 
     update_title: function() {
-        this.$(".exercise-title").text(this.data_model.get("title"));
+        this.$(".exercise-title").text(gettext(this.data_model.get("title")));
     },
 
     hint_used: function() {

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -397,7 +397,7 @@ window.ExerciseView = Backbone.View.extend({
     },
 
     update_title: function() {
-        this.$(".exercise-title").text(gettext(this.data_model.get("title")));
+        this.$(".exercise-title").text(this.data_model.get("title"));
     },
 
     hint_used: function() {

--- a/kalite/distributed/static/perseus/ke/local-only/i18n.js
+++ b/kalite/distributed/static/perseus/ke/local-only/i18n.js
@@ -104,7 +104,7 @@
             str = str.messages[0];
         }
 
-        return interpolateStringToArray(str, options).join("");
+        return interpolateStringToArray(gettext(str), options).join("");
     };
 
     /**

--- a/kalite/distributed/templates/distributed/partials/khan_dummy_channel_translation.html
+++ b/kalite/distributed/templates/distributed/partials/khan_dummy_channel_translation.html
@@ -2,5 +2,5 @@
 
 {% trans "KA Lite" %}
 {% trans "A free world-class education for anyone anywhere." %}
-{% trans "KA Lite is a lightweight web server for viewing and interacting with core Khan Academy content (videos and exercises) without needing an Internet connection." %}
+{% trans "KA Lite is a light-weight web server for viewing and interacting with core Khan Academy content (videos and exercises) without needing an Internet connection." %}
 {% trans "Videos and Exercises © 2014 Khan Academy" %}

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -165,7 +165,7 @@ def get_exercise_cache(force=False, language=settings.LANGUAGE_CODE):
                 exercise_template = os.path.join(exercise_lang, exercise_file)
 
 
-            with i18n.translate_block(exercise_lang):
+            with i18n.translate_block(language):
                 exercise["available"] = available
                 exercise["lang"] = exercise_lang
                 exercise["template"] = exercise_template

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -534,8 +534,7 @@ def smart_translate_item_data(item_data):
             elif isinstance(field_data, list):
                 item_data[field] = map(smart_translate_item_data, field_data)
 
-
-            return item_data
+        return item_data
 
 
 

--- a/kalite/topic_tools/tests/utils_tests.py
+++ b/kalite/topic_tools/tests/utils_tests.py
@@ -17,6 +17,18 @@ class SmartTranslateItemDataTests(KALiteTestCase):
     def tearDown(self):
         ugettext_dummy.reset_mock()
 
+    def test_list_of_dicts(self):
+        # test_data = {"hints": [{"content": TRANS_STRING, "images": {}, "widgets": {}}]}
+        # expected_data = {"hints": [{"content": DUMMY_STRING, "images": {}, "widgets": {}}]}
+        self.maxDiff = None
+        test_data = {'question': {'content': TRANS_STRING, 'images': {'/content/khan/f24b1c8daf0d1b16bf2dc391393b655e72190290.png': {'width': 450, 'height': 81}}, 'widgets': {'radio 1': {'version': {'major': 0, 'minor': 0}, 'type': 'radio', 'graded': True, 'options': {'onePerLine': True, 'noneOfTheAbove': False, 'choices': [], 'displayCount': None, 'multipleSelect': False, 'randomize': True}}}}, 'answerArea': {'calculator': False, 'type': 'multiple', 'options': {'content': '', 'images': {}, 'widgets': {}}}, 'itemDataVersion': {'major': 0, 'minor': 1}, 'hints': [{'content': TRANS_STRING, 'images': {}, 'widgets': {}}]}
+        expected_data = {'question': {'content': DUMMY_STRING, 'images': {'/content/khan/f24b1c8daf0d1b16bf2dc391393b655e72190290.png': {'width': 450, 'height': 81}}, 'widgets': {'radio 1': {'version': {'major': 0, 'minor': 0}, 'type': 'radio', 'graded': True, 'options': {'onePerLine': True, 'noneOfTheAbove': False, 'choices': [], 'displayCount': None, 'multipleSelect': False, 'randomize': True}}}}, 'answerArea': {'calculator': False, 'type': 'multiple', 'options': {'content': '', 'images': {}, 'widgets': {}}}, 'itemDataVersion': {'major': 0, 'minor': 1}, 'hints': [{'content': DUMMY_STRING, 'images': {}, 'widgets': {}}]}
+
+        result = mod.smart_translate_item_data(test_data)
+        # ugettext_dummy.assert_called_once_with(TRANS_STRING)
+
+        self.assertEqual(result, expected_data)
+
     def test_list_of_lists(self):
         test_data = [[TRANS_STRING]]
         expected_data = [[DUMMY_STRING]]


### PR DESCRIPTION
Summary of changes:
1. Match the KA channel description with that's in the po file (already fixed before, but someone edited it.)
![screen shot 2015-04-02 at 9 35 01 am](https://cloud.githubusercontent.com/assets/191955/6968429/97e1e9d0-d91b-11e4-90fb-2dcae062fde5.png)

2. i18nize the exercise title (don't mind the exercise text, this is a khan exercise).
![screen shot 2015-04-02 at 9 34 40 am](https://cloud.githubusercontent.com/assets/191955/6968431/9f799fa8-d91b-11e4-8ecc-fb5276837efb.png)

3. i18nize the hint button.
![screen shot 2015-04-02 at 9 36 17 am](https://cloud.githubusercontent.com/assets/191955/6968448/cb3cec30-d91b-11e4-9715-3b9aa18f77f9.png)

Remaining issues:

Couldn't i18nize the "Remaining hints" text in the hint button:
![screen shot 2015-04-02 at 9 37 13 am](https://cloud.githubusercontent.com/assets/191955/6968467/f9e3c31a-d91b-11e4-93b8-324c7cd02f14.png)

Fixing this properly would require more extensive changes to the perseus codebase, related to integrating Django's and `jed.js`'s catalog file. I'm getting there, but I need more time, and I believe this shouldn't be a blocker for 0.13.


