### PR TITLE
Hiding Exercises in a playlist so that only quiz is visible

### DIFF
--- a/kalite/playlist/static/js/playlist/view_playlist.js
+++ b/kalite/playlist/static/js/playlist/view_playlist.js
@@ -212,11 +212,14 @@ window.PlaylistSidebarView = Backbone.View.extend({
     },
 
     add_new_entry: function(entry) {
-        var view = new PlaylistSidebarEntryView({model: entry});
-        this._entry_views.push(view);
-        this.$(".playlist-sidebar").append(view.render().$el);
-        this.listenTo(view, "clicked", this.item_clicked);
-        this.load_entry_progress();
+        if(entry.get("is_essential"))
+        {
+            var view = new PlaylistSidebarEntryView({model: entry});
+            this._entry_views.push(view);
+            this.$(".playlist-sidebar").append(view.render().$el);
+            this.listenTo(view, "clicked", this.item_clicked);
+            this.load_entry_progress();
+        }
     },
 
     add_all_entries: function() {


### PR DESCRIPTION
We require a Playlist in which there are only a Quiz.
As Quiz are generated from the exercises of that playlist, so we need to hide those exercises.

We have an "is_essential" variable in every entity of a playlist.
      {
        "entity_id": "/v/place-value-3/",
        "entity_kind": "Video",
        "is_essential": true,
        "sort_order": 2
      },

So, if we make it false for the exercise of Quiz playlist, then only Quiz would be visible and exercises would be hidden.