### PR TITLE
Propagate ALL django settings to their respective commands, also fixes t...

### DIFF
--- a/kalite/distributed/management/commands/kaserve.py
+++ b/kalite/distributed/management/commands/kaserve.py
@@ -98,8 +98,12 @@ class Command(BaseCommand):
 
 
     def handle(self, *args, **options):
-        # Eliminate irrelevant settings
+        # Store base django settings and remove them from the options list
+        # because we are proxying one type of option list to another format
+        # where --foo=bar becomes foo=bar
+        base_django_settings = {}
         for opt in BaseCommand.option_list:
+            base_django_settings[opt.dest] = options[opt.dest]
             del options[opt.dest]
 
         # Parse the crappy way that runcherrypy takes args,
@@ -144,4 +148,4 @@ class Command(BaseCommand):
             sys.stdout.write("To access KA Lite from another connected computer, try the following address(es):\n")
             for addr in get_ip_addresses():
                 sys.stdout.write("\thttp://%s:%s/\n" % (addr, settings.USER_FACING_PORT()))
-            call_command("runcherrypyserver", *["%s=%s" % (key,val) for key, val in options.iteritems()])
+            call_command("runcherrypyserver", *["%s=%s" % (key,val) for key, val in options.iteritems()], **base_django_settings)

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -11,17 +11,6 @@ from distutils import spawn
 from annoying.functions import get_object_or_None
 from optparse import make_option
 
-CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
-BASE_DIR = os.path.realpath(CURRENT_DIR + "/../../../")
-
-# This is necessary for this script to run before KA Lite has ever been installed.
-if not os.environ.get("DJANGO_SETTINGS_MODULE"):
-    sys.path = [
-        os.path.join(BASE_DIR, "python-packages"),
-        os.path.join(BASE_DIR, "kalite")
-    ] + sys.path
-    os.environ["DJANGO_SETTINGS_MODULE"] = "kalite.settings"  # allows django commands to run
-
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management import call_command
@@ -211,10 +200,6 @@ class Command(BaseCommand):
             if options["interactive"]:
                 if not raw_input_yn("Do you wish to continue and install it as root?"):
                     raise CommandError("Aborting script.\n")
-
-        # Check to see if the current user is the owner of the install directory
-        if not os.access(BASE_DIR, os.W_OK):
-            raise CommandError("You do not have permission to write to directory {0:s}".format(BASE_DIR))
 
         install_clean = not kalite.is_installed()
         database_kind = settings.DATABASES["default"]["ENGINE"]

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -214,7 +214,7 @@ class Command(BaseCommand):
 
         # Check to see if the current user is the owner of the install directory
         if not os.access(BASE_DIR, os.W_OK):
-            raise CommandError("You do not have permission to write to this directory!")
+            raise CommandError("You do not have permission to write to directory {0:s}".format(BASE_DIR))
 
         install_clean = not kalite.is_installed()
         database_kind = settings.DATABASES["default"]["ENGINE"]

--- a/kalite/distributed/settings.py
+++ b/kalite/distributed/settings.py
@@ -19,7 +19,6 @@ except ImportError:
 
 DEBUG = getattr(local_settings, "DEBUG", False)
 
-
 ########################
 # Functions, for support
 ########################
@@ -37,6 +36,7 @@ def USER_FACING_PORT():
 # TODO(bcipolli): change these to "login" and "logout", respectively, if/when
 #  we migrate to a newer version of Django.  Older versions require these
 #  to be set if using the login_required decorator.
+# TODO(benjaoming): Use reverse_lazy for this sort of stuff
 LOGIN_URL = "/securesync/login/"
 LOGOUT_URL = "/securesync/logout/"
 

--- a/kalite/django_cherrypy_wsgiserver/management/commands/runcherrypyserver.py
+++ b/kalite/django_cherrypy_wsgiserver/management/commands/runcherrypyserver.py
@@ -270,7 +270,7 @@ def runcherrypyserver(argset=[], **kwargs):
     if "stop" in options:
         #we are done, get out
         return True
-
+    
     cherrypyserver.run_cherrypy_server(**options)
 
 

