### PR TITLE
Enabling coach reports for videos by fixing slug lookup

### DIFF
--- a/kalite/playlist/models.py
+++ b/kalite/playlist/models.py
@@ -5,7 +5,7 @@ from django.db import models
 from fle_utils.django_utils import ExtendedModel
 
 from kalite.facility.models import FacilityGroup, FacilityUser
-from kalite.topic_tools import get_flat_topic_tree, get_node_cache
+from kalite.topic_tools import get_flat_topic_tree, get_node_cache, generate_slug_to_video_id_map
 
 from securesync.models import DeferredCountSyncedModel
 
@@ -140,7 +140,11 @@ class VanillaPlaylist:
         unprepared = filter(lambda e: e["entity_kind"]==entry_type, playlist.entries)
         prepared = []
         for entry in unprepared:
-            new_item = get_node_cache()[entry_type].get(entry['entity_id'], [None])[0]
+            if entry_type == "Exercise":
+                new_item = get_node_cache()[entry_type].get(entry['entity_id'], [None])[0]
+            elif entry_type == "Video":
+                video_id = generate_slug_to_video_id_map(get_node_cache())[entry['entity_id']]
+                new_item = get_node_cache()[entry_type].get(video_id, [None])[0]
             if new_item:
                 prepared.append(new_item)
         return prepared


### PR DESCRIPTION
Fixed video slug to video id lookup so that video coach reports works.

![screenshot from 2015-05-16 11 44 36](https://cloud.githubusercontent.com/assets/4207886/7664981/f13e1310-fbc0-11e4-89be-12ec85d933c4.png)


Changed sorting order of students, first_name, last_name.

Improved exercise mastery coach reports to ignore duplicate and display all grade playlists.

