### PR TITLE
increase memory for vagrant virtualbox instances.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,4 +32,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Provision our machine with shell scripts, since the user might not
   # have ansible installed.
   config.vm.provision "shell", path: "provision.sh"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+  end
 end

--- a/provision.sh
+++ b/provision.sh
@@ -7,5 +7,6 @@ curl -sL https://deb.nodesource.com/setup_0.12 | bash -
 apt-get install -y nodejs
 pip install -r /home/vagrant/ka-lite/requirements_dev.txt
 cd /home/vagrant/ka-lite
+pip install -e .
 # --no-bin-links option is for linux guests on windows hosts
 npm install --no-bin-links


### PR DESCRIPTION
Workaround for #3541. We increase the memory so we wouldn't hit the
silent MemoryError, and so people can still continue using Vagrant for development.