### PR TITLE
Sidebar render fix

### DIFF
--- a/kalite/distributed/static/js/distributed/topics/views.js
+++ b/kalite/distributed/static/js/distributed/topics/views.js
@@ -284,7 +284,26 @@ window.TopicContainerInnerView = BaseView.extend({
         this.add_all_entries();
 
         this.state_model.set("current_level", options.level);
+
+        // resize the scrollable part of sidebar to the page height
+        $(window).resize(self.window_resize_callback);
+
+        // When scrolling, increase the height of the element
+        // until it fills up the sidebar panel
+        $(window).scroll(self.window_scroll_callback);
     },
+
+    window_scroll_callback: _.throttle(function() {
+        var sidebarHeight = $(".sidebar-panel").height();
+        var deltaHeight = $(window).scrollTop() + self.$(".slimScrollDiv, .sidebar").height();
+        var height = Math.min(sidebarHeight, deltaHeight);
+        self.$(".slimScrollDiv, .sidebar").height(height);
+    }, 200),
+
+    window_resize_callback: _.throttle(function() {
+        var height = $(window).height();
+        self.$(".slimScrollDiv, .sidebar").height(height);
+    }, 200),
 
     render: function() {
         var self = this;
@@ -299,11 +318,6 @@ window.TopicContainerInnerView = BaseView.extend({
             alwaysVisible: true
         });
 
-        // resize the scrollable part of sidebar to the page height
-        $(window).resize(_.throttle(function() {
-            var height = $(window).height();
-            self.$(".slimScrollDiv, .sidebar").height(height);
-        }, 200));
         $(window).resize();
 
         return this;


### PR DESCRIPTION
Fixes #3221. Supercedes #3512. Adds callbacks to windows resize and scroll events to ensure the sidebar looks ok.