### PR TITLE
Redirect download videos help information to the new FAQ page

### DIFF
--- a/kalite/distributed/custom_context_processors.py
+++ b/kalite/distributed/custom_context_processors.py
@@ -13,6 +13,7 @@ from kalite import version
 def custom(request):
     return {
         "central_server_host": settings.CENTRAL_SERVER_HOST,
+        "central_server_domain": settings.CENTRAL_SERVER_DOMAIN,
         "securesync_protocol": settings.SECURESYNC_PROTOCOL,
         "base_template": "distributed/base.html",
         "channel_data": settings.CHANNEL_DATA,

--- a/kalite/distributed/templates/distributed/help_admin.html
+++ b/kalite/distributed/templates/distributed/help_admin.html
@@ -38,7 +38,7 @@
                 <td class="desc"> {% trans "Contains the latest information about setting up and using KA Lite." %}</td>
             </tr>
             <tr class="client-online-only">
-                <td class="link"><a href="https://learningequality.org/ka-lite/faq/" target="_blank">{% trans "FAQ" %}</a></td>
+                <td class="link"><a href="https://learningequality.org/docs/faq.html" target="_blank">{% trans "FAQ" %}</a></td>
                 <td class="desc">{% trans "Contains the latest FAQ for troubleshooting." %}</td>
             </tr>
 

--- a/kalite/updates/templates/updates/update_videos.html
+++ b/kalite/updates/templates/updates/update_videos.html
@@ -82,7 +82,7 @@
             {% trans "Help for downloading videos" %}
             </h4>
             <div id="help-info">
-                <a id="download-help-link" target="_new" href="http://{{ central_server_host }}/faq/installation/bittorrent/">
+                <a id="download-help-link" target="_new" href="http://{{ central_server_domain }}/docs/faq.html#i-would-like-to-download-the-videos-for-ka-lite-via-bittorrent-is-this-possible">
                     {% trans "Q: How do I bulk-download videos?" %}
                 </a>
             </div>


### PR DESCRIPTION
Fixes #3619  
Replaces the old url with new faq url. As not to hard write the url, central_server_domain is imported.