### PR TITLE
Registration tweaks (destined for central server submodule)

### DIFF
--- a/python-packages/securesync/devices/api_views.py
+++ b/python-packages/securesync/devices/api_views.py
@@ -54,7 +54,10 @@ def register_device(request):
     if not isinstance(client_device, Device):
         return JsonResponseMessageError("Client device must be an instance of the 'Device' model.", code=EC.CLIENT_DEVICE_NOT_DEVICE)
     if not client_device.verify():
-        return JsonResponseMessageError("Client device must be self-signed with a signature matching its own public key.", code=EC.CLIENT_DEVICE_INVALID_SIGNATURE)
+        # We've been getting this verification error a lot, even when we shouldn't. Send more details to us by email so we can diagnose.
+        msg = "\n\n".join([request.body, client_device._hashable_representation(), str(client_device.validate()), client_device.signed_by_id, client_device.id, str(request)])
+        send_mail("Client device did not verify", msg, "kalite@learningequality.org", ["errors@learningequality.org"])
+        return JsonResponseMessageError("Client device must be self-signed with a signature matching its own public key!", code=EC.CLIENT_DEVICE_INVALID_SIGNATURE)
 
     try:
         zone = register_self_registered_device(client_device, models, data)

--- a/python-packages/securesync/devices/forms.py
+++ b/python-packages/securesync/devices/forms.py
@@ -48,7 +48,8 @@ class RegisteredDevicePublicKeyForm(forms.ModelForm):
         return zone
 
     def clean_public_key(self):
-        public_key = self.cleaned_data["public_key"]
+        # Some browsers (unclear which) are converting plus signs to spaces during decodeURIComponent
+        public_key = self.cleaned_data["public_key"].replace(" ", "+")
         if RegisteredDevicePublicKey.objects.filter(public_key=public_key).count() > 0:
             raise forms.ValidationError(_("This public key has already been registered!"))
         return public_key


### PR DESCRIPTION
Two small fixes in here:
- Send us a notification with diagnostic info if the "Client device did not verify" occurs again in production.
- Ensure public key submitted for registration uses "+" rather than " ", to avoid reg issue caused by parsing oddities in some sort of weird browser.