### PR TITLE
Fixes #2470: "Cant register because Client device must be self-signed with a signature matching its own public key"

### DIFF
--- a/kalite/facility/models.py
+++ b/kalite/facility/models.py
@@ -90,7 +90,7 @@ class FacilityGroup(DeferredCountSyncedModel):
 
     def __init__(self, *args, **kwargs):
         super(FacilityGroup, self).__init__(*args, **kwargs)
-        self._unhashable_fields.append("description") # since it's being stripped out by minversion, we can't include it in the signature
+        self._unhashable_fields += ("description",) # since it's being stripped out by minversion, we can't include it in the signature
 
     class Meta:
         app_label = "securesync"  # for back-compat reasons

--- a/python-packages/securesync/engine/models.py
+++ b/python-packages/securesync/engine/models.py
@@ -190,10 +190,9 @@ class SyncedModel(ExtendedModel):
     objects = SyncedModelManager()
     all_objects = SyncedModelManager(show_deleted=True)
 
-    _unhashable_fields = ["signature", "signed_by"] # fields of this class to avoid serializing
-    _always_hash_fields = ["signed_version", "id"]  # fields of this class to always serialize (see note above for signed_version)
-    _import_excluded_validation_fields = []  # fields that should not be validated upon import
-
+    _unhashable_fields = ("signature", "signed_by") # fields of this class to avoid serializing
+    _always_hash_fields = ("signed_version", "id")  # fields of this class to always serialize (see note above for signed_version)
+    _import_excluded_validation_fields = tuple()  # fields that should not be validated upon import
 
     __metaclass__ = SyncedModelMetaclass
 

--- a/python-packages/securesync/tests/crypto_tests.py
+++ b/python-packages/securesync/tests/crypto_tests.py
@@ -257,13 +257,14 @@ class TestZoneFallbackSettingOnCentralSave(SecuresyncTestCase):
 class TestHashableFieldsAndSerialization(unittest.TestCase):
 
     def test_description_exclusion_regression_bug_2470(self):
+        """FacilityGroup.__init__ used to append "description" to _unhashable_fields, which affected other classes as well.
+        This test ensures that the description is not being excluded from Device._hashable_representation, even after
+        instantiating a FacilityGroup."""
 
         d = Device(name="Test", description="Test")
-
-        good_serialization = d._hashable_representation()
+        possibly_bad_serialization = d._hashable_representation()
+        self.assertIn("description=Test", possibly_bad_serialization, "Hashable representation of Device did not include description")
 
         g = FacilityGroup()
-
-        possibly_bad_serialization = d._hashable_representation()
-
-        self.assertEqual(good_serialization, possibly_bad_serialization, "Instatiating a FacilityGroup changed hashable representation of Device")
+        possibly_worse_serialization = d._hashable_representation()
+        self.assertIn("description=Test", possibly_worse_serialization, "Instantiating a FacilityGroup changed hashable representation of Device")

--- a/python-packages/securesync/tests/crypto_tests.py
+++ b/python-packages/securesync/tests/crypto_tests.py
@@ -253,3 +253,17 @@ class TestZoneFallbackSettingOnCentralSave(SecuresyncTestCase):
             group.save()
             assert group.zone_fallback is not None, "Centrally created FacilityGroup was not assigned a zone."
 
+
+class TestHashableFieldsAndSerialization(unittest.TestCase):
+
+    def test_description_exclusion_regression_bug_2470(self):
+
+        d = Device(name="Test", description="Test")
+
+        good_serialization = d._hashable_representation()
+
+        g = FacilityGroup()
+
+        possibly_bad_serialization = d._hashable_representation()
+
+        self.assertEqual(good_serialization, possibly_bad_serialization, "Instatiating a FacilityGroup changed hashable representation of Device")


### PR DESCRIPTION
For now, this is just the regression test, as I want to see whether it fails on Travis.