### PR TITLE
Django js reverse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,6 @@ script:
 - python python-packages/fle_utils/tests.py
 - coverage run --source=kalite --omit="kalite/testing/*,*/tests/*" manage.py test --traceback -v 2
 - grunt jshint
-- bin/kalite manage bundleassets
-- ./node_modules/karma/bin/karma start --single-run --browsers PhantomJS
 notifications:
   email:
     - aron@learningequality.org

--- a/kalite/control_panel/static/js/control_panel/facility_management.js
+++ b/kalite/control_panel/static/js/control_panel/facility_management.js
@@ -69,7 +69,7 @@ $(function() {
         } else if(!confirm(gettext("You are about to move selected users to another group."))) {
             return;
         } else {
-            doRequest(window.sessionModel.get("MOVE_TO_GROUP_URL"), {users: users, group: group})
+            doRequest(window.Urls.move_to_group(), {users: users, group: group})
                 .success(function() {
                     location.reload();
                 });
@@ -108,7 +108,7 @@ $(function() {
         } else if (!confirm(gettext("You are about to delete selected users, they will be permanently deleted."))) {
             return;
         } else {
-            doRequest(window.sessionModel.get("DELETE_USERS_URL"), {users: users})
+            doRequest(window.Urls.delete_users(), {users: users})
                 .success(function() {
                     location.reload();
                 });
@@ -124,7 +124,7 @@ $(function() {
         } else if (!confirm(gettext("You are about to permanently delete the selected group(s). Note that any learners currently in this group will now be characterized as 'Ungrouped' but their profiles will not be deleted."))) {
             return;
         } else {
-            doRequest(window.sessionModel.get("DELETE_GROUPS_URL"), {groups: groups})
+            doRequest(window.Urls.group_delete(), {groups: groups})
                 .success(function() {
                     location.reload();
                 });

--- a/kalite/distributed/management/commands/kaserve.py
+++ b/kalite/distributed/management/commands/kaserve.py
@@ -139,6 +139,8 @@ class Command(BaseCommand):
         logging.info("Copying static media...")
         call_command("collectstatic", interactive=False, verbosity=0)
 
+        call_command("collectstatic_js_reverse", interactive=False)
+
         if options['startuplock']:
             os.unlink(options['startuplock'])
         

--- a/kalite/distributed/static/js/distributed/distributed-server.js
+++ b/kalite/distributed/static/js/distributed/distributed-server.js
@@ -38,7 +38,7 @@ function show_api_messages(messages) {
 function force_sync() {
     // Simple function that calls the API endpoint to force a data sync,
     //   then shows a message for success/failure
-    doRequest(window.sessionModel.get("FORCE_SYNC_URL"))
+    doRequest(window.Urls.api_force_sync())
         .success(function() {
             var msg = gettext("Successfully launched data syncing job.") + " ";
             msg += sprintf(gettext("After syncing completes, visit the <a href='%(devman_url)s'>device management page</a> to view results."), {
@@ -263,7 +263,7 @@ $(function() {
     $("#language_selector").change(function() {
         var lang_code = $("#language_selector").val();
         if (lang_code != "") {
-            doRequest(window.sessionModel.get("SET_DEFAULT_LANGUAGE_URL"),
+            doRequest(window.Urls.set_default_language(),
                       {lang: lang_code}
                      ).success(function() {
                          window.location.reload();
@@ -290,7 +290,7 @@ function get_server_status(options, fields, callback) {
         protocol: "http",
         hostname: "",
         port: 8008,
-        path: window.sessionModel.get("SERVER_INFO_PATH")
+        path: window.Urls.get_server_info()
     };
 
     var args = $.extend(defaults, options);

--- a/kalite/distributed/static/js/distributed/search/views.js
+++ b/kalite/distributed/static/js/distributed/search/views.js
@@ -28,7 +28,7 @@ window.AutoCompleteView = BaseView.extend({
     fetch_topic_tree: function () {
         var self = this;
         if (this._nodes===undefined) {
-            doRequest(window.Urls.topic_tree(window.sessionModel.get("channel")), null, {
+            doRequest(window.Urls.topic_tree(window.sessionModel.get("CHANNEL")), null, {
                 cache: true,
                 dataType: "json",
                 ifModified: true

--- a/kalite/distributed/static/js/distributed/search/views.js
+++ b/kalite/distributed/static/js/distributed/search/views.js
@@ -28,7 +28,7 @@ window.AutoCompleteView = BaseView.extend({
     fetch_topic_tree: function () {
         var self = this;
         if (this._nodes===undefined) {
-            doRequest(window.sessionModel.get("SEARCH_TOPICS_URL"), null, {
+            doRequest(window.Urls.topic_tree(window.sessionModel.get("channel")), null, {
                 cache: true,
                 dataType: "json",
                 ifModified: true
@@ -76,7 +76,7 @@ window.AutoCompleteView = BaseView.extend({
 
     render: function() {
 
-        this.$el.html(this.template({search_url: window.sessionModel.get("SEARCH_URL")}));
+        this.$el.html(this.template({search_url: window.Urls.search());
 
         this.$("#search").autocomplete({
             autoFocus: true,

--- a/kalite/distributed/static/js/distributed/search/views.js
+++ b/kalite/distributed/static/js/distributed/search/views.js
@@ -76,7 +76,7 @@ window.AutoCompleteView = BaseView.extend({
 
     render: function() {
 
-        this.$el.html(this.template({search_url: window.Urls.search());
+        this.$el.html(this.template({search_url: window.Urls.search()}));
 
         this.$("#search").autocomplete({
             autoFocus: true,

--- a/kalite/distributed/static/js/distributed/session/models.js
+++ b/kalite/distributed/static/js/distributed/session/models.js
@@ -1,16 +1,8 @@
 SessionModel = Backbone.Model.extend({
     defaults: {
-        SEARCH_TOPICS_URL           : "",
-        SEARCH_URL                  : "",
         USER_URL                    : "",
-        FORCE_SYNC_URL              : "",
 
-        LOCAL_DEVICE_MANAGEMENT_URL : "",
         USER_LOGIN_URL              : "",
-        SET_DEFAULT_LANGUAGE_URL    : "",
-        DELETE_USERS_URL            : "",
-        DELETE_GROUPS_URL           : "",
-        MOVE_TO_GROUP_URL           : "",
         STATIC_URL                  : "",
 
         ALL_ASSESSMENT_ITEMS_URL    : "",
@@ -20,16 +12,12 @@ SessionModel = Backbone.Model.extend({
 
         KHAN_EXERCISES_SCRIPT_URL   : "",
 
-        SERVER_INFO_PATH            : "",
         CENTRAL_SERVER_HOST         : "",
         SECURESYNC_PROTOCOL         : "",
         CURRENT_LANGUAGE            : "",
 
         // Used by updates app
-        START_LANGUAGEPACKDOWNLOAD_URL  : "",
-        INSTALLED_LANGUAGES_URL         : "",
         AVAILABLE_LANGUAGEPACK_URL      : "",
-        DELETE_LANGUAGEPACK_URL         : "",
         DEFAULT_LANGUAGE                : ""
     }
 });

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -65,6 +65,13 @@
         {% endif %}
 
         {% compress js file basejs %}
+        
+        {% if debug %}
+        <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
+        {% else %}
+        <script src="{% static 'django_js_reverse/js/reverse.js' %}"></script>
+        {% endif %}
+        
         <!-- JS translation file statically included as a back-up, so that if the saved file below isn't available, we don't choke. -->
         <script type="text/javascript" src="{% static 'js/i18n/en.js' %}"></script>
 

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -170,7 +170,8 @@
 
           CENTRAL_SERVER_HOST         : "{{ central_server_host }}",
           SECURESYNC_PROTOCOL         : "{{ securesync_protocol }}",
-          CURRENT_LANGUAGE            : "{{ current_language }}"
+          CURRENT_LANGUAGE            : "{{ current_language }}",
+          CHANNEL                     : "{{ channel }}",
         });
         $(function() {
           window.statusModel.fetch_data();

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -64,13 +64,13 @@
             <script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
         {% endif %}
 
-        {% compress js file basejs %}
-        
         {% if debug %}
         <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
         {% else %}
         <script src="{% static 'django_js_reverse/js/reverse.js' %}"></script>
         {% endif %}
+
+        {% compress js file basejs %}
 
         <!-- JS translation file statically included as a back-up, so that if the saved file below isn't available, we don't choke. -->
         <script type="text/javascript" src="{% static 'js/i18n/en.js' %}"></script>

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -71,7 +71,7 @@
         {% else %}
         <script src="{% static 'django_js_reverse/js/reverse.js' %}"></script>
         {% endif %}
-        
+
         <!-- JS translation file statically included as a back-up, so that if the saved file below isn't available, we don't choke. -->
         <script type="text/javascript" src="{% static 'js/i18n/en.js' %}"></script>
 
@@ -157,16 +157,8 @@
 
         <script>
         window.sessionModel.set({
-          SEARCH_TOPICS_URL           : "{% url 'topic_tree' channel=channel %}",
-          SEARCH_URL                  : "{% url 'search' %}",
           USER_URL                    : "{% url 'api_dispatch_list' resource_name='user' %}",
-          FORCE_SYNC_URL              : "{% url 'api_force_sync' %}",
 
-          LOCAL_DEVICE_MANAGEMENT_URL : "{% url 'device_redirect' %}",
-          SET_DEFAULT_LANGUAGE_URL    : "{% url 'set_default_language' %}",
-          DELETE_USERS_URL            : "{% url 'delete_users' %}",
-          DELETE_GROUPS_URL           : "{% url 'group_delete' %}",
-          MOVE_TO_GROUP_URL           : "{% url 'move_to_group' %}",
           STATIC_URL                  : "{% static "" %}",
 
           ALL_ASSESSMENT_ITEMS_URL    : "{% url 'api_dispatch_list' resource_name='assessment_item' %}",
@@ -176,7 +168,6 @@
 
           KHAN_EXERCISES_SCRIPT_URL : "{% static 'perseus/ke/khan-exercise.js' %}",
 
-          SERVER_INFO_PATH            : "{% url 'get_server_info' %}",
           CENTRAL_SERVER_HOST         : "{{ central_server_host }}",
           SECURESYNC_PROTOCOL         : "{{ securesync_protocol }}",
           CURRENT_LANGUAGE            : "{{ current_language }}"

--- a/kalite/distributed/tests/javascript_unit_tests/session_model_tests.js
+++ b/kalite/distributed/tests/javascript_unit_tests/session_model_tests.js
@@ -5,17 +5,10 @@ module("Session Model Tests", {
 });
 
 test("Default values", function() {
-  expect(18);
+  expect(9);
 
-  equal(this.sessionModel.get("SEARCH_TOPICS_URL"), "");
   equal(this.sessionModel.get("USER_URL"), "");
-  equal(this.sessionModel.get("FORCE_SYNC_URL"), "");
-  equal(this.sessionModel.get("LOCAL_DEVICE_MANAGEMENT_URL"), "");
 
-  equal(this.sessionModel.get("SET_DEFAULT_LANGUAGE_URL"), "");
-  equal(this.sessionModel.get("DELETE_USERS_URL"), "");
-  equal(this.sessionModel.get("DELETE_GROUPS_URL"), "");
-  equal(this.sessionModel.get("MOVE_TO_GROUP_URL"), "");
   equal(this.sessionModel.get("STATIC_URL"), "");
 
   equal(this.sessionModel.get("ALL_ASSESSMENT_ITEMS_URL"), "");
@@ -24,8 +17,6 @@ test("Default values", function() {
   equal(this.sessionModel.get("GET_CONTENT_LOGS_URL"), "");
   equal(this.sessionModel.get("KHAN_EXERCISES_SCRIPT_URL"), "");
 
-  equal(this.sessionModel.get("SERVER_INFO_PATH"), "");
-  equal(this.sessionModel.get("CENTRAL_SERVER_HOST"), "");
   equal(this.sessionModel.get("SECURESYNC_PROTOCOL"), "");
   return equal(this.sessionModel.get("CURRENT_LANGUAGE"), "");
 });
@@ -35,11 +26,8 @@ The updates app defines some variables we should have set.
 This is a regression test for issue 3460.
 */
 test("Default values for updates app", function() {
-  expect(5);
+  expect(2);
 
-  equal(this.sessionModel.get("START_LANGUAGEPACKDOWNLOAD_URL"), "");
-  equal(this.sessionModel.get("INSTALLED_LANGUAGES_URL"), "");
   equal(this.sessionModel.get("AVAILABLE_LANGUAGEPACK_URL"), "");
-  equal(this.sessionModel.get("DELETE_LANGUAGEPACK_URL"), "");
   return equal(this.sessionModel.get("DEFAULT_LANGUAGE"), "");
 });

--- a/kalite/distributed/urls.py
+++ b/kalite/distributed/urls.py
@@ -11,6 +11,8 @@ from django.conf.urls import patterns, include, url
 from django.contrib import admin
 from django.http import HttpResponseRedirect
 
+from django_js_reverse.views import urls_js
+
 from . import api_urls
 import kalite.dynamic_assets.urls
 import kalite.coachreports.urls
@@ -110,6 +112,11 @@ urlpatterns += patterns(__package__ + '.views',
     url(r'^learn/', 'learn', {}, 'learn'),
     url(r'^exercisedashboard/', 'exercise_dashboard', {}, 'exercise_dashboard'),
 )
+
+if settings.DEBUG:
+    urlpatterns += patterns('',
+        url(r'^jsreverse/$', 'django_js_reverse.views.urls_js', name='js_reverse'),
+    )
 
 handler403 = __package__ + '.views.handler_403'
 handler404 = __package__ + '.views.handler_404'

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -289,6 +289,7 @@ INSTALLED_APPS = (
     "django.contrib.sessions",
     "kalite.distributed",
     "compressor",
+    "django_js_reverse",
 )
 
 if not BUILT:

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -320,6 +320,10 @@ STATICFILES_DIRS = (os.path.join(_data_path, 'static-libraries'),)
 
 DEFAULT_ENCODING = 'utf-8'
 
+# Due to a newer version of slimit being installed, allowing this causes an error:
+# https://github.com/ierror/django-js-reverse/issues/29
+JS_REVERSE_JS_MINIFY = False
+
 ########################
 # Storage and caching
 ########################

--- a/kalite/updates/static/js/updates/update_languages.js
+++ b/kalite/updates/static/js/updates/update_languages.js
@@ -31,7 +31,7 @@ function get_available_languages() {
 }
 
 function get_installed_languages() {
-    return doRequest(window.sessionModel.get("INSTALLED_LANGUAGES_URL"), null, {
+    return doRequest(window.Urls.installed_language_packs(), null, {
         cache: false,
         datatype: "json"
     }).success(function(installed) {
@@ -122,7 +122,7 @@ function display_languages() {
     });
 
 function delete_languagepack(lang_code) {
-    doRequest(window.sessionModel.get("DELETE_LANGUAGEPACK_URL"), {lang: lang_code})
+    doRequest(window.Urls.delete_language_pack(), {lang: lang_code})
         .success(function(resp) {
             get_installed_languages();
             display_languages(installables);

--- a/kalite/updates/static/js/updates/update_videos.js
+++ b/kalite/updates/static/js/updates/update_videos.js
@@ -85,7 +85,7 @@ var video_callbacks = {
 
 $(function() {
 
-    doRequest(URL_GET_ANNOTATED_TOPIC_TREE, {})
+    doRequest(window.Urls.get_annotated_topic_tree(), {})
         .success(function(treeData) {
             if ($.isEmptyObject(treeData)) {
                 $("#content_tree h2").html(gettext("Apologies, but there are no videos available for this language."));
@@ -167,7 +167,7 @@ $(function() {
         numVideos = youtube_ids.length;
 
         // Do the request
-        doRequest(URL_START_VIDEO_DOWNLOADS, {youtube_ids: youtube_ids})
+        doRequest(window.Urls.start_video_download(), {youtube_ids: youtube_ids})
             .success(function() {
                 updatesStart("videodownload", 5000, video_callbacks);
             })
@@ -205,7 +205,7 @@ $(function() {
 
                     var youtube_ids = getSelectedStartedMetadata("youtube_id");
                     // Do the request
-                    doRequest(URL_DELETE_VIDEOS, {youtube_ids: youtube_ids})
+                    doRequest(window.Urls.delete_videos(), {youtube_ids: youtube_ids})
                         .success(function() {
                             $.each(youtube_ids, function(ind, id) {
                                 setNodeClass(id, "unstarted");
@@ -244,7 +244,7 @@ $(function() {
         // Prep
 
         // Do the request
-        doRequest(URL_CANCEL_VIDEO_DOWNLOADS)
+        doRequest(window.Urls.cancel_video_download())
             .success(function() {
                 // Reset ALL of the progress tracking
                 updatesReset();
@@ -265,7 +265,7 @@ $(function() {
         // Prep
 
         // Do the request
-        doRequest(URL_START_VIDEO_DOWNLOADS, {});
+        doRequest(window.Urls.start_video_download(), {});
 
         // Update the UI
         $(this).attr("disabled", "disabled");

--- a/kalite/updates/templates/updates/update_languages.html
+++ b/kalite/updates/templates/updates/update_languages.html
@@ -21,10 +21,7 @@
     {% endcompress %}
     <script type="text/javascript">
      window.sessionModel.set({
-         START_LANGUAGEPACKDOWNLOAD_URL: "{% url 'start_languagepack_download' %}",
-         INSTALLED_LANGUAGES_URL: "{% url 'installed_language_packs' %}",
          AVAILABLE_LANGUAGEPACK_URL: "http://" + window.sessionModel.get("CENTRAL_SERVER_HOST") + "/api/i18n/language_packs/available/{{ SHORTVERSION }}",
-         DELETE_LANGUAGEPACK_URL: "{% url 'delete_language_pack' %}",
          DEFAULT_LANGUAGE: "{{ default_language }}",
      });
     </script>

--- a/kalite/updates/templates/updates/update_videos.html
+++ b/kalite/updates/templates/updates/update_videos.html
@@ -19,18 +19,6 @@
 {% block headjs %}{{ block.super }}
     <script type="text/javascript" src="{% static 'js/jquery.dynatree.min.js' %}"></script>
 
-    <script type="text/javascript">
-        var URL_GET_ANNOTATED_TOPIC_TREE = "{% url 'get_annotated_topic_tree' %}?lang={{ current_language }}";
-        var URL_START_VIDEO_DOWNLOADS = "{% url 'start_video_download' %}?lang={{ current_language }}";
-        var URL_DELETE_VIDEOS = "{% url 'delete_videos' %}";
-        var URL_CANCEL_VIDEO_DOWNLOADS = "{% url 'cancel_video_download' %}";
-        var start_languagepackdownload_url = "{% url 'start_languagepack_download' %}";
-        var INSTALLED_LANGUAGES_URL = "{% url 'installed_language_packs' %}"
-        var AVAILABLE_LANGUAGEPACK_URL = "http://" + CENTRAL_SERVER_HOST +  "/api/i18n/language_packs/available/{{ VERSION }}";
-        var DELETE_LANGUAGEPACK_URL = "{% url 'delete_language_pack' %}";
-        var defaultLanguage = "{{ default_language }}";
-    </script>
-
     <script type="text/javascript" src="{% static 'js/updates/update_videos.js' %}"></script>
 {% endblock headjs %}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 django-compressor==1.4
 pyyaml==3.11
+django-js-reverse==0.5.0


### PR DESCRIPTION
Adds Django JS Reverse to expose a Urls object in client side code for access to Django URLs in the browser.

Summary of changes:
* Adds django_js_reverse app
* Ports as many Javascript referenced URLs as possible over to the Urls object.

Note: Tastypie messes it all up. Again.