### PR TITLE
Preload loop

### DIFF
--- a/kalite/caching/__init__.py
+++ b/kalite/caching/__init__.py
@@ -13,41 +13,11 @@ For any app implementing cacheable data or writing to the web cache, the app sho
 """
 from django.conf import settings; logging = settings.LOG
 from django.core.urlresolvers import reverse
-from django.db.models.signals import post_save, pre_delete
-from django.dispatch import receiver
 from django.test.client import Client
 
-from fle_utils.internet import generate_all_paths
 from fle_utils.internet.webcache import *
 from kalite import i18n, topic_tools
 from kalite.distributed.templatetags import kalite_staticfiles
-
-
-# Signals
-
-@receiver(post_save, sender='kalite.updates.models.VideoFile')
-def invalidate_on_video_update(sender, **kwargs):
-    """
-    Listen in to see when videos become available.
-    """
-    # Can only do full check in Django 1.5+, but shouldn't matter--we should only save with
-    # percent_complete == 100 once.
-    just_now_available = kwargs["instance"] and kwargs["instance"].percent_complete == 100 #and "percent_complete" in kwargs["updated_fields"]
-    if just_now_available:
-        # This event should only happen once, so don't bother checking if
-        #   this is the field that changed.
-        logging.debug("Invalidating cache on VideoFile save for %s" % kwargs["instance"])
-        invalidate_all_caches()
-
-@receiver(pre_delete, sender='kalite.updates.models.VideoFile')
-def invalidate_on_video_delete(sender, **kwargs):
-    """
-    Listen in to see when available videos become unavailable.
-    """
-    was_available = kwargs["instance"] and kwargs["instance"].percent_complete == 100
-    if was_available:
-        logging.debug("Invalidating cache on VideoFile delete for %s" % kwargs["instance"])
-        invalidate_all_caches()
 
 
 def create_cache_entry(path=None, url_name=None, cache=None, force=False):

--- a/kalite/updates/management/commands/videoscan.py
+++ b/kalite/updates/management/commands/videoscan.py
@@ -96,8 +96,8 @@ class Command(CronCommand):
             pre_delete.disconnect(receiver=updates.invalidate_on_video_delete, sender=VideoFile)
             for chunk in videos_needing_model_deletion_chunked:
                 video_files_needing_model_deletion = VideoFile.objects.filter(youtube_id__in=chunk)
+                deleted_video_ids += [video_file.youtube_id for video_file in video_files_needing_model_deletion]
                 video_files_needing_model_deletion.delete()
-                deleted_video_ids += [video_file.video_id for video_file in video_files_needing_model_deletion]
             if deleted_video_ids:
                 caching.invalidate_all_caches()
                 self.stdout.write("Deleted %d VideoFile models (because the videos didn't exist in the filesystem)\n" % len(deleted_video_ids))

--- a/kalite/updates/tests/videoscan_tests.py
+++ b/kalite/updates/tests/videoscan_tests.py
@@ -1,0 +1,29 @@
+from mock import patch
+
+from django.core.management import call_command
+
+from kalite.testing.base import KALiteTestCase
+from kalite.updates.models import VideoFile
+
+class CacheInvalidationTestCase(KALiteTestCase):
+    """
+    Test that cache invalidation only happens ONCE per videoscan, even if multiple deletions are made.
+    See issue 3621.
+    """
+
+    def setUp(self):
+        super(CacheInvalidationTestCase, self).setUp()
+        # Depends on the implementation details of videoscan command
+        # Youtube id should be not None so that these videos are in the `videos_marked_at_all` set.
+        # Since they don't actually exist they should automatically fail to be in `youtube_ids_in_filesystem` set.
+        # `flagged_for_download=False` ensures `delete_objects_for_missing_videos` function attempts to delete them.
+        # `percent_complete=100` ensures that the listener does something nontrivial.
+        VideoFile.objects.create(youtube_id="blah1", flagged_for_download=False, percent_complete=100)
+        VideoFile.objects.create(youtube_id="blah2", flagged_for_download=False, percent_complete=100)
+
+    @patch('kalite.caching.invalidate_all_caches')
+    def test_cache_invaldation_occurs_exactly_once(self, mock_func):
+        call_command("videoscan")
+        actual = mock_func.call_count
+        self.assertEqual(actual, 1, "The call count should be exactly 1. Actual count: {actual}".format(actual=actual))
+

--- a/kalite/updates/tests/videoscan_tests.py
+++ b/kalite/updates/tests/videoscan_tests.py
@@ -1,9 +1,11 @@
 from mock import patch
 
 from django.core.management import call_command
+from django.db.models.signals import post_save
 
 from kalite.testing.base import KALiteTestCase
 from kalite.updates.models import VideoFile
+from kalite import updates, caching
 
 class CacheInvalidationTestCase(KALiteTestCase):
     """
@@ -18,8 +20,10 @@ class CacheInvalidationTestCase(KALiteTestCase):
         # Since they don't actually exist they should automatically fail to be in `youtube_ids_in_filesystem` set.
         # `flagged_for_download=False` ensures `delete_objects_for_missing_videos` function attempts to delete them.
         # `percent_complete=100` ensures that the listener does something nontrivial.
+        post_save.disconnect(receiver=updates.invalidate_on_video_update, sender=VideoFile)
         VideoFile.objects.create(youtube_id="blah1", flagged_for_download=False, percent_complete=100)
         VideoFile.objects.create(youtube_id="blah2", flagged_for_download=False, percent_complete=100)
+        post_save.connect(receiver=updates.invalidate_on_video_update, sender=VideoFile)
 
     @patch('kalite.caching.invalidate_all_caches')
     def test_cache_invaldation_occurs_exactly_once(self, mock_func):


### PR DESCRIPTION
Fixes #3621. Removes duplicate definitions in `kalite.caching` and `kalite.updates`. Disconnects `pre_delete` callback for the duration of the offending section in `videoscan` command, where potentially a lot of deletions are made. Ensures that `caching.invalidate_all_caches` _is_ called once if a video is deleted. Plus a test!