### PR TITLE
Delete the reg state from session post-reg to reload on next pageload.

### DIFF
--- a/python-packages/securesync/devices/views.py
+++ b/python-packages/securesync/devices/views.py
@@ -42,6 +42,9 @@ def initialize_registration():
 @render_to("securesync/register_public_key_client.html")
 def register_public_key_client(request):
 
+    # Delete the registration state from the session to ensure it is refreshed next pageload
+    del request.session["registered"]
+
     own_device = Device.get_own_device()
     if own_device.is_registered():
         initialize_registration()


### PR DESCRIPTION
Session variable `"registered"` is only updated [here](https://github.com/learningequality/ka-lite/blob/0.13.x/python-packages/securesync/devices/middleware.py#L23) when it's not already defined in the session, so when it was used [here](https://github.com/learningequality/ka-lite/blob/0.13.x/kalite/distributed/views.py#L43) without logging out/in, it was using the session-cached value, and hence still showing the "Please register" message.

This PR clears the session variable whenever the reg page is viewed, which always happens post-reg, ensuring it will be cleared as needed. If another user is logged in in parallel, clicking on the "reg now" button will take them to the reg page, clear the var, and tell them it's already reg'ed.

