### PR TITLE
Installer test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,18 @@ before_install:
 install:
 -  npm install
 -  npm install -g grunt-cli
+-  pip install .
 -  pip install -r requirements_dev.txt
 -  pip install coveralls
 script:
+# Test that we can run from source directory
 - bin/kalite start --traceback -v 2
 - bin/kalite status
 - bin/kalite stop --traceback -v 2
+# Test that we can run as the installed script
+- kalite start --traceback -v 2
+- kalite status
+- kalite stop --traceback -v 2
 - python python-packages/fle_utils/tests.py
 - coverage run --source=kalite --omit="kalite/testing/*,*/tests/*" manage.py test --traceback -v 2
 - grunt jshint

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ before_install:
 install:
 -  npm install
 -  npm install -g grunt-cli
--  pip install .
+-  pip install -r requirements.txt
+-  python setup.py install
+#-  pip install .
 -  pip install -r requirements_dev.txt
 -  pip install coveralls
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,7 @@ before_install:
 install:
 -  npm install
 -  npm install -g grunt-cli
--  pip install -r requirements.txt
--  python setup.py install
-#-  pip install .
+-  pip install .
 -  pip install -r requirements_dev.txt
 -  pip install coveralls
 script:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,7 +14,6 @@ exclude kalite/private_key.pem
 exclude kalite/secrets.py
 
 # Data files, these are not picked up by sdist unless listed here
-recursive-include locale *
 recursive-include python-packages *
 recursive-include static-libraries *
 recursive-include data *

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -315,17 +315,8 @@ class Command(BaseCommand):
         # Now deploy the static files
         call_command("collectstatic", interactive=False)
 
+        # This is not possible in a distributed env
         if not settings.CENTRAL_SERVER:
-            # Move scripts
-            for script_name in ["start", "stop", "run_command"]:
-                script_file = script_name + system_script_extension()
-                dest_dir = os.path.join(settings.PROJECT_PATH, "..")
-                src_dir = os.path.join(dest_dir, "scripts")
-                shutil.copyfile(os.path.join(src_dir, script_file), os.path.join(dest_dir, script_file))
-                try:
-                    shutil.copystat(os.path.join(src_dir, script_file), os.path.join(dest_dir, script_file))
-                except OSError:  # even if we have write permission, we might not have permission to change file mode
-                    print("WARNING: Unable to set file permissions on %s! " % script_file)
 
             kalite_executable = 'kalite'
             if not spawn.find_executable('kalite'):

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -31,8 +31,10 @@ try:
         "and then call kalite start with an additional argument pointing to "
         "your new settings module:\n\n"
         "    kalite start --settings=kalite.my_settings\n\n"
-        "You can put your settings module in a different location, but make "
-        "sure that this location is in your Python path.",
+        "In the future, it is recommended not to keep your own settings module "
+        "in the kalite code base but to put the file somewhere else in your "
+        "python path, for instance in the current directory when running "
+        "'kalite --settings=my_module'.",
         RemovedInKALite_v015_Warning
     )
 except ImportError:

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -206,9 +206,11 @@ else:
         os.mkdir(USER_DATA_ROOT)
     
     LOCALE_PATHS = getattr(local_settings, "LOCALE_PATHS", (os.path.join(USER_DATA_ROOT, 'locale'),))
+    for path in LOCALE_PATHS:
+        if not os.path.exists(path):
+            os.mkdir(path)
     
     DEFAULT_DATABASE_PATH = os.path.join(USER_DATA_ROOT, "database",)
-    
     if not os.path.exists(DEFAULT_DATABASE_PATH):
         os.mkdir(DEFAULT_DATABASE_PATH)
     

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -185,13 +185,10 @@ USER_DATA_ROOT = os.environ.get(
 )
 
 
-if not os.path.exists(USER_DATA_ROOT):
-    os.mkdir(USER_DATA_ROOT)
-
 # Most of these data locations are messed up because of legacy
 if IS_SOURCE:
     USER_DATA_ROOT = SOURCE_DIR
-    LOCALE_PATHS = getattr(local_settings, "LOCALE_PATHS", (os.path.join(_data_path, 'locale'),))
+    LOCALE_PATHS = getattr(local_settings, "LOCALE_PATHS", (os.path.join(USER_DATA_ROOT, 'locale'),))
     LOCALE_PATHS = tuple([os.path.realpath(lp) + "/" for lp in LOCALE_PATHS])
     
     # This is the legacy location kalite/database/data.sqlite
@@ -200,15 +197,16 @@ if IS_SOURCE:
     MEDIA_ROOT = os.path.join(_data_path, "kalite", "media")
     STATIC_ROOT = os.path.join(_data_path, "kalite", "static")
 
+
 # Storing data in a user directory
 else:
