### PR TITLE
Added management command to reset points from exercise/video/attempt logs to zero

### DIFF
--- a/kalite/distributed/management/commands/points_reset.py
+++ b/kalite/distributed/management/commands/points_reset.py
@@ -1,7 +1,7 @@
 """
 """
 from django.core.management.base import BaseCommand, CommandError
-from kalite.main.models import ExerciseLog, VideoLog, AttemptLog
+from kalite.main.models import ExerciseLog, VideoLog
 
 class Command(BaseCommand):
     help = "Reset Points to zero for all the student accounts"
@@ -11,8 +11,5 @@ class Command(BaseCommand):
     		entry.points = 0
     		entry.save()
     	for entry in VideoLog.objects.all():
-    		entry.points = 0
-    		entry.save()
-    	for entry in AttemptLog.objects.all():
     		entry.points = 0
     		entry.save()

--- a/kalite/distributed/management/commands/points_reset.py
+++ b/kalite/distributed/management/commands/points_reset.py
@@ -1,0 +1,18 @@
+"""
+"""
+from django.core.management.base import BaseCommand, CommandError
+from kalite.main.models import ExerciseLog, VideoLog, AttemptLog
+
+class Command(BaseCommand):
+    help = "Reset Points to zero for all the student accounts"
+
+    def handle(self, *args, **options):
+    	for entry in ExerciseLog.objects.all():
+    		entry.points = 0
+    		entry.save()
+    	for entry in VideoLog.objects.all():
+    		entry.points = 0
+    		entry.save()
+    	for entry in AttemptLog.objects.all():
+    		entry.points = 0
+    		entry.save()


### PR DESCRIPTION
For new Nalanda year, all the students points have to be reset to zero.
Added points_reset management command to iterate through these logs and reset points to zero.