### PR TITLE
Profiler

### DIFF
--- a/kalite/distributed/profiler.py
+++ b/kalite/distributed/profiler.py
@@ -1,0 +1,25 @@
+import cProfile
+import os
+
+from time import time, strftime
+
+from kalite.distributed import settings
+
+def profile(filename):
+    """ Decorator to profile a function. A no-op if setting PROFILE is False.
+    :param filename: A file where the profile stats will be written. Has a %Y-%m-%d-%H-%M-%S timestamp appended to it.
+    """
+    def _outer_f(func):
+        def _inner_f(*args, **kwargs):
+            pr = cProfile.Profile()
+            pr.enable()
+            func(*args, **kwargs)
+            pr.disable()
+            timestamp = strftime("%Y-%m-%d-%H-%M-%S")
+            fn, ext = os.path.splitext(filename)
+            pr.dump_stats(fn + timestamp + ext)
+        if settings.PROFILE:
+            return _inner_f
+        else:
+            return func
+    return _outer_f

--- a/kalite/distributed/settings.py
+++ b/kalite/distributed/settings.py
@@ -18,6 +18,7 @@ except ImportError:
     local_settings = object()
 
 DEBUG = getattr(local_settings, "DEBUG", False)
+PROFILE = getattr(local_settings, "PROFILE", False)
 
 
 ########################

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -31,6 +31,7 @@ from django.utils.translation import gettext as _
 
 from fle_utils.general import softload_json, json_ascii_decoder
 from kalite import i18n
+from kalite.distributed.profiler import profile
 
 TOPICS_FILEPATHS = {
     settings.CHANNEL: os.path.join(settings.CHANNEL_DATA_PATH, "topics.json")
@@ -237,6 +238,7 @@ def create_thumbnail_url(thumbnail):
 
 CONTENT          = None
 CACHE_VARS.append("CONTENT")
+@profile("content_cache_profile.dat")
 def get_content_cache(force=False, annotate=False, language=settings.LANGUAGE_CODE):
     global CONTENT, CONTENT_FILEPATH
 
@@ -484,6 +486,7 @@ def get_topic_videos(*args, **kwargs):
     return get_topic_leaves(*args, **kwargs)
 
 
+@profile("get_exercise_data_profile.dat")
 def get_exercise_data(request, exercise_id=None):
     exercise = get_exercise_cache(language=request.language).get(exercise_id, None)
 

--- a/profile_server_start.py
+++ b/profile_server_start.py
@@ -5,7 +5,7 @@ import sys
 from time import strftime
 
 sys.path.insert(0, ".")
-from kalitectl import start
+from kalitectl import manage
 
 try:
     filename = sys.argv[1]
@@ -15,9 +15,11 @@ pr = cProfile.Profile()
 try:
     # Start profiling...
     pr.enable()
-    start(debug=True, args=["--traceback"], skip_job_scheduler=True)
+    manage("runserver", args=["--traceback"])
 finally:
     # When you get tired or accidentally hit CTRL-C, the profiler will wrap up
     pr.disable()
     fn, ext = os.path.splitext(filename)
-    pr.dump_stats(fn + strftime("%Y-%m-%d-%H-%M-%S") + ext)
+    stamped_filename = fn + strftime("%Y-%m-%d-%H-%M-%S") + ext
+    print "Dumping to %s" % stamped_filename
+    pr.dump_stats(stamped_filename)

--- a/profile_server_start.py
+++ b/profile_server_start.py
@@ -15,7 +15,7 @@ pr = cProfile.Profile()
 try:
     # Start profiling...
     pr.enable()
-    start()
+    start(debug=True, args=["--traceback"], skip_job_scheduler=True)
 finally:
     # When you get tired or accidentally hit CTRL-C, the profiler will wrap up
     pr.disable()

--- a/profile_server_start.py
+++ b/profile_server_start.py
@@ -1,0 +1,23 @@
+import cProfile
+import os
+import sys
+
+from time import strftime
+
+sys.path.insert(0, ".")
+from kalitectl import start
+
+try:
+    filename = sys.argv[1]
+except:
+    filename = "server_start_profile.dat"
+pr = cProfile.Profile()
+try:
+    # Start profiling...
+    pr.enable()
+    start()
+finally:
+    # When you get tired or accidentally hit CTRL-C, the profiler will wrap up
+    pr.disable()
+    fn, ext = os.path.splitext(filename)
+    pr.dump_stats(fn + strftime("%Y-%m-%d-%H-%M-%S") + ext)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 behave==1.2.4
 selenium==2.45.0
+pyinotify==0.9.5


### PR DESCRIPTION
Let's discuss the options for profiling. I played around with various methods for a while, and there are 2 that I think have merit:

1. As in `profile_server_start.py`, start the server wrapped in a profiler. Advantage: it's going to profile what's actually happening.  Disadvantage: lots of "noise" -- though clever processing of the results can focus in on what's relevant.

2. Targeted profiling of functions with a decorator. See `kalite/distributed/profiler.py`. Advantage: more specific. Disadvantage: we have to guess where the hotspots are.

As it is, the files the profiler dumps it's data to are relative to the directory from which you start the server. (So for me, it's been dumping everything in the project root.) Is there a better way?