--- a/kalite/settings/__init__.py
+++ b/kalite/settings/__init__.py
@@ -30,7 +30,10 @@ from .base import *
 
 import_installed_app_settings(INSTALLED_APPS, globals())
 
-# Override
+# TODO(benjaoming): Why on earth is there both a PRODUCTION_PORT and a CHERRYPY_PORT !?
+# Mesa confused!
+# TODO(benjaoming): Furthermore, this is dependent on kalite.distributed.settings
+# so there's no way that kalite.distributed was ever decoupled from kalite
 CHERRYPY_PORT = getattr(local_settings, "CHERRYPY_PORT", PRODUCTION_PORT)
 TEST_RUNNER = KALITE_TEST_RUNNER
 

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -110,9 +110,9 @@ else:
     _data_path = os.path.join(ROOT_DATA_PATH,)
     
     # BEING DEPRECATED, PLEASE DO NOT USE PROJECT_PATH!
-    PROJECT_PATH = os.path.join(
-        os.path.expanduser("~"),
-        '.kalite'
+    PROJECT_PATH = os.environ.get(
+        "KALITE_HOME",
+        os.path.join(os.path.expanduser("~"), ".kalite")
     )
 
 
@@ -157,10 +157,11 @@ LOAD_KHAN_RESOURCES = getattr(local_settings, "LOAD_KHAN_RESOURCES", CHANNEL == 
 # the user running kalite and should be in a user-data
 # storage place.
 
-USER_DATA_ROOT = os.path.join(
-    os.path.expanduser("~"),
-    '.kalite'
+USER_DATA_ROOT = os.environ.get(
+    "KALITE_HOME",
+    os.path.join(os.path.expanduser("~"), ".kalite")
 )
+
 
 if not os.path.exists(USER_DATA_ROOT):
     os.mkdir(USER_DATA_ROOT)

--- a/kalite/shared/compat.py
+++ b/kalite/shared/compat.py
@@ -1,0 +1,9 @@
+"""
+Helper stuff for compatibility issues
+"""
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    # Python 2.6
+    from ordereddict import OrderedDict  # @UnusedImport

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -53,7 +53,6 @@ from __future__ import print_function
 # DO NOT IMPORT BEFORE THIS LIKE
 import sys
 import os
-from collections import OrderedDict
 
 # KALITE_DIR set, so probably called from bin/kalite
 if 'KALITE_DIR' in os.environ:
@@ -76,6 +75,7 @@ from docopt import docopt
 from urllib2 import URLError
 from socket import timeout
 from kalite.version import VERSION
+from kalite.shared.compat import OrderedDict
 
 if os.name == "nt":
     from subprocess import Popen, CREATE_NEW_PROCESS_GROUP

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -83,7 +83,11 @@ if os.name == "nt":
 # Necessary for loading default settings from kalite
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "kalite.settings")
 
-KALITE_HOME = os.path.join(os.path.expanduser("~"), ".kalite")
+# Where to store user data
+KALITE_HOME = os.environ.get(
+    "KALITE_HOME",
+    os.path.join(os.path.expanduser("~"), ".kalite")
+)
 if not os.path.isdir(KALITE_HOME):
     os.mkdir(KALITE_HOME)
 PID_FILE = os.path.join(KALITE_HOME, 'kalite.pid')

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -53,6 +53,7 @@ from __future__ import print_function
 # DO NOT IMPORT BEFORE THIS LIKE
 import sys
 import os
+from collections import OrderedDict
 
 # KALITE_DIR set, so probably called from bin/kalite
 if 'KALITE_DIR' in os.environ:
@@ -69,7 +70,7 @@ else:
 import httplib
 import re
 
-from django.core.management import ManagementUtility, get_commands
+from django.core.management import ManagementUtility
 from threading import Thread
 from docopt import docopt
 from urllib2 import URLError
@@ -139,20 +140,26 @@ def udpate_default_args(defaults, updates):
     looking into django.
     """
     # Returns either the default or an updated argument
-    arg_name = re.compile(r"^--?([^\s\=]+)")
+    arg_name = re.compile(r"^-?-?\s*=?([^\s=-]+)")
     # Create a dictionary of defined defaults and updates where '-somearg' is
     # always the key, update the defined defaults dictionary with the updates
     # dictionary thus overwriting the defaults.
-    defined_defaults = map(
+    defined_defaults_ = map(
         lambda arg: (arg_name.search(arg).group(1), arg),
         defaults
     )
-    defined_defaults = dict(defined_defaults)
-    defined_updates = map(
+    # OrderedDict because order matters when space-split options such as "-v 2"
+    # cause arguments to span over severel elements.
+    defined_defaults = OrderedDict()
+    for elm in defined_defaults_:
+        defined_defaults[elm[0]] = elm[1]
+    defined_updates_ = map(
         lambda arg: (arg_name.search(arg).group(1), arg),
         updates
     )
-    defined_updates = dict(defined_updates)
+    defined_updates = OrderedDict()
+    for elm in defined_updates_:
+        defined_updates[elm[0]] = elm[1]
     defined_defaults.update(defined_updates)
     return defined_defaults.values()
         

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ requirements = [
     "Python>=2.7",
 ]
 
-requirements += open('requirements.txt', 'r').read().split("\n"),
+# Path of setup.py
+where_am_i = os.path.dirname(os.path.realpath(__file__))
+
+requirements += open(os.path.join(where_am_i, 'requirements.txt'), 'r').read().split("\n"),
 
 
 #############################
@@ -39,34 +42,34 @@ def gen_data_files(*dirs):
 
     for src_dir in dirs:
         for root, dirs, files in os.walk(src_dir):
-            results.append((root, map(lambda f: root + "/" + f, files)))
+            results.append((root, map(lambda f: os.path.join(root, f), files)))
     return results
 
 # Append the ROOT_DATA_PATH to all paths
 data_files = map(
     lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
-    gen_data_files('python-packages')
+    gen_data_files(os.path.join(where_am_i, 'python-packages'))
 )
 
 data_files += map(
     lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
-    gen_data_files('data')
+    gen_data_files(os.path.join(where_am_i, 'data'))
 )
 
 data_files += map(
     lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
-    gen_data_files('locale')
+    gen_data_files(os.path.join(where_am_i, 'locale'))
 )
 
 data_files += map(
     lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
-    gen_data_files('static-libraries')
+    gen_data_files(os.path.join(where_am_i, 'static-libraries'))
 )
 
 # For now, just disguise the kalitectl.py script here as it's only to be accessed
 # with the bin/kalite proxy.
 data_files += [(
-    kalite.ROOT_DATA_PATH, ['kalitectl.py']
+    kalite.ROOT_DATA_PATH, [os.path.join(where_am_i, 'kalitectl.py')]
 )]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -48,22 +48,22 @@ def gen_data_files(*dirs):
 # Append the ROOT_DATA_PATH to all paths
 data_files = map(
     lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
-    gen_data_files(os.path.join(where_am_i, 'python-packages'))
+    gen_data_files('python-packages')
 )
 
 data_files += map(
     lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
-    gen_data_files(os.path.join(where_am_i, 'data'))
+    gen_data_files('data')
 )
 
 data_files += map(
     lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
-    gen_data_files(os.path.join(where_am_i, 'locale'))
+    gen_data_files('locale')
 )
 
 data_files += map(
     lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
-    gen_data_files(os.path.join(where_am_i, 'static-libraries'))
+    gen_data_files('static-libraries')
 )
 
 # For now, just disguise the kalitectl.py script here as it's only to be accessed


### PR DESCRIPTION
Propagate ALL django settings to their respective commands, also fixes the kaserve command which also didn't do this. This introduces the option of kalite start --settings=my_settings_module and also support for --traceback

Needed for deprecating local_settings #3579

Update:

The description of this PR was a bit hard to understand.. but for instance, this didn't work before:

    kalite start --settings=tralalaa

Because the `--settings` option was never passed on to the next django management commands.

Furthermore, this didn't work:

    kalite start --traceback

We should've had tracebacks in case of startup failures... we will now :)