### PR TITLE
Fixes #3168: New responsive menu for mobile devices and small desktop screen views

### DIFF
--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -206,15 +206,12 @@ a#user-name-a.dropdown-toggle {
         left: 0;
     }
 }
-
 .glyphicon-search:hover, .glyphicon-search:focus {
     cursor: pointer;
 }
 form#search-box {
     margin-right: 25px;
     margin-top: 14px;
-    position: relative;
-    right: 30px;
 }
 input #search.ui-autocomplete-input {
     font-size: 12px;
@@ -228,9 +225,6 @@ form .input-group {
 #search-button {
     color: #fff !important;
     background: #5AA685 !important;
-    position: relative;
-    left: 188px;
-    top: -2px;
     border-radius: 3px;
 }
 .source {
@@ -466,19 +460,6 @@ footer {
     h3.suggested-action-title { font-size: 18px; }
 
 }
-@media only screen and (max-width: 767px) {
-    .main-headline { font-size: 27px; margin-bottom: 0; margin-top: 0; }
-    form#search-box { margin-bottom: 10px; }
-    h3.suggested-action-title { font-size: 24px; padding-top: 15px; }
-    .suggested-action .topic-list a { font-size: 1.25em; }
-    .language-select { text-align: center; margin: 10px 0px; height: 20px !important; }
-    .language-select select { top: 0 !important; }
-    .teacher-only.language-select { height: 20px !important; }
-    .navbar-nav .open .dropdown-menu { background: white; }
-    #search_box { width: 30%; margin-left: 15px; }
-    .navbar-nav { margin: 0px 0px; }
-    
-}
 @media only screen and (max-width: 469px) {
     h3.suggested-action-title { font-size: 18px; padding-top: 0; }
     #suggested-action-p { font-size: 14px; }
@@ -499,20 +480,12 @@ footer {
     }
 }
 @media screen and (max-width: 454px) {
-    #search_box {
-        width: 70%;
-        margin-left: 8%;;
-    }
     .navbar-nav {
         margin: 0px 0px;
     }
     .navbar-collapse.in {
         overflow-y: hidden;
         overflow-x: hidden;
-    }
-    #search_btn {
-        float: right;
-        margin-right: 9%;
     }
     .manage-nav ul li {
         width: 100px;
@@ -524,8 +497,9 @@ footer {
         margin: 0 2px -10px -4px;
     }
 }
