### PR TITLE
Modify coachreport legend to accomodate long compound words auf Deutsch

### DIFF
--- a/kalite/coachreports/static/css/coachreports/tabular_view.css
+++ b/kalite/coachreports/static/css/coachreports/tabular_view.css
@@ -97,7 +97,6 @@ th.headrowuser {
     height: 20px;
     overflow: hidden;
     text-align: center;
-    width: 120px;
     padding-right: 10px;
 }
 
@@ -105,6 +104,10 @@ th.headrowuser {
     float: left;
     width: 35px;
     height: 21px;
+}
+
+.legend span {
+    padding-left: 10px;
 }
 
 .selection {

--- a/kalite/coachreports/templates/coachreports/tabular_view.html
+++ b/kalite/coachreports/templates/coachreports/tabular_view.html
@@ -134,10 +134,10 @@
     <div class="row">
         <div class="col-md-6 col-xs-12">
             <ul id="legend">
-                <li class="legend"><div class="partial"></div>{% trans "In Progress" %}</li>
-                <li class="legend"><div class="complete"></div>{% trans "Completed" %}</li>
+                <li class="legend"><div class="partial"></div><span>{% trans "In Progress" %}</span></li>
+                <li class="legend"><div class="complete"></div><span>{% trans "Completed" %}</span></li>
                 {% if request_report_type != "video" %}
-                <li class="legend"><div class="struggle"></div>{% trans "Struggling" %}</li>
+                <li class="legend"><div class="struggle"></div><span>{% trans "Struggling" %}</span></li>
                 {% endif %}
             </ul>
         </div>


### PR DESCRIPTION
Fixes #3225. No test included, it's purely display.
![ss](https://cloud.githubusercontent.com/assets/8888020/7013631/0c401aca-dc70-11e4-8813-da0cce1f4350.png)
