### PR TITLE
Attempt Display and Sidebar icons fixes

### DIFF
--- a/kalite/distributed/hbtemplates/search/search-item.handlebars
+++ b/kalite/distributed/hbtemplates/search/search-item.handlebars
@@ -1,1 +1,1 @@
-<span class='autocomplete icon-{{ kind }} {{#unless available }}un{{/unless}}available'><span class = 'dropdown-icon'>&nbsp;</span><span>{{ title }}</span></span>&nbsp;
+<span class='autocomplete {{#unless available }}un{{/unless}}available'><span class = 'dropdown-icon icon-{{ kind }}'>&nbsp;</span><span>{{ title }}</span></span>&nbsp;

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -805,22 +805,22 @@ Now add class definitions below for your new icon, and add that
 to items you want to have the icon appear with.
 */
 
-.icon-Exercise .dropdown-icon:before {
+.icon-Exercise:before {
     content: "\e60f";
 }
-.icon-Video .dropdown-icon:before {
+.icon-Video:before {
     content: "\e610";
 }
-.icon-Quiz .dropdown-icon:before {
+.icon-Quiz:before {
     content: "\e611";
 }
-.icon-Topic .dropdown-icon:before {
+.icon-Topic:before {
     content: "\e612";
 }
-.icon-Audio .dropdown-icon:before {
+.icon-Audio:before {
     content: "\e613";
 }
-.icon-Document .dropdown-icon:before {
+.icon-Document:before {
     content: "\e614";
 }
 

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -54,7 +54,7 @@ window.ExerciseProgressView = BaseView.extend({
 
         this.collection.forEach(function(model) {
             if (model.has("correct")) {
-                attempt_text = (model.get("correct") ? "<span><b>&#10003;</b></span> " : "<span>&#10007;</span> ") + attempt_text;
+                attempt_text = (model.get("correct") ? "<span class='correct'><b>&#10003;</b></span> " : "<span class='incorrect'>&#10007;</span> ") + attempt_text;
             }
         });
 


### PR DESCRIPTION
Summary of changes:
* Reinstate colourisation of ticks and crosses for attempt display on exercises
* Reinstate sidebar icons on topic tree
* Properly fix search autocomplete dropdown icons to have a whitespace between them and the text

![image](https://cloud.githubusercontent.com/assets/1680573/7381911/a7ef17ec-edbd-11e4-9123-4cb1915a3431.png)

![image](https://cloud.githubusercontent.com/assets/1680573/7381909/9e0fe648-edbd-11e4-86af-32ca12df5be7.png)

Can't take a screenshot of the autocomplete, it vanishes.