### PR TITLE
Buildserver-oriented memory profiling

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,7 @@ test:
     - bin/kalite status
     - bin/kalite stop --traceback -v 2
     - python python-packages/fle_utils/tests.py
+    - bin/kalite manage test
     - grunt jshint
     - bin/kalite manage bundleassets
     - ./node_modules/karma/bin/karma start --single-run --browsers PhantomJS

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,6 @@
 machine:
   python:
-    version:
-      - 2.6.8
-      - pypy-2.4.0
+    version: 2.6.8
 
 dependencies:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,21 @@
+machine:
+  python:
+    version:
+      - 2.6.8
+      - pypy-2.4.0
+
+dependencies:
+  override:
+    - pip install -r requirements_dev.txt
+    - npm install
+    - npm install -g grunt-cli
+
+test:
+  override:
+    - bin/kalite start --traceback -v 2
+    - bin/kalite status
+    - bin/kalite stop --traceback -v 2
+    - python python-packages/fle_utils/tests.py
+    - grunt jshint
+    - bin/kalite manage bundleassets
+    - ./node_modules/karma/bin/karma start --single-run --browsers PhantomJS

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -597,7 +597,7 @@ def profile_memory():
 
     signal.setitimer(signal.ITIMER_PROF, 1, 1)
 
-    signal.signal(signal.ITIMER_PROF, collect_mem_usage)
+    signal.signal(signal.SIGPROF, collect_mem_usage)
     atexit.register(handle_exit)
 
 if __name__ == "__main__":

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -556,6 +556,7 @@ def profile_memory():
     import csv
     import resource
     import signal
+    import sparkline
     import time
 
     starttime = time.time()
@@ -568,7 +569,10 @@ def profile_memory():
         except StopIteration:
             highest_mem_usage = {"pid": os.getpid(), "timestamp": 0, "mem_usage": 0}
 
-        print("PID: {pid} Highest memory usage: {mem_usage}MB".format(**highest_mem_usage))
+        graph = sparkline.sparkify([m['mem_usage'] for m in mem_usage]).encode("utf-8")
+
+        print("PID: {pid} Highest memory usage: {mem_usage}MB. Usage over time: {sparkline}".format(sparkline=graph, **highest_mem_usage))
+
 
     def write_profile_results(filename=None):
 

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -42,7 +42,7 @@ Planned features:
   kalite diagnose             Outputs user and copy-paste friendly diagnostics
   kalite query [COMMAND ...]  A query method for external UIs etc. to send
                               commands and obtain data from kalite.
-  
+
   Universal --verbose option and --debug option. Shows INFO level and DEBUG
   level from logging.. depends on proper logging being introduced and
   settings.LOGGERS. Currently, --debug just tells cherrypy to do "debug" mode.
@@ -129,16 +129,16 @@ class NotRunning(Exception):
         super(NotRunning, self).__init__()
 
 
-def udpate_default_args(defaults, updates):
+def update_default_args(defaults, updates):
     """
     Takes a list of default arguments and overwrites the defaults with
     contents of updates.
-    
+
     e.g.:
-    
-    udpate_default_args(["--somearg=default"], ["--somearg=overwritten"])
+
+    update_default_args(["--somearg=default"], ["--somearg=overwritten"])
      => ["--somearg=overwritten"]
-    
+
     This is done to avoid defining all known django command line arguments,
     we just want to proxy things and update with our own default values without
     looking into django.
@@ -166,7 +166,7 @@ def udpate_default_args(defaults, updates):
         defined_updates[elm[0]] = elm[1]
     defined_defaults.update(defined_updates)
     return defined_defaults.values()
-        
+
 
 # Utility functions for pinging or killing PIDs
 if os.name == 'posix':
@@ -328,7 +328,7 @@ def manage(command, args=[], in_background=False):
     :param args: List of options to parse to the django management command
     :param in_background: Creates a new process for the command
     """
-    
+
     if not in_background:
         utility = ManagementUtility([os.path.basename(sys.argv[0]), command] + args)
         # This ensures that 'kalite' is printed in help menus instead of
@@ -338,7 +338,7 @@ def manage(command, args=[], in_background=False):
     else:
         # Create a new subprocess, beware that it won't die with the parent
         # so you have to kill it in another fashion
-        
+
         # If we're on windows, we need to create a new process group, otherwise
         # the newborn will be murdered when the parent becomes a daemon
         if os.name == "nt":
@@ -398,12 +398,12 @@ def start(debug=False, args=[], skip_job_scheduler=False):
         manage(
             'cronserver',
             in_background=True,
-            args=udpate_default_args(
+            args=update_default_args(
                 ['--daemon', '--pid-file={0000:s}'.format(PID_FILE_JOB_SCHEDULER)],
                 args
             )
         )
-    args = udpate_default_args(
+    args = update_default_args(
         [
             "--host=%s" % LISTEN_ADDRESS,
             "--daemonize",
@@ -450,7 +450,7 @@ def stop(args=[], sys_exit=True):
             if sys_exit:
                 sys.exit(-1)
             return  # Do not continue because error could not be handled
- 
+
     # If there's no PID for the job scheduler, just quit
     if not os.path.isfile(PID_FILE_JOB_SCHEDULER):
         pass

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -562,7 +562,16 @@ def profile_memory():
 
     mem_usage = []
 
+    def print_results():
+        try:
+            highest_mem_usage = next(s for s in sorted([x['mem_usage'] for x in mem_usage], reverse=True)) / 1024
+        except StopIteration:
+            highest_mem_usage = 0
+
+        print("Highest memory usage: {mem}MB".format(mem=highest_mem_usage))
+
     def write_profile_results(filename=None):
+
         if not filename:
             filename = os.path.join(os.getcwd(), "memory_profile.log")
 
@@ -574,6 +583,7 @@ def profile_memory():
 
     def handle_exit():
         write_profile_results()
+        print_results()
 
     def collect_mem_usage(_sig, _frame):
         """

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 behave==1.2.4
 selenium==2.45.0
+pysparklines==0.9

--- a/sphinx-docs/developer_docs/index.rst
+++ b/sphinx-docs/developer_docs/index.rst
@@ -7,3 +7,4 @@ Useful stuff our devs think that the rest of our devs ought to know about.
     Developing Front End Code <front_end_code>
     Javascript Unit Tests <javascript_testing>
     Behavior-Driven Integration Tests <behave_testing>
+    Profiling KA Lite <profiling>

--- a/sphinx-docs/developer_docs/profiling.rst
+++ b/sphinx-docs/developer_docs/profiling.rst
@@ -1,0 +1,14 @@
+Profiling KA Lite
+=================
+
+Getting a general overview of resources used
+--------------------------------------------
+
+To get a sense of the resources used by KA Lite over a period of time,
+run the `kalite` command with the `PROFILE` environment variable::
+
+  PROFILE=yes kalite <command>
+
+Upon normal exit, the program will write to a file called
+`memory_profile.log` containing the time and resource utilization. For
+now we only log memory usage.


### PR DESCRIPTION
The goal of this patch is to introduce lightweight memory profiling that can be run in the build server/in the background. The data will be used to track how our memory usage grows over time as measured by the benchmarking suite. This isn't designed to help pinpoint where memory leaks happen, see `guppy-heapy` and `memory_profiler` for that.

Oh, and with this change I also introduce a more substantial CircleCI config file.