### PR TITLE
Replace urllib.urlopen with more robust requests.get method.

### DIFF
--- a/python-packages/securesync/devices/views.py
+++ b/python-packages/securesync/devices/views.py
@@ -1,5 +1,6 @@
 """
 """
+import requests
 import urllib
 from annoying.decorators import render_to
 from annoying.functions import get_object_or_None
@@ -92,8 +93,8 @@ def central_server_down_or_error(error_msg):
     error_msg: a string
     """
     if error_msg:
-        if urllib.urlopen(settings.CENTRAL_SERVER_URL).getcode() != 200:
-            return {"error_msg": "Central Server is not reachable, Please try after sometime."}
+        if requests.get(settings.CENTRAL_SERVER_URL).status_code != 200:
+            return {"error_msg": "Central Server is not reachable; please try after some time."}
         else:
             return {"error_msg": error_msg}
 

--- a/python-packages/securesync/devices/views.py
+++ b/python-packages/securesync/devices/views.py
@@ -94,7 +94,7 @@ def central_server_down_or_error(error_msg):
     """
     if error_msg:
         if requests.get(settings.CENTRAL_SERVER_URL).status_code != 200:
-            return {"error_msg": "Central Server is not reachable; please try after some time."}
+            return {"error_msg": _("Central Server is not reachable; please try again after some time.")}
         else:
             return {"error_msg": error_msg}
 

--- a/python-packages/securesync/tests/regression_tests.py
+++ b/python-packages/securesync/tests/regression_tests.py
@@ -14,16 +14,16 @@ class CentralServerDownMessageTest(TestCase):
     was returned by the central server, and pass it along.
     """
 
-    @patch('urllib.urlopen')
+    @patch('requests.get')
     def test_error_message_when_central_server_down(self, mock):
-        mock().getcode.return_value = 500
+        mock().status_code = 500
         error_msg = "Some error message ah!"
-        expected_msg = "Central Server is not reachable, Please try after sometime."
+        expected_msg = "Central Server is not reachable; please try again after some time."
         self.assertEqual(central_server_down_or_error(error_msg)['error_msg'], expected_msg)
     
-    @patch('urllib.urlopen')
+    @patch('requests.get')
     def test_error_message_when_central_server_up(self, mock):
-        mock().getcode.return_value = 200
+        mock().status_code = 200
         error_msg = "Some error message ah!"
         expected_msg = "Some error message ah!"
         self.assertEqual(central_server_down_or_error(error_msg)['error_msg'], expected_msg)


### PR DESCRIPTION
This avoids a "peer did not return certificate" error being thrown; urllib.urlopen is a bit flaky.