+    
+    # Ensure that path exists
+    if not os.path.exists(USER_DATA_ROOT):
+        os.mkdir(USER_DATA_ROOT)
+    
     LOCALE_PATHS = getattr(local_settings, "LOCALE_PATHS", (os.path.join(USER_DATA_ROOT, 'locale'),))
     
-    # Copy in the distributed locales
-    for p in LOCALE_PATHS:
-        if not os.path.exists(p):
-            import shutil
-            shutil.copytree(os.path.join(_data_path, 'locale'), p)
     DEFAULT_DATABASE_PATH = os.path.join(USER_DATA_ROOT, "database",)
     
     if not os.path.exists(DEFAULT_DATABASE_PATH):

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -326,7 +326,7 @@ def manage(command, args=[], in_background=False):
 
     :param command: The django command string identifier, e.g. 'runserver'
     :param args: List of options to parse to the django management command
-    :param in_background: Creates a thread for the command
+    :param in_background: Creates a new process for the command
     """
     
     if not in_background:
@@ -336,11 +336,18 @@ def manage(command, args=[], in_background=False):
         utility.prog_name = 'kalite manage'
         utility.execute()
     else:
-        # Create a new subprocess, it will die together with the main process
-        # which is fine.
+        # Create a new subprocess, beware that it won't die with the parent
+        # so you have to kill it in another fashion
+        
+        # If we're on windows, we need to create a new process group, otherwise
+        # the newborn will be murdered when the parent becomes a daemon
+        if os.name == "nt":
+            kwargs = {'creationflags': subprocess.CREATE_NEW_PROCESS_GROUP}
+        else:
+            kwargs = {}
         subprocess.Popen(
             [sys.executable, os.path.abspath(sys.argv[0]), "manage", command] + args,
-            # creationflags=CREATE_NEW_PROCESS_GROUP
+            **kwargs
         )
 
 

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -53,8 +53,6 @@ from __future__ import print_function
 # DO NOT IMPORT BEFORE THIS LIKE
 import sys
 import os
-import atexit
-import signal
 
 # KALITE_DIR set, so probably called from bin/kalite
 if 'KALITE_DIR' in os.environ:
@@ -70,16 +68,17 @@ else:
 
 import httplib
 import re
+import subprocess
 
-from django.core.management import ManagementUtility
 from threading import Thread
 from docopt import docopt
 from urllib2 import URLError
 from socket import timeout
+
+from django.core.management import ManagementUtility
+
 from kalite.version import VERSION
 from kalite.shared.compat import OrderedDict
-
-import subprocess
 
 # Necessary for loading default settings from kalite
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "kalite.settings")
@@ -339,17 +338,10 @@ def manage(command, args=[], in_background=False):
     else:
         # Create a new subprocess, it will die together with the main process
         # which is fine.
-        proc = subprocess.Popen(
+        subprocess.Popen(
             [sys.executable, os.path.abspath(sys.argv[0]), "manage", command] + args,
             # creationflags=CREATE_NEW_PROCESS_GROUP
         )
-        
-        def kill_on_exit():
-            if proc.pid is None:
-                pass
-            else:
-                os.kill(proc.pid, signal.SIGTERM)
-        atexit.register(kill_on_exit)
 
 
 def start(debug=False, args=[], skip_job_scheduler=False):
@@ -451,7 +443,7 @@ def stop(args=[], sys_exit=True):
             if sys_exit:
                 sys.exit(-1)
             return  # Do not continue because error could not be handled
-
+ 
     # If there's no PID for the job scheduler, just quit
     if not os.path.isfile(PID_FILE_JOB_SCHEDULER):
         pass

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -11,7 +11,7 @@ echo "http://kalite.learningequality.org"
 echo "                                  "
 
 SCRIPT_DIR=`dirname "${BASH_SOURCE[0]}"`
-if [ -e $SCRIPT_DIR/kalite ];; then
+if [ -e $SCRIPT_DIR/kalite ]; then
     BASE_DIR=$SCRIPT_DIR
 else
     BASE_DIR=$SCRIPT_DIR/..

--- a/setup.py
+++ b/setup.py
@@ -56,11 +56,6 @@ data_files += map(
 
 data_files += map(
     lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
-    gen_data_files('locale')
-)
-
-data_files += map(
-    lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
     gen_data_files('static-libraries')
 )
 

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,7 @@ from setuptools import setup, find_packages
 
 # Handle requirements
 
-requirements = [
-    "Python>=2.7",
-]
+requirements = []
 
 # Path of setup.py
 where_am_i = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
This PR adds installer testing for Travis and removes the threaded execution of cronserver, being replaced by a subprocess.Popen, same on all platforms.

This in turn fixes #3616

@aronasorman do you known why the previous call for Windows contained `creationflags=CREATE_NEW_PROCESS_GROUP` ? I removed it because I couldn't find anything on Google explaining why it was needed (it doesn't work on other platforms, so I wanted something that could be similar on all).