### PR TITLE
3-column enhancement for search page

### DIFF
--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -22,6 +22,7 @@ footer {
     width: 100%;
     bottom: 0;
     left: 0;
+    padding: 10px 0;
 }
 
 a:hover, a:focus {
@@ -445,8 +446,7 @@ footer {
     margin: 0;
 }
 #fle-logo {
-    margin-top: 15px;
-    margin-bottom: 5px;
+    margin: 5px 0;
     height: 18px;
     width: 268px;
 }

--- a/kalite/distributed/static/css/distributed/search.css
+++ b/kalite/distributed/static/css/distributed/search.css
@@ -1,0 +1,8 @@
+ul {
+    list-style: none;
+    padding: 0;
+}
+
+li {
+    margin: 8px 0;
+}

--- a/kalite/distributed/static/css/distributed/search.css
+++ b/kalite/distributed/static/css/distributed/search.css
@@ -1,8 +1,8 @@
-ul {
+.subresults-list {
     list-style: none;
     padding: 0;
 }
 
-li {
-    margin: 8px 0;
+.subresults-item {
+    margin: 10px 0;
 }

--- a/kalite/distributed/static/css/distributed/sidebar.css
+++ b/kalite/distributed/static/css/distributed/sidebar.css
@@ -140,6 +140,8 @@ div.sidebar-fade {
 
 .sidebar-back button {
     height: 3em;
+    padding: 0;
+    width: 1.8em;
 }
 
 .sidebar-back-hover {

--- a/kalite/distributed/templates/distributed/search_page.html
+++ b/kalite/distributed/templates/distributed/search_page.html
@@ -1,13 +1,10 @@
 {% extends base_template %}
 {% load i18n %}
 {% load my_filters %}
+{% load staticfiles %}
 
 {% block headcss %}{{ block.super }}
-    <style>
-        h3 {
-            margin:20px 0px 5px 0px;
-        }
-    </style>
+    <link rel="stylesheet" href="{% static 'css/distributed/search.css' %}">
 {% endblock headcss %}
 
 {% block title %}{{ title }}{% endblock title %}
@@ -22,7 +19,11 @@
             <div class="row">
             {% for category, subresults in results.iteritems %}
                 <div class="col-sm-4 category-col">    
-                    <h3>{{ category }}{% if hit_max|get_item:category %}&nbsp;<br class="visible-sm"/><small>({% blocktrans %}showing first {{ max_results }} results{% endblocktrans %})</small>{% endif %}</h3>
+                    <h3>{{ category }}
+                    {% if hit_max|get_item:category %}
+                        <br class="visible-sm"/>
+                        <small>({% blocktrans %}showing first {{ max_results }} results{% endblocktrans %})</small>
+                    {% endif %}</h3>
                     <ul class="subresults-list">
                     {% for node in subresults %}
                         <li class="subresults-item">

--- a/kalite/distributed/templates/distributed/search_page.html
+++ b/kalite/distributed/templates/distributed/search_page.html
@@ -35,6 +35,7 @@
                     {% endif %}
                     </ul>
                 </div>
+                <hr class="visible-xs">
             {% endfor %}
             </div>
         </div>

--- a/kalite/distributed/templates/distributed/search_page.html
+++ b/kalite/distributed/templates/distributed/search_page.html
@@ -18,20 +18,14 @@
 
     {% else %}
         <h2>{{ title }}</h2>
-        <div class="container container-fluid">
+        <div class="container container-fluid search-results">
             <div class="row">
             {% for category, subresults in results.iteritems %}
-                <div class="col-md-4">
-                    {{ category }}{% if hit_max|get_item:category %} ({% blocktrans %}showing first {{ max_results }} results{% endblocktrans %}){% endif %}
-                </div>
-            {% endfor %}
-            </div>
-            <div class="row">
-            {% for category, subresults in results.iteritems %}
-                <div class="col-md-4">    
-                    <ul>
+                <div class="col-sm-4 category-col">    
+                    <h3>{{ category }}{% if hit_max|get_item:category %}&nbsp;<br class="visible-sm"/><small>({% blocktrans %}showing first {{ max_results }} results{% endblocktrans %})</small>{% endif %}</h3>
+                    <ul class="subresults-list">
                     {% for node in subresults %}
-                        <li>
+                        <li class="subresults-item">
                             <a href="{% url 'learn' %}{{ node.path }}" class="{{ node.kind }}-{% if not node.available %}un{% endif %}available">{% trans node.title %}</a>
                         </li>
                     {% endfor %}

--- a/kalite/distributed/templates/distributed/search_page.html
+++ b/kalite/distributed/templates/distributed/search_page.html
@@ -18,17 +18,17 @@
 
     {% else %}
         <h2>{{ title }}</h2>
-        <table class="table table-bordered">
-            <tr>    
-            {% for category in results.iteritems %}
-                <th>
-                    {{ category }}{% if hit_max|get_item:category %} ({% blocktrans %}showing first {{ max_results }} results{% endblocktrans %}){% endif %}
-                </th>
-            {% endfor %}
-            </tr>
-            <tr>
+        <div class="container container-fluid">
+            <div class="row">
             {% for category, subresults in results.iteritems %}
-                <td>    
+                <div class="col-md-4">
+                    {{ category }}{% if hit_max|get_item:category %} ({% blocktrans %}showing first {{ max_results }} results{% endblocktrans %}){% endif %}
+                </div>
+            {% endfor %}
+            </div>
+            <div class="row">
+            {% for category, subresults in results.iteritems %}
+                <div class="col-md-4">    
                     <ul>
                     {% for node in subresults %}
                         <li>
@@ -36,12 +36,12 @@
                         </li>
                     {% endfor %}
                     {% if hit_max|get_item:category %}
-                        <li>...</li>
+                        <div>...</div>
                     {% endif %}
                     </ul>
-                </td>
+                </div>
             {% endfor %}
-            </tr>
-        </table>
+            </div>
+        </div>
     {% endif %}
 {% endblock %}

--- a/kalite/distributed/templates/distributed/search_page.html
+++ b/kalite/distributed/templates/distributed/search_page.html
@@ -18,19 +18,30 @@
 
     {% else %}
         <h2>{{ title }}</h2>
-
-        {% for category, subresults in results.iteritems %}
-            <h3>{{ category }}{% if hit_max|get_item:category %} ({% blocktrans %}showing first {{ max_results }} results{% endblocktrans %}){% endif %}</h3>
-            <ul>
-            {% for node in subresults %}
-                <li>
-                    <a href="{% url 'learn' %}{{ node.path }}" class="{{ node.kind }}-{% if not node.available %}un{% endif %}available">{% trans node.title %}</a>
-                </li>
+        <table class="table table-bordered">
+            <tr>    
+            {% for category in results.iteritems %}
+                <th>
+                    {{ category }}{% if hit_max|get_item:category %} ({% blocktrans %}showing first {{ max_results }} results{% endblocktrans %}){% endif %}
+                </th>
             {% endfor %}
-            {% if hit_max|get_item:category %}
-                <li>...</li>
-            {% endif %}
-            </ul>
-        {% endfor %}
+            </tr>
+            <tr>
+            {% for category, subresults in results.iteritems %}
+                <td>    
+                    <ul>
+                    {% for node in subresults %}
+                        <li>
+                            <a href="{% url 'learn' %}{{ node.path }}" class="{{ node.kind }}-{% if not node.available %}un{% endif %}available">{% trans node.title %}</a>
+                        </li>
+                    {% endfor %}
+                    {% if hit_max|get_item:category %}
+                        <li>...</li>
+                    {% endif %}
+                    </ul>
+                </td>
+            {% endfor %}
+            </tr>
+        </table>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
I always thought the search page could do with a refresh, but I couldn't quite put a finger on what was wrong with it. I don't think anything was wrong with it, but I decided to make a few enhancements anyway.

1. It does not look as bland
2. Requires less scrolling (mobile optimization FTW!)
3. No more wasted whitespace

Here's what it looks like:

![screen shot 2015-04-07 at 3 22 21 pm](https://cloud.githubusercontent.com/assets/6601788/7035134/a488f426-dd3a-11e4-9afd-f44587f8b7a9.png)

![screen shot 2015-04-07 at 3 22 50 pm](https://cloud.githubusercontent.com/assets/6601788/7035136/a6163722-dd3a-11e4-94ca-3fcd16d00fae.png)

I'm not sure if there are any more categories than the ones pictured above, but this new layout should scale gracefully, stacking them underneath, since it uses a simple Bootstrap grid.

Suggestions for enhancements like splashes of color etc. are welcome.