### PR TITLE
Sidebar bug fix

### DIFF
--- a/kalite/distributed/static/js/distributed/topics/views.js
+++ b/kalite/distributed/static/js/distributed/topics/views.js
@@ -284,6 +284,12 @@ window.TopicContainerInnerView = BaseView.extend({
         this.add_all_entries();
 
         this.state_model.set("current_level", options.level);
+
+        // resize the scrollable part of sidebar to the page height
+        $(window).resize(_.throttle(function() {
+            var height = $(window).height();
+            self.$(".slimScrollDiv, .sidebar").height(height);
+        }, 200));
     },
 
     render: function() {
@@ -299,11 +305,6 @@ window.TopicContainerInnerView = BaseView.extend({
             alwaysVisible: true
         });
 
-        // resize the scrollable part of sidebar to the page height
-        $(window).resize(_.throttle(function() {
-            var height = $(window).height();
-            self.$(".slimScrollDiv, .sidebar").height(height);
-        }, 200));
         $(window).resize();
 
         return this;

--- a/kalite/distributed/static/js/distributed/topics/views.js
+++ b/kalite/distributed/static/js/distributed/topics/views.js
@@ -290,6 +290,15 @@ window.TopicContainerInnerView = BaseView.extend({
             var height = $(window).height();
             self.$(".slimScrollDiv, .sidebar").height(height);
         }, 200));
+
+        // When scrolling, increase the height of the element
+        // until it fills up the sidebar panel
+        $(window).scroll(_.throttle(function() {
+            var sidebarHeight = $(".sidebar-panel").height();
+            var deltaHeight = $(window).scrollTop() + self.$(".slimScrollDiv, .sidebar").height();
+            var height = Math.min(sidebarHeight, deltaHeight);
+            self.$(".slimScrollDiv, .sidebar").height(height);
+        }, 200));
     },
 
     render: function() {


### PR DESCRIPTION
Just changes the resizing rules of the sidebar. Fixes #3221. Now when you scroll, the height is recalculated. @rtibbles as part of our comprehensive testing initiative, how shall we deal with "bugs" like this? Is it possible to "mock" DOM events, and assert that height will be recalculated? I would probably need to refactor this view to properly test that.