-@media screen and (max-width: 767px) {
+/* END SMALL MOBILE SCREENS */
 
+@media screen and (max-width: 767px) {
     /*** RESTYLING OF FIRST LEVEL DROPDOWN NAV ***/
     .nav-tabs li a {
         margin-bottom: 0px;
@@ -590,25 +564,24 @@ footer {
     }
     /*** END RESTYLE OF FIRST LEVEL DROPDOWN NAV ***/
 
-    .navbar-form {
-        padding: 0px 0px;
-    }
-    form#search-box{
-        margin-left: 5px;
-    }
-    form#search-box, #language_selector {
-        margin-bottom: 0px;
-    }
-    .navbar-collapse{
-        margin-left: 10px;
-    }
+    .main-headline { font-size: 27px; margin-bottom: 0; margin-top: 0; }
+    h3.suggested-action-title { font-size: 24px; padding-top: 15px; }
+    .suggested-action .topic-list a { font-size: 1.25em; }
+    .language-select { text-align: center; margin: 10px 0px; height: 20px !important; }
+    .language-select select { top: 0 !important; }
+    .teacher-only.language-select { height: 20px !important; }
+    .navbar-nav .open .dropdown-menu { background: white; }
+    .navbar-nav { margin: 0px 0px; }
+    .navbar-form { padding: 0px 0px; }
+    .input-group { width: 100%; }
+    #search-box { margin: auto !important; }
+    #search-box input { width: 85% !important; float: none !important; }
+    form#search-box { margin-bottom: 10px; width: 100%; margin-right: 0 !important;}
+    form#search-box, #language_selector { margin-bottom: 0px; }
+    .navbar-collapse { margin-left: 10px; }
     #search_input{
         margin-bottom: 10px;
         list-style-type: none;
-    }
-    #search_btn {
-        color: #fff !important;
-        background: #5AA685 !important;
     }
     .navbar-collapse.in {
         overflow-y: hidden;

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -475,6 +475,8 @@ footer {
     .language-select select { top: 0 !important; }
     .teacher-only.language-select { height: 20px !important; }
     .navbar-nav .open .dropdown-menu { background: white; }
+    #search_box { width: 30%; margin-left: 15px; }
+    .navbar-nav { margin: 0px 0px; }
     
 }
 @media only screen and (max-width: 469px) {
@@ -491,8 +493,8 @@ footer {
 /* SMALLEST MOBILE SCREEN */
 @media (max-width: 454px) {
     #search_box {
-        width: 75%;
-        margin-left: 15px;
+        width: 70%;
+        margin-left: 8%;;
     }
     .navbar-nav {
         margin: 0px 0px;
@@ -501,6 +503,10 @@ footer {
         overflow-y: hidden;
         overflow-x: hidden;
     }
+    #search_btn {
+        float: right;
+        margin-right: 9%;
+    }
 }
 @media (max-width: 480px) {
     .manage-nav ul li {
@@ -508,35 +514,46 @@ footer {
         margin: 0 2px -10px -4px;
     }
 }
-
-/* SMALL TABLET */
-@media only screen and (min-width: 455px) and (max-width: 600px) {
-    #search_box {
-        width: 87%;
-        margin-left: 15px;
-
-    }
-    .navbar-nav {
-        margin: 0px 0px;
-    }
-
-}
-
-/* LARGER TABLETS */
-@media only screen and (min-width: 600px) and (max-width: 767px) {
-
-    #search_box{
-        width: 90%;
-        margin-left: 15px;
-    }
-
-    .navbar-nav {
-         margin: 0px 0px;
-    }
-}
-
-
 @media screen and (max-width: 767px) {
+    /*** RESTYLING OF FIRST LEVEL DROPDOWN NAV ***/
+    .nav-tabs li a {
+        margin-bottom: 0px;
+        background: transparent;
+        border-left: 0px !important;
+        border-top: 0px !important;
+        border-right: 0px !important;
+        border-radius: 0 0 0 0 !important;
+    }
+    .nav-tabs li {
+        width: 100% !important;
+        text-align: left !important;
+    }
+    .nav-tabs li.active a:hover,
+    .nav-tabs li.active a,
+    .nav-tabs li a:hover,
+    .nav-tabs li.active a,
+    .nav-tabs li a:active {
+        border-left: 0px !important;
+        border-top: 0px !important;
+        border-right: 0px !important;
+        background: #76afd5 !important;
+        border-radius: 0 0 0 0;
+    }
+    .nav-tabs li.active a:hover,
+    .nav-tabs li a:hover, 
+    .nav-tabs li.active a {
+        color: white !important;
+    }
+    .nav-tabs li.active a,
+    .nav-tabs li a:active {
+        background: transparent !important;
+    }
+    #username-divider {
+        margin: -5px 0 10px 0;
+        background: #a3ceea;
+        color: #a3ceea;
+    }
+    /*** END RESTYLE OF FIRST LEVEL DROPDOWN NAV ***/
     .navbar-form {
         padding: 0px 0px;
     }
@@ -549,11 +566,9 @@ footer {
     .navbar-collapse{
         margin-left: 10px;
     }
-    .nav-tabs li {
-        margin-bottom: 0;
-    }
     #search_input{
         margin-bottom: 10px;
+        list-style-type: none;
     }
     #search_btn {
         color: #fff !important;

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -134,12 +134,12 @@ input[type="submit"] {
 .top-nav li a:hover,
 .top-nav li a,
 .top-nav li.active a,
-.top-nav li a:active {
+.top-nav li a:active,
+a#user-name-a.dropdown-toggle {
     border-left: 2px solid #5AA685;
     border-top: 2px solid #5AA685;
     border-right: 2px solid #5AA685;
 }
-
 .navbar ul li.dropdown,
 .navbar ul li.dropdown.open {
     padding-right: 0;
@@ -553,13 +553,17 @@ footer {
         background: #76afd5 !important;
         border-radius: 0 0 0 0;
     }
-    .nav-tabs li.active a:hover,
-    .nav-tabs li a:hover,
-    .navbar ul li.dropdown.open a, 
-    .top-nav li.active a,
+    .navbar ul li.dropdown.open a,
     #points {
+        color: #32739E !important;
+        font-weight: normal !important;
+    }
+    .navbar ul li.dropdown.open a:hover,
+    .top-nav li.active a,
+    .top-nav li.active a:hover,
+    .nav-tabs li a:hover {
         color: white !important;
-        font-weight: bold;
+        font-weight: bold !important;
     }
     .nav-tabs li a:active,
     .navbar ul li.dropdown.open a,
@@ -579,12 +583,10 @@ footer {
     .nav-divider {
         background: #a3ceea;
     }
-    .navbar ul li.dropdown.open ul.dropdown-menu li a,
-    #points {
+    #username {
         text-transform: uppercase !important;
-    }
-    .navbar ul li.dropdown.open ul.dropdown-menu li {
-        padding-left: 20px;
+        font-weight: bold;
+        color: #32839E;
     }
     /*** END RESTYLE OF FIRST LEVEL DROPDOWN NAV ***/
 

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -491,7 +491,14 @@ footer {
 }
 
 /* SMALLEST MOBILE SCREEN */
-@media (max-width: 454px) {
+@media screen and (max-width: 342px) {
+    .manage-nav {
+        width: 320px !important;
+        margin-left: -17px;
+        text-align: center;
+    }
+}
+@media screen and (max-width: 454px) {
     #search_box {
         width: 70%;
         margin-left: 8%;;
@@ -507,14 +514,18 @@ footer {
         float: right;
         margin-right: 9%;
     }
+    .manage-nav ul li {
+        width: 100px;
+    }
 }
-@media (max-width: 480px) {
+@media screen and (max-width: 480px) {
     .manage-nav ul li {
         text-align: center;
         margin: 0 2px -10px -4px;
     }
 }
 @media screen and (max-width: 767px) {
+
     /*** RESTYLING OF FIRST LEVEL DROPDOWN NAV ***/
     .nav-tabs li a {
         margin-bottom: 0px;
@@ -523,8 +534,9 @@ footer {
         border-top: 0px !important;
         border-right: 0px !important;
         border-radius: 0 0 0 0 !important;
+        font-weight: bold;
     }
-    .nav-tabs li {
+    .top-nav li {
         width: 100% !important;
         text-align: left !important;
     }
@@ -532,7 +544,9 @@ footer {
     .nav-tabs li.active a,
     .nav-tabs li a:hover,
     .nav-tabs li.active a,
-    .nav-tabs li a:active {
+    .nav-tabs li a:active,
+    .navbar-nav .open .dropdown-menu,
+    .navbar-nav .open .dropdown-menu li a:hover {
         border-left: 0px !important;
         border-top: 0px !important;
         border-right: 0px !important;
@@ -540,12 +554,18 @@ footer {
         border-radius: 0 0 0 0;
     }
     .nav-tabs li.active a:hover,
-    .nav-tabs li a:hover, 
-    .nav-tabs li.active a {
+    .nav-tabs li a:hover,
+    .navbar ul li.dropdown.open a, 
+    .top-nav li.active a,
+    #points {
         color: white !important;
+        font-weight: bold;
     }
-    .nav-tabs li.active a,
-    .nav-tabs li a:active {
+    .nav-tabs li a:active,
+    .navbar ul li.dropdown.open a,
+    li.dropdown.open.sub-active,
+    .navbar-nav .open .dropdown-menu,
+    #points, .dropdown-menu .divider {
         background: transparent !important;
     }
     #username-divider {
@@ -553,7 +573,21 @@ footer {
         background: #a3ceea;
         color: #a3ceea;
     }
+    .dropdown-menu .divider {
+        margin: 6px 0px;
+    }
+    .nav-divider {
+        background: #a3ceea;
+    }
+    .navbar ul li.dropdown.open ul.dropdown-menu li a,
+    #points {
+        text-transform: uppercase !important;
+    }
+    .navbar ul li.dropdown.open ul.dropdown-menu li {
+        padding-left: 20px;
+    }
     /*** END RESTYLE OF FIRST LEVEL DROPDOWN NAV ***/
+
     .navbar-form {
         padding: 0px 0px;
     }
@@ -578,15 +612,19 @@ footer {
         overflow-y: hidden;
         overflow-x: hidden;
     }
-    .mobile-nav, .mobile-manage-nav {
-        margin: 5px 0px;
-    }
     .teach-nav, .manage-nav {
         border-bottom: none !important;
         text-align: center;
     }
-    .teach-nav li, .manage-nav li {
+    .teach-nav li, .manage-nav ul li {
         border-top-left-radius: 0px !important; 
         border-top-right-radius: 0px !important;
+        margin: 2px 0px !important;
+        border-bottom: 3px solid #5AA685;
+    }
+}
+@media screen and (min-width: 767px) {
+    .nav-divider {
+        display: none !important;
     }
 }

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -724,8 +724,7 @@ a.disabled {
     border-top-left-radius: 6px;
     border-bottom-left-radius: 6px;
     position: relative;
-    top: -2px;
-    float: right;
+    top: -1px;
     padding: 2px 5px;
     font-size: 12px;
 }

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -89,18 +89,32 @@
             FastClick.attach(document.body);
         });
 
-         /* Jessica TODO: Backbonify this function and this page... when the time comes.
+         /* TODO(jtamiace): Backbonify this function and this page... when the time comes.
             This function addresses Bootstrap's limitation of having a dropdown menu in an already collapsed menu*/
-          window.addEventListener("resize", function (e) {
-              if ( $('body').innerWidth() <= 750 ) {
+          var collapsedNav = $(function () {
+            if ( $('body').innerWidth() <= 750 ) {
                 document.getElementById("user-name-a").removeAttribute("data-toggle");
                 document.getElementById("user-name").classList.add("open");
-              }
-              if ( $('body').innerWidth() >= 751 ) {
+              } 
+            if ( $('body').innerWidth() >= 751 ) {
                 document.getElementById("user-name-a").setAttribute("data-toggle", "dropdown");
                 document.getElementById("user-name").classList.remove("open");
               }
             });
+          window.addEventListener("resize", collapsedNav);
+          //window.addEventListener("onload", collapsedNav);
+          
+
+
+          /*window.addEventListener("resize", function (e) {
+              if ( $('body').innerWidth() <= 750 ) {
+                document.getElementById("user-name-a").removeAttribute("data-toggle");
+                document.getElementById("user-name").classList.add("open");
+              } else {
+                document.getElementById("user-name-a").setAttribute("data-toggle", "dropdown");
+                document.getElementById("user-name").classList.remove("open");
+              }
+            });*/
 
         </script>
         <script type="text/javascript" src="{% static 'js/underscore-min.js' %}"></script>
@@ -195,25 +209,14 @@
                                   <img src="/data/{{ channel }}/images/horizontal-logo-small.png" alt="{{ channel_data.channel_name }} {% trans 'logo' %}">
                               </a>
                               <div class="pull-right visible-xs sitepoint" id="points-xs"></div>
-                          </div>
-                          {# Search box for responsive nav #}
-                              <div class="visible-xs">
-                                  <li id="search_input">
-                                      <form class="navbar-form " action="{% url 'search' %}" method="get"  role="search">
-                                          {% comment %}translators: this will appear in the navigation bar. please try to keep it as short as possible.{% endcomment %}
-                                          <input type="text" name="query" id="search_box" class="form-control pull-left" placeholder="{% trans 'Topic, video, exercise...' %}" aria-label="{% trans 'Search for' %}" />
-                                          <button class="btn btn-default" id="search_btn" type="submit" aria-label="{% trans 'Submit' %}"><i class="glyphicon glyphicon-search" aria-hidden="true"></i></button>
-                                      </form>
-                                  </li>
-                              </div>
+                          </div>                             
                       </div>
 
                       <div class="collapse navbar-collapse top-nav">
                           <ul class="nav navbar-nav navbar-right nav-tabs " id="topnav"role="tablist">
-
                             <!-- For all users -->
-                            {# Search box for normal nav #}
-                            <li class="hidden-xs">
+                            {# Search box #}
+                            <li>
                               <form class="navbar-form" action="{% url 'search' %}" method="get" id="search-box" role="search">
                                 {% comment %}translators: this will appear in the navigation bar. please try to keep it as short as possible.{% endcomment %}
                                 <div class="input-group">

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -91,7 +91,8 @@
 
          /* TODO(jtamiace): Backbonify this function and this page... when the time comes.
             This function addresses Bootstrap's limitation of having a dropdown menu in an already collapsed menu*/
-          var collapsedNav = $(function () {
+          
+          function collapsedNav(e) {
             if ( $('body').innerWidth() <= 750 ) {
                 document.getElementById("user-name-a").removeAttribute("data-toggle");
                 document.getElementById("user-name").classList.add("open");
@@ -100,21 +101,9 @@
                 document.getElementById("user-name-a").setAttribute("data-toggle", "dropdown");
                 document.getElementById("user-name").classList.remove("open");
               }
-            });
-          window.addEventListener("resize", collapsedNav);
-          //window.addEventListener("onload", collapsedNav);
-          
-
-
-          /*window.addEventListener("resize", function (e) {
-              if ( $('body').innerWidth() <= 750 ) {
-                document.getElementById("user-name-a").removeAttribute("data-toggle");
-                document.getElementById("user-name").classList.add("open");
-              } else {
-                document.getElementById("user-name-a").setAttribute("data-toggle", "dropdown");
-                document.getElementById("user-name").classList.remove("open");
-              }
-            });*/
+            };
+          window.addEventListener("resize", collapsedNav, false);
+          window.addEventListener("pageshow", collapsedNav, true);
 
         </script>
         <script type="text/javascript" src="{% static 'js/underscore-min.js' %}"></script>

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -91,7 +91,6 @@
 
          /* TODO(jtamiace): Backbonify this function and this page... when the time comes.
             This function addresses Bootstrap's limitation of having a dropdown menu in an already collapsed menu*/
-          
           function collapsedNav(e) {
             if ( $('body').innerWidth() <= 750 ) {
                 document.getElementById("user-name-a").removeAttribute("data-toggle");

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -84,22 +84,16 @@
 
         <script type="text/javascript" src="{% static 'js/fastclick.js' %}"></script>
         <script>
+
         $(function() {
             FastClick.attach(document.body);
         });
 
+         /* Jessica TODO: Backbonify this function... when the time comes.*/
         $(function() {
-              if ( $(window).width() <= 767 ) {
-                document.getElementById("user-name-a").removeAttribute("data-toggle");
-                document.getElementById("user-name").classList.add("open");
-              }
-            });
-
-        $(function() {
-            var logout = document.getElementById("logout");
-            var topnav = document.getElementById("topnav");
             if ( $(window).width() <= 767 ) {
-              //$(logout).parent().prepend($(topnav));
+              document.getElementById("user-name-a").removeAttribute("data-toggle");
+              document.getElementById("user-name").classList.add("open");
             }
           });
 
@@ -209,7 +203,6 @@
                               </div>
                       </div>
 
-                      {# implement dropdown here? #}
                       <div class="collapse navbar-collapse top-nav">
                           <ul class="nav navbar-nav navbar-right nav-tabs " id="topnav"role="tablist">
 
@@ -296,6 +289,11 @@
                               </li>
                             {% endif %}
                             
+                            <hr class="nav-divider student-only">
+                            {% if request.is_admin or request.session.facility_user.facility %}
+                            <hr class="nav-divider admin-only">
+                            {% endif %}
+
                             <!-- Farthest right nav is logged in user dropdown -->
                             <li class="dropdown {% block help_active %}{% endblock help_active %}{% block progress_active %}{% endblock progress_active %} " id="user-name">
                               <a href="#" class="logged-in-only dropdown-toggle" data-toggle="dropdown" id="user-name-a">

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -89,13 +89,18 @@
             FastClick.attach(document.body);
         });
 
-         /* Jessica TODO: Backbonify this function... when the time comes.*/
-        $(function() {
-            if ( $(window).width() <= 767 ) {
-              document.getElementById("user-name-a").removeAttribute("data-toggle");
-              document.getElementById("user-name").classList.add("open");
-            }
-          });
+         /* Jessica TODO: Backbonify this function and this page... when the time comes.
+            This function addresses Bootstrap's limitation of having a dropdown menu in an already collapsed menu*/
+          window.addEventListener("resize", function (e) {
+              if ( $('body').innerWidth() <= 750 ) {
+                document.getElementById("user-name-a").removeAttribute("data-toggle");
+                document.getElementById("user-name").classList.add("open");
+              }
+              if ( $('body').innerWidth() >= 751 ) {
+                document.getElementById("user-name-a").setAttribute("data-toggle", "dropdown");
+                document.getElementById("user-name").classList.remove("open");
+              }
+            });
 
         </script>
         <script type="text/javascript" src="{% static 'js/underscore-min.js' %}"></script>

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -51,6 +51,8 @@
                 window.js_errors = window.js_errors || [];
                 window.js_errors.push(msg);
             }
+
+            
         </script>
 
         {% if request.in_context_localized %}
@@ -85,6 +87,22 @@
         $(function() {
             FastClick.attach(document.body);
         });
+
+        $(function() {
+              if ( $(window).width() <= 767 ) {
+                document.getElementById("user-name-a").removeAttribute("data-toggle");
+                document.getElementById("user-name").classList.add("open");
+              }
+            });
+
+        $(function() {
+            var logout = document.getElementById("logout");
+            var topnav = document.getElementById("topnav");
+            if ( $(window).width() <= 767 ) {
+              //$(logout).parent().prepend($(topnav));
+            }
+          });
+
         </script>
         <script type="text/javascript" src="{% static 'js/underscore-min.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/backbone/backbone.js' %}"></script>
@@ -167,6 +185,7 @@
               <div class="container">
                   <div class="row">
                       <div class="navbar-header">
+                          {# collapse entire menu #}
                           <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse" aria-hidden="true">
                               <span class="icon-bar"></span>
                               <span class="icon-bar"></span>
@@ -178,12 +197,7 @@
                               </a>
                               <div class="pull-right visible-xs sitepoint" id="points-xs"></div>
                           </div>
-                      </div>
-                      <div class="collapse navbar-collapse top-nav">
-                          <ul class="nav navbar-nav navbar-right nav-tabs " role="tablist">
-
-                            <!-- For all users -->
-                              {# Search box for responsive nav #}
+                          {# Search box for responsive nav #}
                               <div class="visible-xs">
                                   <li id="search_input">
                                       <form class="navbar-form " action="{% url 'search' %}" method="get"  role="search">
@@ -193,7 +207,13 @@
                                       </form>
                                   </li>
                               </div>
+                      </div>
 
+                      {# implement dropdown here? #}
+                      <div class="collapse navbar-collapse top-nav">
+                          <ul class="nav navbar-nav navbar-right nav-tabs " id="topnav"role="tablist">
+
+                            <!-- For all users -->
                             {# Search box for normal nav #}
                             <li class="hidden-xs">
                               <form class="navbar-form" action="{% url 'search' %}" method="get" id="search-box" role="search">
@@ -277,12 +297,12 @@
                             {% endif %}
                             
                             <!-- Farthest right nav is logged in user dropdown -->
-                            <li class="dropdown {% block help_active %}{% endblock help_active %}{% block progress_active %}{% endblock progress_active %}" id="user-name">
-                              <a href="#" class="logged-in-only dropdown-toggle" data-toggle="dropdown">
+                            <li class="dropdown {% block help_active %}{% endblock help_active %}{% block progress_active %}{% endblock progress_active %} " id="user-name">
+                              <a href="#" class="logged-in-only dropdown-toggle" data-toggle="dropdown" id="user-name-a">
                                   <span id="username">
                                     <!-- Username injected here w/ js -->
                                   </span>
-                                <span class="caret"></span>
+                                <span class="caret hidden-xs"></span>
                               </a>
 
                               <ul class="dropdown-menu" data-no-collapse="true" role="menu">
@@ -305,7 +325,7 @@
                                 </li> -->
                                 <li role="presentation" class="divider student-only"></li>
                                 <!-- Logout goes at the bottom! -->
-                                <li role="presentation">
+                                <li role="presentation" id="logout">
                                   <a role="menuitem" tabindex="-1" id="nav_logout" class="logged-in-only" title="{% trans 'Logout'%}" href="#">
                                     {% trans "Logout" %}
                                   </a>

--- a/kalite/distributed/templates/distributed/base_manage.html
+++ b/kalite/distributed/templates/distributed/base_manage.html
@@ -10,6 +10,14 @@
 {% endblock i18n_do_not_translate %}
 
 {% block subnavbar %}
+<!-- <script>
+    $(function() {
+        if ( $(window).width() <= 454 ) {
+            var icon = document.getElementsByClassName("icon");
+            console.log(icon);
+        }
+    });
+</script> -->
 
     <div class="manage-nav logged-in-only admin-only">
         <ul class="nav nav-tabs">

--- a/kalite/distributed/templates/distributed/base_manage.html
+++ b/kalite/distributed/templates/distributed/base_manage.html
@@ -10,15 +10,6 @@
 {% endblock i18n_do_not_translate %}
 
 {% block subnavbar %}
-<!-- <script>
-    $(function() {
-        if ( $(window).width() <= 454 ) {
-            var icon = document.getElementsByClassName("icon");
-            console.log(icon);
-        }
-    });
-</script> -->
-
     <div class="manage-nav logged-in-only admin-only">
         <ul class="nav nav-tabs">
             <div class="mobile-manage-nav">


### PR DESCRIPTION
This pull request fixes the closed issue https://github.com/learningequality/ka-lite/issues/3168

The dropdown menu for smaller screens is now much more aesthetically pleasing. 
Also, the second search bar has been removed from distributed/base.html. @rtibbles please check to see that this hasn't adversely affected the autofill; seems to work on my end though. 

Following are screenshots of the new mobile navigation. Critiques and suggestions are very welcome!

Not logged in screen:
![mobile not logged in](https://cloud.githubusercontent.com/assets/6668144/6989432/0f975fec-da10-11e4-999c-363a4f050045.PNG)

Unopened menu for admins/teachers:
![mobile menu closed](https://cloud.githubusercontent.com/assets/6668144/6989421/f9763b3e-da0f-11e4-9541-6039e32685ff.PNG)

Opened menu for admins/teachers:
![mobile menu open](https://cloud.githubusercontent.com/assets/6668144/6989425/027553fa-da10-11e4-8467-3b2989463e93.PNG)

Second level navigation for teachers:
![teacher manage mobile](https://cloud.githubusercontent.com/assets/6668144/6989462/6c66dbda-da10-11e4-8124-2f338cf526f8.PNG)

Dropdown for students:
![mobile student menu](https://cloud.githubusercontent.com/assets/6668144/6989468/7dae051c-da10-11e4-820b-57bfa6dc75e1.PNG)


