### PR TITLE
Resolves depricated playlist in 0.13 release with more clean up needed

### DIFF
--- a/kalite/distributed/templates/distributed/homepage.html
+++ b/kalite/distributed/templates/distributed/homepage.html
@@ -15,8 +15,6 @@
     <!-- import handlebars templates here -->
     <script src="{% url 'handlebars_templates' module_name="playlists" %}"></script>
     <script type="text/javascript" src="{% static 'js/playlist/models.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/jquery.dotdotdot.min.js' %}"></script>
-    <script type="text/javascript" src="{% static 'js/distributed/homepage_playlists.js' %}"></script>
     {% if settings.AUTO_LOAD_TEST %}{# TODO(bcipolli): eliminate this, make the load testing app inherit from / override this page #}
     <script>
         if (window.parent.frames.length === 0) {


### PR DESCRIPTION
Issue discovered in using the installers to update 0.12 to 0.13 this should resolve those issues as a temp fix however since the entire playlist is deprecated we should go back through this and remove other parts such as divs and tables for 0.14 that could right now affect release of 0.13. 