### PR TITLE
Avoid setuptools UserWarning: The version specified requires normaliz…

### DIFF
--- a/kalite/version.py
+++ b/kalite/version.py
@@ -1,7 +1,7 @@
 # THIS IS USED BY settings.py.  NEVER import settings.py here; hard-codes only!
 MAJOR_VERSION = "0"
 MINOR_VERSION = "14"
-PATCH_VERSION = "dev"
+PATCH_VERSION = "dev0"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
 


### PR DESCRIPTION
…ation, consider using '0.14.dev0' instead of '0.14.dev'.