### PR TITLE
Silence collectstatic so we can read test output easier

### DIFF
--- a/kalite/distributed/management/commands/kaserve.py
+++ b/kalite/distributed/management/commands/kaserve.py
@@ -135,7 +135,10 @@ class Command(BaseCommand):
         # them to be started up again as needed.
         Job.objects.update(is_running=False)
 
-        call_command("collectstatic", interactive=False)
+        # Copy static media, one reason for not symlinking: It is not cross-platform and can cause permission issues
+        # with many webservers
+        logging.info("Copying static media")
+        call_command("collectstatic", interactive=False, verbosity=0)
 
         if options['startuplock']:
             os.unlink(options['startuplock'])


### PR DESCRIPTION
So eventhough it should be a healthy annoyance/punishment to have to read all those static files that are being copied, I kind of can't see test failures without scrolling around for several minutes...

Would you agree?