### PR TITLE
Allow subtitle_urls through the TastyPie firewall

### DIFF
--- a/kalite/main/api_resources.py
+++ b/kalite/main/api_resources.py
@@ -240,7 +240,6 @@ class Content:
             "kind",
             "content_urls",
             "selected_language",
-            "subtitle_urls",
             "available",
         ]
 


### PR DESCRIPTION
Fixes #3561.

Summary of changes:
* Counterintuitively, removes 'subtitle_urls' from the list of explicit Content model fields, so that it gets parsed as an 'extra_field' and then properly transmitted to the client side.

@aronasorman This is the fix you've been looking for. It is a very minor change, that I think would be best to include in 0.13.0.

(Note: subtitles will not work with DEBUG=True as we are currently copying them directly into the static folder which is not served).