### PR TITLE
pull in latest Vagrantfile from develop

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,12 +7,12 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "trusty64"
+  config.vm.box = "ubuntu/trusty32"
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 8008, host: 38008
+  config.vm.network "forwarded_port", guest: 8008, host: 8008
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
@@ -27,6 +27,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder ".", "/vagrant", type: "nfs"
+  config.vm.synced_folder ".", "/home/vagrant/ka-lite", type: "nfs"
 
+  # Provision our machine with shell scripts, since the user might not
+  # have ansible installed.
+  config.vm.provision "shell", path: "provision.sh"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+  end
 end


### PR DESCRIPTION
Supersedes https://github.com/learningequality/ka-lite/pull/3569. We pull in the box that the box name points to, from vagrantcloud itself.