### PR TITLE
Test and fix for regression error on SyncedModel.full_clean(imported=True)

### DIFF
--- a/python-packages/securesync/engine/models.py
+++ b/python-packages/securesync/engine/models.py
@@ -230,7 +230,7 @@ class SyncedModel(ExtendedModel):
         """
         exclude = exclude or []
         if imported:
-            exclude = list(set(exclude + self._import_excluded_validation_fields))
+            exclude = list(set(tuple(exclude) + self._import_excluded_validation_fields))
         if self.deleted:
             exclude = exclude + [f.name for f in self._meta.fields if isinstance(f, models.ForeignKey) ]
         return super(SyncedModel, self).full_clean(exclude=exclude)

--- a/python-packages/securesync/tests/regression_tests.py
+++ b/python-packages/securesync/tests/regression_tests.py
@@ -5,12 +5,15 @@ Regressions tests.
 from mock import patch
 
 from django.test import TestCase
-from securesync.devices.views import central_server_down_or_error
+from ..devices.views import central_server_down_or_error
+from ..devices.models import SyncedModel
 
+class DummySyncedModelClass(SyncedModel):
+    pass
 
 class CentralServerDownMessageTest(TestCase):
     """ Tests that if the central server is down, then an error message
-    sasying as much is returned. Otherwise assume that an actual error message
+    saying as much is returned. Otherwise assume that an actual error message
     was returned by the central server, and pass it along.
     """
 
@@ -27,3 +30,15 @@ class CentralServerDownMessageTest(TestCase):
         error_msg = "Some error message ah!"
         expected_msg = "Some error message ah!"
         self.assertEqual(central_server_down_or_error(error_msg)['error_msg'], expected_msg)
+
+
+class SimpleBugRegressionTests(TestCase):
+    """ Tests for simple regressions, e.g. caused by syntax or runtime errors.
+    """
+
+    def test_for_full_clean_concatenation_bug(self):
+        """ Tests that SyncedModel.full_clean does not regress with the error:
+        `TypeError: can only concatenate list (not "tuple") to list`
+        """
+        m = DummySyncedModelClass()
+        m.full_clean(imported=True)


### PR DESCRIPTION
This started showing up on the central server tests, even though it was passing here (since we never do `full_clean(imported=True)` in the distributed server tests, only in the ecosystem tests on the central server). Adding the fix here, along with a test so that any regressions will be caught here directly.