### PR TITLE
enable to specify khan(perseus images) folder from local_settings

### DIFF
--- a/kalite/distributed/urls.py
+++ b/kalite/distributed/urls.py
@@ -43,6 +43,9 @@ urlpatterns += patterns('',
 # serving it otherwise. Cherrypy is currently serving it through modifications
 # in kalite/django_cherrypy_wsgiserver/cherrypyserver.py
 urlpatterns += patterns('',
+    url(r'^%s/khan(?P<path>.*)$' % settings.CONTENT_URL[1:], 'django.views.static.serve', {
+        'document_root': settings.CONTENT_ROOT_KHAN,
+    }),
     url(r'^%s(?P<path>.*)$' % settings.CONTENT_URL[1:], 'django.views.static.serve', {
         'document_root': settings.CONTENT_ROOT,
     }),

--- a/kalite/django_cherrypy_wsgiserver/cherrypyserver.py
+++ b/kalite/django_cherrypy_wsgiserver/cherrypyserver.py
@@ -28,6 +28,16 @@ class DjangoAppPlugin(plugins.SimplePlugin):
         cherrypy.log("Loading and serving the Django application")
         cherrypy.tree.graft(WSGIHandler())
 
+        # Enable serve the khan folder specified in lcoal_settings.py
+        # (for android, user may put the content folder on SD card, it's reasonable to decouple content folder and khan folder(20000+ images in it)).
+        if getattr(settings, "CONTENT_ROOT_KHAN", None):
+            static_handler = cherrypy.tools.staticdir.handler(
+                section="/",
+                dir=os.path.split(settings.CONTENT_ROOT_KHAN)[1],
+                root=os.path.abspath(os.path.split(settings.CONTENT_ROOT_KHAN)[0])
+            )
+            cherrypy.tree.mount(static_handler, settings.CONTENT_URL + 'khan/')
+
         # Serve the content files
         if getattr(settings, "CONTENT_ROOT", None):
             static_handler = cherrypy.tools.staticdir.handler(

--- a/kalite/legacy/updates_settings.py
+++ b/kalite/legacy/updates_settings.py
@@ -60,6 +60,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 from kalite.settings.base import USER_DATA_ROOT
 
 CONTENT_ROOT = os.path.realpath(getattr(local_settings, "CONTENT_ROOT", os.path.join(USER_DATA_ROOT, 'content')))
+CONTENT_ROOT_KHAN = os.path.realpath(getattr(local_settings, "CONTENT_ROOT_KHAN", os.path.join(CONTENT_ROOT, 'khan')))
 CONTENT_URL = getattr(local_settings, "CONTENT_URL", "/content/")
 
 # Should be a function that receives a video file (youtube ID), and returns a URL to a video stream

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -80,7 +80,13 @@ if os.name == "nt":
 # Necessary for loading default settings from kalite
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "kalite.settings")
 
-KALITE_HOME = os.path.join(os.path.expanduser("~"), ".kalite")
+from django.conf import settings
+if getattr(settings, "TARGET_OS", None) == "Android":
+    #puting this dir in the current working dir solves the unrooted privilege issue on Android
+    KALITE_HOME = os.path.join(os.getcwd(), ".kalite")
+else:
+    KALITE_HOME = os.path.join(os.path.expanduser("~"), ".kalite")
+
 if not os.path.isdir(KALITE_HOME):
     os.mkdir(KALITE_HOME)
 PID_FILE = os.path.join(KALITE_HOME, 'kalite.pid')
@@ -219,7 +225,6 @@ def get_pid():
         raise NotRunning(7)  # Unclean shutdown
 
     # TODO: why is the port in django settings!? :) /benjaoming
-    from django.conf import settings
     listen_port = getattr(settings, "CHERRYPY_PORT", LISTEN_PORT)
 
     # Timeout is 1 second, we don't want the status command to be slow


### PR DESCRIPTION
This is especially useful when run kalite on Android, where user may put video content on SD card and don't need to move the khan folder(super huge)
Also added TARGET_OS flag in local_settings for kalitectl.py to solve the unrooted privilege issue on android 