### PR TITLE
Topic tools backend

### DIFF
--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -266,6 +266,7 @@ INSTALLED_APPS = (
     "django.contrib.sessions",
     "kalite.distributed",
     "compressor",
+    "mptt",
 )
 
 if not BUILT:

--- a/kalite/topic_tools/management/__init__.py
+++ b/kalite/topic_tools/management/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'Mike'

--- a/kalite/topic_tools/management/commands/__init__.py
+++ b/kalite/topic_tools/management/commands/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'Mike'

--- a/kalite/topic_tools/management/commands/init_topic_tree.py
+++ b/kalite/topic_tools/management/commands/init_topic_tree.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         def recurse_nodes(raw_node, parent=None):
             """
             Recurse through the raw_topics and create TopicTreeNodes
-            :param node: a node from raw_topics
+            :param raw_node: a node from raw_topics
             :param parent: a saved topic_tools.models.TopicTreeNode
             """
             # In general title or description could be absent, but it's probably an error

--- a/kalite/topic_tools/management/commands/init_topic_tree.py
+++ b/kalite/topic_tools/management/commands/init_topic_tree.py
@@ -1,0 +1,57 @@
+"""
+A management command to populate the topic tree from our various json files.
+This is a limited-use command meant to transition from the json magic in
+topic_tools/__init__.py to using the Django backend. Specifically, it assumes
+there's one channel and it's set by settings.CHANNEL.
+
+This management command should be idempotent if the underlying data is the same, which just means
+that running twice should be a no-op.
+"""
+import os
+from django.core.management.base import BaseCommand
+from django.utils.translation import gettext as _
+
+from fle_utils.general import softload_json
+
+from django.conf import settings; logging = settings.LOG
+TOPICS_FILEPATHS = {
+    settings.CHANNEL: os.path.join(settings.CHANNEL_DATA_PATH, "topics.json")
+}
+EXERCISES_FILEPATH = os.path.join(settings.CHANNEL_DATA_PATH, "exercises.json")
+ASSESSMENT_ITEMS_FILEPATH = os.path.join(settings.CHANNEL_DATA_PATH, "assessmentitems.json")
+CONTENT_FILEPATH = os.path.join(settings.CHANNEL_DATA_PATH, "contents.json")
+
+from kalite.topic_tools.models import TopicTreeNode, NodeSubtype, Channel
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        # Create the one channel.
+        khan_ch, found = Channel.objects.get_or_create(language="en", title="khan")
+
+        raw_topics = softload_json(TOPICS_FILEPATHS.get(settings.CHANNEL), logger=logging.debug, raises=False)
+        # raw topics is the actual tree structure... have to parse it a node at a time
+        def recurse_nodes(raw_node, parent=None):
+            """
+            Recurse through the raw_topics and create TopicTreeNodes
+            :param node: a node from raw_topics
+            :param parent: a saved topic_tools.models.TopicTreeNode
+            """
+            # In general title or description could be absent, but it's probably an error
+            # if the other fields are.
+            subtype = NodeSubtype()
+            subtype.save()
+            node = TopicTreeNode(
+                title=_(raw_node.get("title", "")),
+                description=_(raw_node.get("description", "")) if raw_node.get("description") else "",
+                slug=raw_node["slug"],
+                path=raw_node["path"],
+                channel=khan_ch,
+                parent=parent,
+                node_subtype=subtype
+            )
+            node.save()
+            for child in raw_node.get("children", []):
+                recurse_nodes(child, node)
+        recurse_nodes(raw_topics)

