### PR TITLE
Minimal benchmark stuff

### DIFF
--- a/data/version.yml
+++ b/data/version.yml
@@ -1,4 +1,4 @@
-0.14.dev:
+0.14.dev0:
   release_date:
   git_commit: ""
   new_features:

--- a/kalite/distributed/management/commands/add_random_db_stuff.py
+++ b/kalite/distributed/management/commands/add_random_db_stuff.py
@@ -1,0 +1,17 @@
+"""
+"""
+import json
+from django.core.management.base import BaseCommand, CommandError
+
+from kalite.main.models import AssessmentBenchmarkModel
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        for i in xrange(1,5000):
+            a, found = AssessmentBenchmarkModel.objects.get_or_create(pk=i)
+            if found:
+                a.kind = "blah"
+                a.item_data = json.dumps({"blah": "whatever"})
+                a.author_names = str(["Michael Gallaspy"])
+                a.sha = "yeahright"
+                a.save()

--- a/kalite/main/api_resources.py
+++ b/kalite/main/api_resources.py
@@ -5,7 +5,7 @@ from tastypie.exceptions import NotFound
 from django.conf.urls import url
 from django.conf import settings
 
-from .models import VideoLog, ExerciseLog, AttemptLog, ContentLog
+from .models import VideoLog, ExerciseLog, AttemptLog, ContentLog, AssessmentBenchmarkModel
 
 from kalite.distributed.api_views import get_messages_for_api_calls
 from kalite.topic_tools import get_exercise_data, get_assessment_item_data, get_content_data
@@ -169,6 +169,12 @@ class AssessmentItem():
         self.item_data = kwargs.get('item_data')
         self.author_names = kwargs.get('author_names')
         self.sha = kwargs.get('sha')
+
+
+class AssessmentItemORMResource(ModelResource):
+    class Meta:
+        queryset = AssessmentBenchmarkModel.objects.all()
+        resource_name = 'orm_assessment_item'
 
 
 class AssessmentItemResource(Resource):

--- a/kalite/main/api_urls.py
+++ b/kalite/main/api_urls.py
@@ -7,7 +7,7 @@ they're imported into the project's urls.py file.
 from django.conf.urls import include, patterns, url
 
 from .api_resources import VideoLogResource, ExerciseLogResource, AttemptLogResource, ContentLogResource, ExerciseResource, AssessmentItemResource, ContentResource, ContentRecommenderResource
