### PR TITLE
Auto-update the lists of packages of the vagrant box when provisioning.

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Used by vagrant for provisioning
 
+apt-get update --fix-missing
+
 apt-get install -y python2.7 python2.7-dev python-pip
 pip install -r /home/vagrant/ka-lite/requirements.txt
 pip install -r /home/vagrant/ka-lite/dev_requirements.txt


### PR DESCRIPTION
Hi @aronasorman - this fixes #3516 - Using vagrant throws some errors.

I've modified the `provision.sh` script so it automatically run `apt-get update --fix-missing` to retrieve new lists of packages.