Just for grins, here's some output from profiling `get_content_cache`, sorted by cumulative time spent in each function and restricted to functions in `kalite` or `python-packages`:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.619    0.619   69.442   69.442 /vagrant/kalite/topic_tools/__init__.py:241(get_content_cache)
        2    0.001    0.001   41.930   20.965 python-packages/fle_utils/general.py:252(softload_json)
36965/14795   21.084    0.001   39.694    0.003 python-packages/fle_utils/general.py:223(json_ascii_decoder)
     7377    1.260    0.000   18.381    0.002 /vagrant/kalite/i18n/__init__.py:149(get_id2oklang_map)
    36421    1.355    0.000    9.610    0.000 /vagrant/kalite/i18n/__init__.py:177(get_video_id)
    36421    0.642    0.000    7.826    0.000 /vagrant/kalite/i18n/__init__.py:135(get_file2id_map)
    22131    0.441    0.000    7.287    0.000 /vagrant/kalite/topic_tools/__init__.py:593(is_content_on_disk)
        2    0.004    0.002    7.043    3.522 /vagrant/kalite/i18n/__init__.py:74(get_dubbed_video_map)
     7377    0.080    0.000    4.898    0.001 /vagrant/kalite/topic_tools/__init__.py:232(create_thumbnail_url)
    51044    0.490    0.000    2.810    0.000 /vagrant/kalite/i18n/__init__.py:271(lcode_to_django_lang)
     7377    0.180    0.000    2.549    0.000 /vagrant/kalite/i18n/__init__.py:396(select_best_available_language)
    51506    0.690    0.000    2.244    0.000 /vagrant/kalite/i18n/__init__.py:280(convert_language_code_format)
    14754    0.135    0.000    0.884    0.000 /vagrant/kalite/i18n/__init__.py:479(translate_block)
    12906    0.081    0.000    0.829    0.000 python-packages/django/utils/translation/__init__.py:64(gettext)
    12906    0.079    0.000    0.748    0.000 python-packages/django/utils/translation/trans_real.py:269(gettext)
    12906    0.327    0.000    0.669    0.000 python-packages/django/utils/translation/trans_real.py:241(do_translate)
     7377    0.098    0.000    0.297    0.000 /vagrant/kalite/i18n/__init__.py:213(get_srt_path)
    29511    0.196    0.000    0.284    0.000 python-packages/django/conf/__init__.py:51(__getattr__)
     7377    0.054    0.000    0.185    0.000 python-packages/django/utils/translation/__init__.py:89(activate)
     7377    0.062    0.000    0.132    0.000 python-packages/django/utils/translation/trans_real.py:177(activate)
     7377    0.049    0.000    0.122    0.000 python-packages/django/utils/translation/__init__.py:92(deactivate)
       78    0.015    0.000    0.098    0.001 /vagrant/kalite/i18n/__init__.py:117(get_langcode_map)
     7377    0.050    0.000    0.074    0.000 python-packages/django/utils/translation/trans_real.py:185(deactivate)
      462    0.009    0.000    0.072    0.000 /vagrant/kalite/i18n/__init__.py:277(lcode_to_ietf)
     7377    0.048    0.000    0.070    0.000 python-packages/django/utils/translation/trans_real.py:96(translation)
     7377    0.022    0.000    0.022    0.000 /vagrant/kalite/i18n/__init__.py:166(get_youtube_id)
        1    0.000    0.000    0.000    0.000 python-packages/django/utils/translation/__init__.py:45(__getattr__)
        1    0.000    0.000    0.000    0.000 /vagrant/kalite/i18n/__init__.py:233(get_code2lang_map)
```

More profiling coming soon.