--- a/kalite/topic_tools/migrations/0001_initial.py
+++ b/kalite/topic_tools/migrations/0001_initial.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'Channel'
+        db.create_table(u'topic_tools_channel', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('language', self.gf('django.db.models.fields.CharField')(max_length=8)),
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=50)),
+        ))
+        db.send_create_signal(u'topic_tools', ['Channel'])
+
+        # Adding model 'TopicTreeNode'
+        db.create_table(u'topic_tools_topictreenode', (
+            ('title', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('description', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('slug', self.gf('django.db.models.fields.SlugField')(unique=True, max_length=255, primary_key=True)),
+            ('path', self.gf('django.db.models.fields.URLField')(unique=True, max_length=200)),
+            ('channel', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['topic_tools.Channel'])),
+            ('content_type', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['contenttypes.ContentType'])),
+            ('object_id', self.gf('django.db.models.fields.PositiveIntegerField')()),
+            (u'lft', self.gf('django.db.models.fields.PositiveIntegerField')(db_index=True)),
+            (u'rght', self.gf('django.db.models.fields.PositiveIntegerField')(db_index=True)),
+            (u'tree_id', self.gf('django.db.models.fields.PositiveIntegerField')(db_index=True)),
+            (u'level', self.gf('django.db.models.fields.PositiveIntegerField')(db_index=True)),
+        ))
+        db.send_create_signal(u'topic_tools', ['TopicTreeNode'])
+
+        # Adding model 'NodeSubtype'
+        db.create_table(u'topic_tools_nodesubtype', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal(u'topic_tools', ['NodeSubtype'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'Channel'
+        db.delete_table(u'topic_tools_channel')
+
+        # Deleting model 'TopicTreeNode'
+        db.delete_table(u'topic_tools_topictreenode')
+
+        # Deleting model 'NodeSubtype'
+        db.delete_table(u'topic_tools_nodesubtype')
+
+
+    models = {
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'topic_tools.channel': {
+            'Meta': {'object_name': 'Channel'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'topic_tools.nodesubtype': {
+            'Meta': {'object_name': 'NodeSubtype'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'topic_tools.topictreenode': {
+            'Meta': {'object_name': 'TopicTreeNode'},
+            'channel': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['topic_tools.Channel']"}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'path': ('django.db.models.fields.URLField', [], {'unique': 'True', 'max_length': '200'}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['topic_tools']

--- a/kalite/topic_tools/migrations/0002_auto__add_field_topictreenode_parent.py
+++ b/kalite/topic_tools/migrations/0002_auto__add_field_topictreenode_parent.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'TopicTreeNode.parent'
+        db.add_column(u'topic_tools_topictreenode', 'parent',
+                      self.gf('mptt.fields.TreeForeignKey')(blank=True, related_name='children', null=True, to=orm['topic_tools.TopicTreeNode']),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'TopicTreeNode.parent'
+        db.delete_column(u'topic_tools_topictreenode', 'parent_id')
+
+
+    models = {
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'topic_tools.channel': {
+            'Meta': {'object_name': 'Channel'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'topic_tools.nodesubtype': {
+            'Meta': {'object_name': 'NodeSubtype'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'})
+        },
+        u'topic_tools.topictreenode': {
+            'Meta': {'object_name': 'TopicTreeNode'},
+            'channel': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['topic_tools.Channel']"}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'level': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            u'lft': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {}),
+            'parent': ('mptt.fields.TreeForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': u"orm['topic_tools.TopicTreeNode']"}),
+            'path': ('django.db.models.fields.URLField', [], {'unique': 'True', 'max_length': '200'}),
+            u'rght': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '255', 'primary_key': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'tree_id': ('django.db.models.fields.PositiveIntegerField', [], {'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['topic_tools']

--- a/kalite/topic_tools/models.py
+++ b/kalite/topic_tools/models.py
@@ -21,4 +21,7 @@ class TopicTreeNode(MPTTModel):
     node_subtype = generic.GenericForeignKey('content_type', 'object_id')
 
 class NodeSubtype(models.Model):
+    """
+    Fields which are not common to all nodes should be dealt with here.
+    """
     pass

--- a/kalite/topic_tools/models.py
+++ b/kalite/topic_tools/models.py
@@ -1,0 +1,23 @@
+from mptt.models import MPTTModel, TreeForeignKey
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.contenttypes import generic
+from django.db import models
+
+class Channel(models.Model):
+    language = models.CharField(max_length=8)
+    title = models.CharField(max_length=50)
+
+class TopicTreeNode(MPTTModel):
+    title = models.CharField(max_length=50)
+    description = models.CharField(max_length=50)
+    slug = models.SlugField(max_length=255, primary_key=True, unique=True)
+    path = models.URLField(max_length=200, unique=True)
+    channel = models.ForeignKey('Channel')
+
+    # The "kind" of the node
+    content_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    node_subtype = generic.GenericForeignKey('content_type', 'object_id')
+
+class NodeSubtype(models.Model):
+    pass

--- a/kalite/topic_tools/models.py
+++ b/kalite/topic_tools/models.py
@@ -13,6 +13,7 @@ class TopicTreeNode(MPTTModel):
     slug = models.SlugField(max_length=255, primary_key=True, unique=True)
     path = models.URLField(max_length=200, unique=True)
     channel = models.ForeignKey('Channel')
+    parent = TreeForeignKey('self', null=True, blank=True, related_name='children', db_index=True)
 
     # The "kind" of the node
     content_type = models.ForeignKey(ContentType)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 django-compressor==1.4
+django-mptt

--- a/sphinx-docs/developer_docs/topic_tools.rst
+++ b/sphinx-docs/developer_docs/topic_tools.rst
@@ -1,0 +1,30 @@
+topic_tools app
+===============
+
+The purpose of this document is to track the development of the topic_tools app.
+
+The Topic Tree
+--------------
+
+The topic tree is a hierarchical representation of real data (exercises, and videos).
+Leaf nodes of the tree are real learning resources, such as videos and exercises.
+Non-leaf nodes are topics, which describe a progressively higher-level grouping of the topic data.
+
+Each node in the topic tree comes with lots of metadata, including:
+* title
+* description
+* id (unique identifier; now equivalent to slug below)
+* slug (for computing a URL)
+* path (which is equivalent to a URL)
+* kind (Topic, Exercise, Video)
+and more.
+
+The attributes available will vary depending on the kind of the node.
+
+A topic tree node also has an associated channel. Nodes with different channels should be disjoint, in the graph-theoretical sense.
+That is, all the children of a node, all the ancestors of a node, and all the children of all the ancestors of a node should all have the same channel.
+
+API
+---
+
+API description goes here.


### PR DESCRIPTION
Just want to get the ball rolling on the discussion here. The main action is in `topic_tools/models.py` and `kalite/topic_tools/management/commands/init_topic_tree.py`.

Points of discussion include: 

* What kind of attributes do we want our topic tree models to have?
* How should we handle different node types (topic, exercise, etc)?
  * My first thought is to use a polymorphic foreign key on nodes to another model which will represent subtypes -- so a Topic model, an Exercise model, or YourCoolContentType model.
  * Perhaps it might be better to create a polymorphic tree, i.e. all topic tree nodes extend a base node type. Not sure if it's supported in django, but it would be desirable if the queryset for the base class included all the subclasses.
* How to import data from KA? It's a little tricky when it's not clear what attributes are available.

By the way, I get the following error when I run the `init_topic_tree` management command, which is trying to bootstrap the DB from the json stuff.
```sh
Traceback (most recent call last):
  File "python-packages/django/core/management/base.py", line 224, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "python-packages/django/core/management/base.py", line 263, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/ka-lite/kalite/topic_tools/management/commands/init_topic_tree.py", line 61, in handle
    recurse_nodes(raw_topics)
  File "/home/vagrant/ka-lite/kalite/topic_tools/management/commands/init_topic_tree.py", line 60, in recurse_nodes
    recurse_nodes(child, node)
  File "/home/vagrant/ka-lite/kalite/topic_tools/management/commands/init_topic_tree.py", line 60, in recurse_nodes
    recurse_nodes(child, node)
  File "/home/vagrant/ka-lite/kalite/topic_tools/management/commands/init_topic_tree.py", line 60, in recurse_nodes
    recurse_nodes(child, node)
  File "/home/vagrant/ka-lite/kalite/topic_tools/management/commands/init_topic_tree.py", line 60, in recurse_nodes
    recurse_nodes(child, node)
  File "/home/vagrant/ka-lite/kalite/topic_tools/management/commands/init_topic_tree.py", line 60, in recurse_nodes
    recurse_nodes(child, node)
  File "/home/vagrant/ka-lite/kalite/topic_tools/management/commands/init_topic_tree.py", line 54, in recurse_nodes
    node.save()
  File "/usr/local/lib/python2.7/dist-packages/mptt/models.py", line 956, in save
    self.insert_at(parent, position='last-child', allow_existing_pk=True)
  File "/usr/local/lib/python2.7/dist-packages/mptt/models.py", line 702, in insert_at
    self, target, position, save, allow_existing_pk=allow_existing_pk, refresh_target=refresh_target)
  File "/usr/local/lib/python2.7/dist-packages/mptt/managers.py", line 519, in insert_node
    self._post_insert_update_cached_parent_right(parent, right_shift)
  File "/usr/local/lib/python2.7/dist-packages/mptt/managers.py", line 667, in _post_insert_update_cached_parent_right
    raise InvalidMove
InvalidMove
```
@benjaoming as an django-mptt contributor do you have any special insight here? I suspect in-memory MPTTModel attributes are not being updated when new nodes are inserted in the tree.

Some benchmark data incoming.