### PR TITLE
Display label text in the search box on focus, when using keyboard navig...

### DIFF
--- a/kalite/distributed/static/js/distributed/search_autocomplete.js
+++ b/kalite/distributed/static/js/distributed/search_autocomplete.js
@@ -80,6 +80,10 @@ $(document).ready(function() {
         minLength: 3,
         appendTo: ".navbar-collapse",
         html: true,  // extension allows html-based labels
+        focus: function(event, ui) {
+            // display label text in the search box on focus
+            ui.item.value = $(ui.item.label).text();
+        },
         source: function(request, response) {
             clear_messages();
 


### PR DESCRIPTION
Display label text in the search box on focus, when using keyboard navigation keys.

Fixes #3349: Bug: auto-suggestion search bar not working properly when using keyboard navigation keys 

Branch: develop
Expected behavior: When using the search box and selecting an item with the keyboard, the name of the exercise should be displayed in the search box.
Steps to reproduce: Using the search box, e.g. search for "algebra"
Actual behavior: Instead of showing the name,a short name based value-id from retrieved JSON data is shown.

Summary of changes:
-Added a focus event handler, updating the display label text in the search box on focus

Screenshot after update:
![search input focus fixed](https://cloud.githubusercontent.com/assets/67566/6991318/527ecf3e-da8d-11e4-9e33-5d92afdac4ac.png)


Thanks, Georgy