### PR TITLE
turn VERSION_INFO into a function.

### DIFF
--- a/kalite/control_panel/views.py
+++ b/kalite/control_panel/views.py
@@ -586,7 +586,7 @@ def local_install_context(request):
 
     return {
         "software_version": current_version,
-        "software_release_date": VERSION_INFO[current_version]["release_date"],
+        "software_release_date": VERSION_INFO()[current_version]["release_date"],
         "install_dir": settings.SOURCE_DIR if settings.IS_SOURCE else "Not applicable (not a source installation)",
         "database_last_updated": datetime.datetime.fromtimestamp(os.path.getctime(database_path)),
         "database_size": os.stat(settings.DATABASES["default"]["NAME"]).st_size / float(1024**2),

--- a/kalite/distributed/settings.py
+++ b/kalite/distributed/settings.py
@@ -161,7 +161,7 @@ CACHE_NAME = getattr(local_settings, "CACHE_NAME", None)  # without a cache defi
 # Cache is activated in every case,
 #   EXCEPT: if CACHE_TIME=0
 if CACHE_TIME != 0:  # None can mean infinite caching to some functions
-    KEY_PREFIX = version.VERSION_INFO[version.VERSION]["git_commit"][0:6]  # new cache for every build
+    KEY_PREFIX = version.VERSION_INFO()[version.VERSION]["git_commit"][0:6]  # new cache for every build
     if 'CACHES' not in locals():
         CACHES = {}
 

--- a/kalite/facility/custom_context_processors.py
+++ b/kalite/facility/custom_context_processors.py
@@ -8,7 +8,7 @@ from kalite import version
 
 # TODO(jamalex): this should be calculated more intelligently, and incorporated into a template tag
 # (see https://github.com/learningequality/ka-lite/issues/1161)
-BUILD_ID = version.VERSION_INFO[version.VERSION]["git_commit"][0:8]
+BUILD_ID = version.VERSION_INFO()[version.VERSION]["git_commit"][0:8]
 
 def custom(request):
     return {

--- a/kalite/version.py
+++ b/kalite/version.py
@@ -23,4 +23,21 @@ def load_yaml(file_name):
         return yaml.load(f)
 
 
-VERSION_INFO = load_yaml(os.path.join(os.path.dirname(__file__), "..", "data", "version.yml"))
+def VERSION_INFO():
+    """
+    Load a dictionary of changes between each version. The key of the
+    dictionary is the VERSION (i.e. X.X.X), with the value being another dictionary with
+    the following keys:
+
+    release_date
+    git_commit
+    new_features
+    bugs_fixed
+
+    """
+
+    # we import settings lazily, since the settings modules depends on
+    # this file. Importing it on top will lead to circular imports.
+    from django.conf import settings
+
+    return load_yaml(os.path.join(settings.CONTENT_DATA_PATH, "version.yml"))


### PR DESCRIPTION
Fixes #3562. So apparently upon installation, data files (things in
data/) and py files are placed in separate directories. So importing
version.yaml relative to version.py would break things upon install.

The solution is to turn VERSION_INFO into a function, and call
django.conf.settings when VERSION_INFO's value is needed. That would
avoid circular imports and allow us to use settings.CONTENT_DATA_PATH,
which is where the data files are defined.