-
+from .api_resources import AssessmentItemORMResource
 
 urlpatterns = patterns(__package__ + '.api_views',
 
@@ -20,6 +20,7 @@ urlpatterns = patterns(__package__ + '.api_views',
     # Retrieve assessment item data to render front-end Perseus Exercises
     url(r'^', include(AssessmentItemResource().urls)),
     url(r'^', include(ContentResource().urls)),
+    url(r'^', include(AssessmentItemORMResource().urls)),
     
     url(r'^', include(ContentRecommenderResource().urls)),
 

--- a/kalite/main/migrations/0037_auto__add_assessmentbenchmarkmodel__add_index_attemptlog_user_exercise.py
+++ b/kalite/main/migrations/0037_auto__add_assessmentbenchmarkmodel__add_index_attemptlog_user_exercise.py
@@ -1,0 +1,238 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'AssessmentBenchmarkModel'
+        db.create_table(u'main_assessmentbenchmarkmodel', (
+            ('kind', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('item_data', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('author_names', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('sha', self.gf('django.db.models.fields.CharField')(max_length=50)),
+            ('id', self.gf('django.db.models.fields.CharField')(max_length=50, primary_key=True)),
+        ))
+        db.send_create_signal(u'main', ['AssessmentBenchmarkModel'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'AssessmentBenchmarkModel'
+        db.delete_table(u'main_assessmentbenchmarkmodel')
+
+
+    models = {
+        u'main.assessmentbenchmarkmodel': {
+            'Meta': {'object_name': 'AssessmentBenchmarkModel'},
+            'author_names': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '50', 'primary_key': 'True'}),
+            'item_data': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'kind': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'sha': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'main.attemptlog': {
+            'Meta': {'object_name': 'AttemptLog', 'index_together': "[['user', 'exercise_id', 'context_type']]"},
+            'answer_given': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'assessment_item_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100', 'blank': 'True'}),
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'context_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'context_type': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'correct': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'exercise_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'response_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'response_log': ('django.db.models.fields.TextField', [], {'default': "'[]'"}),
+            'seed': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'time_taken': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.contentlog': {
+            'Meta': {'object_name': 'ContentLog'},
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'content_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'content_kind': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'content_source': ('django.db.models.fields.CharField', [], {'default': "'khan'", 'max_length': '100', 'db_index': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'extra_fields': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'progress': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'progress_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'start_timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'time_spent': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'views': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.exerciselog': {
+            'Meta': {'object_name': 'ExerciseLog'},
+            'attempts': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'attempts_before_completion': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'exercise_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'streak_progress': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'struggling': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.userlog': {
+            'Meta': {'object_name': 'UserLog'},
+            'activity_type': ('django.db.models.fields.IntegerField', [], {}),
+            'end_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'last_active_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'start_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'total_seconds': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"})
+        },
+        u'main.userlogsummary': {
+            'Meta': {'object_name': 'UserLogSummary'},
+            'activity_type': ('django.db.models.fields.IntegerField', [], {}),
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'device': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Device']"}),
+            'end_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'last_activity_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'start_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'total_seconds': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.videolog': {
+            'Meta': {'object_name': 'VideoLog'},
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'total_seconds_watched': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'video_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'youtube_id': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.device': {
+            'Meta': {'object_name': 'Device'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'public_key': ('django.db.models.fields.CharField', [], {'max_length': '500', 'db_index': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'version': ('django.db.models.fields.CharField', [], {'default': "'0.9.2'", 'max_length': '9', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.facility': {
+            'Meta': {'object_name': 'Facility'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'address_normalized': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'contact_email': ('django.db.models.fields.EmailField', [], {'max_length': '60', 'blank': 'True'}),
+            'contact_name': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'contact_phone': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'longitude': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_count': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"}),
+            'zoom': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'securesync.facilitygroup': {
+            'Meta': {'object_name': 'FacilityGroup'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'facility': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Facility']"}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.facilityuser': {
+            'Meta': {'object_name': 'FacilityUser'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'default_language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'facility': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Facility']"}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityGroup']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'is_teacher': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.zone': {
+            'Meta': {'object_name': 'Zone'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        }
+    }
+
+    complete_apps = ['main']

--- a/kalite/main/models.py
+++ b/kalite/main/models.py
@@ -25,6 +25,14 @@ from kalite.dynamic_assets.utils import load_dynamic_settings
 from securesync.models import DeferredCountSyncedModel, Device
 
 
+class AssessmentBenchmarkModel(models.Model):
+    kind = models.CharField(max_length=50)
+    item_data = models.CharField(max_length=50)
+    author_names = models.CharField(max_length=50)
+    sha = models.CharField(max_length=50)
+    id = models.CharField(max_length=50, primary_key=True)
+
+
 class VideoLog(DeferredCountSyncedModel):
 
     user = models.ForeignKey(FacilityUser, blank=True, null=True, db_index=True)


### PR DESCRIPTION
Just a proof of concept that getting assessment items from the ORM is not crazy slow. Is this what you were getting at @jamalex? How to test this out:

1. Migrate your db, then run the `add_random_db_stuff` management command to initialize the db.
2. Visit exercise pages and look at the response time for the `api/assessment_item/` endpoint -- generally between 15 and 30ms for me.
3. Visit various `api/orm_assessment_item/<pk>`s, where `<pk>` is just an integer between 0 and 4999. Note the load time again; generally between 20 and 50ms for me.

So the ORM (as expected) is marginally slower but probably not enough to be the bottleneck on any given page. Should I be a little more systematic about this, or do we agree that we're not shooting ourselves in the foot?

Also, don't merge this. It's for discussion only.