### PR TITLE
Remove the test for the `securesync` module.

### DIFF
--- a/kalite/basetests/tests.py
+++ b/kalite/basetests/tests.py
@@ -226,7 +226,6 @@ class PackagesTests(DependenciesTests):
         "pytz": "2012d",
         "requests": "0.14.2",
         "rsa": "3.1.1",
-        "securesync": "1.0",
         "smmap": "0.8.2",
         "south": "0.8.4",
         "tastypie": "0.11.0",


### PR DESCRIPTION
Hi @aronasorman - this fixes #3525 - Basetests are failing for `kalite`.

I've removed the check for `securesync` module version as discussed.

See attached screenshot for result of running `python kalite/basetests/tests.py`.
![screenshot 2015-04-16 09 18 17](https://cloud.githubusercontent.com/assets/175580/7172545/2f2856f2-e41c-11e4-96d6-4af28e42f5f3.png)
