### PR TITLE
Add method to wait for page load after a click

### DIFF
--- a/kalite/control_panel/features/steps/control_panel.py
+++ b/kalite/control_panel/features/steps/control_panel.py
@@ -3,7 +3,7 @@ from selenium.common.exceptions import NoSuchElementException
 
 from django.core.urlresolvers import reverse
 
-from kalite.testing.behave_helpers import build_url, find_css_class_with_wait, find_id_with_wait
+from kalite.testing.behave_helpers import *
 from kalite.facility.models import Facility
 
 
@@ -30,7 +30,7 @@ def step_impl(context):
     go_to_facilities_page(context)
     # Wait used because this one is subject to race conditions. 
     create_facility_link = find_css_class_with_wait(context, "create-facility")
-    create_facility_link.click()
+    click_and_wait_for_page_load(context, create_facility_link)
     submit_facility_form(context)
 
 

--- a/kalite/testing/behave_helpers.py
+++ b/kalite/testing/behave_helpers.py
@@ -5,6 +5,9 @@ as the first positional argument.
 
 Useful functions you should know about and use include:
 
+For clicking elements that cause a page load (`click` is not safe!):
+* click_and_wait_for_page_load
+
 For finding and interacting with elements safely:
 * elem_is_invisible_with_wait
 * find_css_class_with_wait
@@ -45,6 +48,26 @@ from kalite.testing.mixins.facility_mixins import FacilityMixins
 
 # Maximum time to wait when trying to find elements
 MAX_WAIT_TIME = 1
+# Maximum time to wait for a page to load.
+MAX_PAGE_LOAD_TIME = 3
+
+
+def click_and_wait_for_page_load(context, elem, wait_time=MAX_PAGE_LOAD_TIME):
+    """ Click an element and then wait for the page to load. Does this by
+    first getting an element on the page, clicking, and then waiting for the
+    reference to become stale. If the element doesn't become stale then it throws
+    a TimeoutException. (So if you pass an element to click that doesn't cause a 
+    page load, then you'll probably get a TimeoutException.)
+    context: a behave context
+    elem: a WebElement to click.
+    wait_time: Optional. Max wait time for the page to load. Has a default value.
+    """
+    # The body element should always be on the page.
+    wait_elem = context.browser.find_element_by_tag_name("body")
+    elem.click()
+    WebDriverWait(context.browser, wait_time).until(
+        EC.staleness_of(wait_elem)
+    )
 
 
 def elem_is_invisible_with_wait(context, elem, wait_time=MAX_WAIT_TIME):


### PR DESCRIPTION
After a behave test failed on python 2.6, I realized I was flirting with race conditions. The upshot is that if one clicks an element in selenium and causes a page load, selenium will not wait for the page to load. In general, the `WebElement.click` method will not wait for anything and so should be used with great caution. See [this blog post](http://www.obeythetestinggoat.com/how-to-get-selenium-to-wait-for-page-load-after-a-click.html) for some context.

**What's inside:**
* A helper method for the common case that you want to click an element and wait for a new page to load as a result.
* Fixed an existing test to explicitly wait for a page load.