### PR TITLE
Created backbone view for the navigation bar

### DIFF
--- a/kalite/coachreports/templates/coachreports/base.html
+++ b/kalite/coachreports/templates/coachreports/base.html
@@ -3,12 +3,6 @@
 {% load i18n %}
 {% load my_filters %}
 
-{% block i18n_do_not_translate %}
-    {% block reports_active %}reports-active active-tab active-nav{% endblock reports_active %}
-    {% block teacher_active %}active{% endblock teacher_active %}
-    {% block admin_active %}active{% endblock admin_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block title %}{% trans "Coach Reports" %}{% endblock title %}
 
 {% block headcss %}{{ block.super }}
@@ -41,9 +35,8 @@
                 el: $('#coachreport-navigation-container')
             });
         });
-        $(document).ready(function() {
-            window.toggleNavbarView.active_tab($("#teach-tab"));
-        });
+        var onTeachPage = true; 
+        var onManagePage, onLearnPage = false;
 
     </script>
 {% endblock headjs %}

--- a/kalite/coachreports/templates/coachreports/base.html
+++ b/kalite/coachreports/templates/coachreports/base.html
@@ -35,8 +35,6 @@
                 el: $('#coachreport-navigation-container')
             });
         });
-        var onTeachPage = true; 
-
     </script>
 {% endblock headjs %}
 

--- a/kalite/coachreports/templates/coachreports/base.html
+++ b/kalite/coachreports/templates/coachreports/base.html
@@ -36,7 +36,6 @@
             });
         });
         var onTeachPage = true; 
-        var onManagePage, onLearnPage = false;
 
     </script>
 {% endblock headjs %}

--- a/kalite/coachreports/templates/coachreports/base.html
+++ b/kalite/coachreports/templates/coachreports/base.html
@@ -41,6 +41,10 @@
                 el: $('#coachreport-navigation-container')
             });
         });
+        $(document).ready(function() {
+            window.toggleNavbarView.active_tab($("#teach-tab"));
+        });
+
     </script>
 {% endblock headjs %}
 

--- a/kalite/coachreports/templates/coachreports/base_d3_visualization.html
+++ b/kalite/coachreports/templates/coachreports/base_d3_visualization.html
@@ -22,11 +22,6 @@
 {% load my_filters %}
 {% load staticfiles %}
 
-{% block i18n_do_not_translate %}
-    {% block teacher_active %}active{% endblock teacher_active %}
-    {% block admin_active %}active{% endblock admin_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block headcss %} {{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/jquery-ui/jquery-ui.min.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'css/jquery-ui/plugins/ui.dynatree.css' %}" />

--- a/kalite/coachreports/templates/coachreports/scatter_view.html
+++ b/kalite/coachreports/templates/coachreports/scatter_view.html
@@ -5,8 +5,6 @@
 
 {% block title %}{{ title }} | {{ block.super }}{% endblock title %}
 {% block report_title %}{{ title }}{% endblock report_title %}
-{% block teacher_active %}active{% endblock teacher_active %}
-{% block admin_active %}active{% endblock admin_active %}
 {% block effort_active %}sub-active{% endblock effort_active %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/coachreports/templates/coachreports/student_view.html
+++ b/kalite/coachreports/templates/coachreports/student_view.html
@@ -3,10 +3,6 @@
 {% load staticfiles %}
 {% load my_filters %}
 
-{% block reports_active %}reports-active active-tab active-nav{% endblock reports_active %}
-{% block teacher_active %}active{% endblock teacher_active %}
-{% block admin_active %}active{% endblock admin_active %}
-
 {% block title %}{% trans "User report" %} {{ block.super }}{% endblock title%}
 {% block report_title %}{% trans "User report" %}{% endblock report_title %}
 

--- a/kalite/control_panel/templates/control_panel/base.html
+++ b/kalite/control_panel/templates/control_panel/base.html
@@ -22,6 +22,15 @@
     </style>
 {% endblock headcss %}
 
+{% block headjs %}
+
+<script>
+    var onManagePage = true; 
+    var onTeachPage, onLearnPage = false;
+</script>
+
+{% endblock headjs %}
+
 {% block content %}
 
 {% block subnavbar %}{{block.super}}{% endblock subnavbar %}

--- a/kalite/control_panel/templates/control_panel/base.html
+++ b/kalite/control_panel/templates/control_panel/base.html
@@ -26,7 +26,6 @@
 
 <script>
     var onManagePage = true; 
-    var onTeachPage, onLearnPage = false;
 </script>
 
 {% endblock headjs %}

--- a/kalite/control_panel/templates/control_panel/base.html
+++ b/kalite/control_panel/templates/control_panel/base.html
@@ -2,10 +2,6 @@
 {% load staticfiles %}
 {% load i18n %}
 
-{% block i18n_do_not_translate %}
-    {% block control_panel_active %}active{% endblock control_panel_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/control_panel/base.css' %}" />
     <!-- Override bootstrap here to fix up search bar -->

--- a/kalite/control_panel/templates/control_panel/base.html
+++ b/kalite/control_panel/templates/control_panel/base.html
@@ -18,14 +18,6 @@
     </style>
 {% endblock headcss %}
 
-{% block headjs %}
-
-<script>
-    var onManagePage = true; 
-</script>
-
-{% endblock headjs %}
-
 {% block content %}
 
 {% block subnavbar %}{{block.super}}{% endblock subnavbar %}

--- a/kalite/distributed/hbtemplates/user/login.handlebars
+++ b/kalite/distributed/hbtemplates/user/login.handlebars
@@ -10,7 +10,6 @@
                   <option selected disabled>{{_ "Select Facility" }}</option>
                   {{#each facilities}}
                     <option value="{{this.id}}">{{this.name}}</option>
-                    <option value="{{this.id}}">{{this.name}}</option>
                   {{/each}}
                 </select>
               </div>

--- a/kalite/distributed/hbtemplates/user/login.handlebars
+++ b/kalite/distributed/hbtemplates/user/login.handlebars
@@ -10,6 +10,7 @@
                   <option selected disabled>{{_ "Select Facility" }}</option>
                   {{#each facilities}}
                     <option value="{{this.id}}">{{this.name}}</option>
+                    <option value="{{this.id}}">{{this.name}}</option>
                   {{/each}}
                 </select>
               </div>

--- a/kalite/distributed/hbtemplates/user/navigation.handlebars
+++ b/kalite/distributed/hbtemplates/user/navigation.handlebars
@@ -1,9 +1,9 @@
 
-  <li id="teach-tab" class="teacher admin display-none"><a href="/coachreports/table/" {{!-- id="nav_coachreports"--}}>{{_ "Teach" }}</a></li>
+  <li id="teach-tab" class="teacher teach-tab admin display-none"><a href="/coachreports/table/" {{!-- id="nav_coachreports"--}}>{{_ "Teach" }}</a></li>
 
-  <li id="a-manage" class="admin display-none"><a href="/management/zone">{{_ "Manage" }}</a></li>
+  <li class="manage-tab admin display-none"><a href="/management/zone">{{_ "Manage" }}</a></li>
 
-  <li id="t-manage" class="teacher display-none"><a href="/management/zone/None/facility/{{ facility_id }}/management/">{{_ "Manage" }}</a></li>
+  <li class="manage-tab teacher display-none"><a href="/management/zone/None/facility/{{ facility_id }}/management/">{{_ "Manage" }}</a></li>
 
   {{!-- Learn for all --}}
   <li id="nav-handlebars" class="learn-tab display-none"><a href="/learn" id="nav_learn" class="home-navlink">{{_ "Learn" }}</a></li>

--- a/kalite/distributed/hbtemplates/user/navigation.handlebars
+++ b/kalite/distributed/hbtemplates/user/navigation.handlebars
@@ -1,12 +1,12 @@
 
-  <li class="teacher admin display-none"><a href="/coachreports/table/"{{!-- id="nav_coachreports"--}}>{{_ "Teach" }}</a></li>
+  <li class="teacher admin display-none" id="search-prepend"><a href="/coachreports/table/"{{!-- id="nav_coachreports"--}}>{{_ "Teach" }}</a></li>
 
   <li class="admin display-none"><a href="/management/zone">{{_ "Manage" }}</a></li>
 
   <li class="teacher display-none"><a href="/management/zone/None/facility/{{ facility_id }}/management/">{{_ "Manage" }}</a></li>
 
   {{!-- Learn for all --}}
-  <li id="nav-handlebars"><a href="/learn" id="nav_learn" class="home-navlink">{{_ "Learn" }}</a></li>
+  <li id="nav-handlebars" class="learn-tab display-none"><a href="/learn" id="nav_learn" class="home-navlink">{{_ "Learn" }}</a></li>
 
   {{!-- Login --}}
   <li><a href="#" class="guest display-none" data-toggle="modal" data-target="#loginModal" title="" id="nav_login">{{_ "Login" }}</a></li>
@@ -23,7 +23,7 @@
     </a>
 
     <ul class="dropdown-menu" data-no-collapse="true" role="menu">
-      <li class="student display-none" role="presentation">
+      <li class="student display-none" id="points-tab" role="presentation">
         <span class="student display-none" id="points">
           {{!-- Points injected here w/ js --}}
         </span>

--- a/kalite/distributed/hbtemplates/user/navigation.handlebars
+++ b/kalite/distributed/hbtemplates/user/navigation.handlebars
@@ -1,46 +1,48 @@
-
-  <li id="teach-tab" class="teacher teach-tab admin display-none"><a href="/coachreports/table/" {{!-- id="nav_coachreports"--}}>{{_ "Teach" }}</a></li>
-
-  <li class="manage-tab admin display-none"><a href="/management/zone">{{_ "Manage" }}</a></li>
-
-  <li class="manage-tab teacher display-none"><a href="/management/zone/None/facility/{{ facility_id }}/management/">{{_ "Manage" }}</a></li>
-
-  {{!-- Learn for all --}}
-  <li id="nav-handlebars" class="learn-tab display-none"><a href="/learn" id="nav_learn" class="home-navlink">{{_ "Learn" }}</a></li>
-
-  {{!-- Login --}}
-  <li><a href="#" class="guest display-none" data-toggle="modal" data-target="#loginModal" title="" id="nav_login">{{_ "Login" }}</a></li>
-  <li><a href="" id="nav_signup" class="guest display-none" title="">{{_ "Sign Up" }}</a></li>
+{{#if is_admin }}
+  <li class="teach-tab"><a href="/coachreports/table/">{{_ "Teach" }}</a></li>
+  <li class="manage-tab"><a href="/management/zone/None/{{#unless is_django_user }}facility/{{ facility_id }}/management/{{/unless}}">{{_ "Manage" }}</a></li>
+{{/if}}
+{{!-- Learn for all --}}
+  <li id="nav-handlebars" class="learn-tab"><a href="/learn" id="nav_learn" class="home-navlink">{{_ "Learn" }}</a></li>
+{{!-- Login --}}
+{{#unless is_logged_in}}
+  <li><a href="#" data-toggle="modal" data-target="#loginModal" id="nav_login">{{_ "Login" }}</a></li>
+  <li><a href="/securesync/signup/" id="nav_signup">{{_ "Sign Up" }}</a></li>
+{{/unless}}
 
   <hr class="nav-divider">
-  <hr class="nav-divider admin display-none">
+{{#if is_admin}}
+  <hr class="nav-divider">
+{{/if}}
 
-  {{!-- Farthest right nav is logged in user dropdown --}}
+{{!-- Farthest right nav is logged in user dropdown --}}
+{{#if is_logged_in}}
   <li class="dropdown " id="user-name">
-    <a href="#" class="logged-in display-none dropdown-toggle" data-toggle="dropdown" id="user-name-a">
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown" id="user-name-a">
         <span id="username">{{!-- Username injected here w/ js --}}</span>
       <span class="caret hidden-xs"></span>
     </a>
 
     <ul class="dropdown-menu" data-no-collapse="true" role="menu">
-      <li class="student display-none" id="points-tab" role="presentation">
-        <span class="student display-none" id="points">
-          {{!-- Points injected here w/ js --}}
-        </span>
+    {{#unless is_admin}}
+      <li id="points-tab" role="presentation">
+        <span id="points">{{!-- Points injected here w/ js --}}</span>
       </li>
-      <li role="presentation" class="divider student display-none"></li>
+      <li role="presentation" class="divider"></li>
       {{!-- Student account management --}}
-      <li role="presentation" class="motivational-feature student display-none">
-        <a role="menuitem" tabindex="-1" href="" id="nav_progress" title="" class="student display-none">
+      <li role="presentation" class="motivational-feature">
+        <a role="menuitem" tabindex="-1" id="nav_progress">
           {{_ "My Progress" }}
         </a>
       </li>
-      <li role="presentation" class="divider student display-none"></li>
+      <li role="presentation" class="divider"></li>
+    {{/unless}}
       {{!-- Logout goes at the bottom! --}}
       <li role="presentation" id="logout">
-        <a role="menuitem" tabindex="-1" id="nav_logout" class="logged-in display-none" title="" href="#">
+        <a role="menuitem" tabindex="-1" id="nav_logout" href="#">
           {{_ "Logout" }}
         </a>
       </li>
     </ul>
   </li>
+{{/if}}

--- a/kalite/distributed/hbtemplates/user/navigation.handlebars
+++ b/kalite/distributed/hbtemplates/user/navigation.handlebars
@@ -1,0 +1,59 @@
+
+{{!-- For logged in admins --}}
+  <li class="admin-nav ">
+    <a href="" id="nav_coachreports" class="teacher-only">Teach</a>
+  </li>
+  <li class="admin-nav ">
+    <a href="" id="manage" class="">Manage</a>
+  </li>
+  {{!-- For logged in teachers --}}
+  <li class="teacher-nav">
+    <a href="" id="nav_coachreports" >Teach</a>
+  </li>
+  <li class="teacher-nav display-none ">
+    <a href="" id="manage" class="">Manage</a>
+  </li>
+  {{!-- Learn for all --}}
+  <li id="nav-handlebars" class="">
+    <a href="" id="nav_learn" class="home-navlink">Learn</a>
+  </li>
+  {{!-- Login --}}
+  <li class="guest-nav">
+    <a href="#" class="not-logged-in-only" data-toggle="modal" data-target="#loginModal" title="" id="nav_login">Login</a>
+  </li>
+  <li class="guest-nav ">
+    <a href="" id="nav_signup" class="not-logged-in-only" title="">Sign Up</a>
+  </li>
+
+  <hr class="nav-divider student-nav student-only">
+  <hr class="nav-divider admin-only">
+
+  {{!-- Farthest right nav is logged in user dropdown --}}
+  <li class="dropdown " id="user-name">
+    <a href="#" class="logged-in-only dropdown-toggle" data-toggle="dropdown" id="user-name-a">
+        <span id="username">{{!-- Username injected here w/ js --}}</span>
+      <span class="caret hidden-xs"></span>
+    </a>
+
+    <ul class="dropdown-menu" data-no-collapse="true" role="menu">
+      <li class="student-only student-nav" role="presentation">
+        <span class="student-only student-nav" id="points">
+          {{!-- Points injected here w/ js --}}
+        </span>
+      </li>
+      <li role="presentation" class="divider student-only student-nav"></li>
+      {{!-- Student account management --}}
+      <li role="presentation" class="motivational-feature student-only student-nav">
+        <a role="menuitem" tabindex="-1" href="" id="nav_progress" title="" class="student-only">
+          My Progress
+        </a>
+      </li>
+      <li role="presentation" class="divider student-only student-nav"></li>
+      {{!-- Logout goes at the bottom! --}}
+      <li role="presentation" id="logout">
+        <a role="menuitem" tabindex="-1" id="nav_logout" class="logged-in-only" title="" href="#">
+          Logout
+        </a>
+      </li>
+    </ul>
+  </li>

--- a/kalite/distributed/hbtemplates/user/navigation.handlebars
+++ b/kalite/distributed/hbtemplates/user/navigation.handlebars
@@ -1,9 +1,9 @@
 
-  <li class="teacher admin display-none" id="search-prepend"><a href="/coachreports/table/"{{!-- id="nav_coachreports"--}}>{{_ "Teach" }}</a></li>
+  <li id="teach-tab" class="teacher admin display-none"><a href="/coachreports/table/" {{!-- id="nav_coachreports"--}}>{{_ "Teach" }}</a></li>
 
-  <li class="admin display-none"><a href="/management/zone">{{_ "Manage" }}</a></li>
+  <li id="a-manage" class="admin display-none"><a href="/management/zone">{{_ "Manage" }}</a></li>
 
-  <li class="teacher display-none"><a href="/management/zone/None/facility/{{ facility_id }}/management/">{{_ "Manage" }}</a></li>
+  <li id="t-manage" class="teacher display-none"><a href="/management/zone/None/facility/{{ facility_id }}/management/">{{_ "Manage" }}</a></li>
 
   {{!-- Learn for all --}}
   <li id="nav-handlebars" class="learn-tab display-none"><a href="/learn" id="nav_learn" class="home-navlink">{{_ "Learn" }}</a></li>

--- a/kalite/distributed/hbtemplates/user/navigation.handlebars
+++ b/kalite/distributed/hbtemplates/user/navigation.handlebars
@@ -1,31 +1,18 @@
 
-{{!-- For logged in admins --}}
-  <li class="admin-nav ">
-    <a href="" id="nav_coachreports" class="teacher-only">Teach</a>
-  </li>
-  <li class="admin-nav ">
-    <a href="" id="manage" class="">Manage</a>
-  </li>
-  {{!-- For logged in teachers --}}
-  <li class="teacher-nav">
-    <a href="" id="nav_coachreports" >Teach</a>
-  </li>
-  <li class="teacher-nav display-none ">
-    <a href="" id="manage" class="">Manage</a>
-  </li>
-  {{!-- Learn for all --}}
-  <li id="nav-handlebars" class="">
-    <a href="" id="nav_learn" class="home-navlink">Learn</a>
-  </li>
-  {{!-- Login --}}
-  <li class="guest-nav">
-    <a href="#" class="not-logged-in-only" data-toggle="modal" data-target="#loginModal" title="" id="nav_login">Login</a>
-  </li>
-  <li class="guest-nav ">
-    <a href="" id="nav_signup" class="not-logged-in-only" title="">Sign Up</a>
-  </li>
+  <li class="admin-toggle"><a href="/coachreports/table/"{{!-- id="nav_coachreports"--}}>{{_ "Teach" }}</a></li>
 
-  <hr class="nav-divider student-nav student-only">
+  <li class="admin-manage admin-toggle"><a href="/management/zone">{{_ "Manage" }}</a></li>
+
+  <li class="teacher-manage admin-toggle"><a href="/management/zone">{{_ "Manage" }}</a></li>
+
+  {{!-- Learn for all --}}
+  <li id="nav-handlebars"><a href="/learn" id="nav_learn" class="home-navlink">{{_ "Learn" }}</a></li>
+
+  {{!-- Login --}}
+  <li><a href="#" class="not-logged-in-only" data-toggle="modal" data-target="#loginModal" title="" id="nav_login">{{_ "Login" }}</a></li>
+  <li><a href="" id="nav_signup" class="not-logged-in-only" title="">{{_ "Sign Up" }}</a></li>
+
+  <hr class="nav-divider">
   <hr class="nav-divider admin-only">
 
   {{!-- Farthest right nav is logged in user dropdown --}}
@@ -36,23 +23,23 @@
     </a>
 
     <ul class="dropdown-menu" data-no-collapse="true" role="menu">
-      <li class="student-only student-nav" role="presentation">
-        <span class="student-only student-nav" id="points">
+      <li class="student-only" role="presentation">
+        <span class="student-only" id="points">
           {{!-- Points injected here w/ js --}}
         </span>
       </li>
-      <li role="presentation" class="divider student-only student-nav"></li>
+      <li role="presentation" class="divider student-only"></li>
       {{!-- Student account management --}}
-      <li role="presentation" class="motivational-feature student-only student-nav">
+      <li role="presentation" class="motivational-feature student-only">
         <a role="menuitem" tabindex="-1" href="" id="nav_progress" title="" class="student-only">
-          My Progress
+          {{_ "My Progress" }}
         </a>
       </li>
-      <li role="presentation" class="divider student-only student-nav"></li>
+      <li role="presentation" class="divider student-only"></li>
       {{!-- Logout goes at the bottom! --}}
       <li role="presentation" id="logout">
         <a role="menuitem" tabindex="-1" id="nav_logout" class="logged-in-only" title="" href="#">
-          Logout
+          {{_ "Logout" }}
         </a>
       </li>
     </ul>

--- a/kalite/distributed/hbtemplates/user/navigation.handlebars
+++ b/kalite/distributed/hbtemplates/user/navigation.handlebars
@@ -1,44 +1,44 @@
 
-  <li class="admin-toggle"><a href="/coachreports/table/"{{!-- id="nav_coachreports"--}}>{{_ "Teach" }}</a></li>
+  <li class="teacher admin display-none"><a href="/coachreports/table/"{{!-- id="nav_coachreports"--}}>{{_ "Teach" }}</a></li>
 
-  <li class="admin-manage admin-toggle"><a href="/management/zone">{{_ "Manage" }}</a></li>
+  <li class="admin display-none"><a href="/management/zone">{{_ "Manage" }}</a></li>
 
-  <li class="teacher-manage admin-toggle"><a href="/management/zone">{{_ "Manage" }}</a></li>
+  <li class="teacher display-none"><a href="/management/zone/None/facility/{{ facility_id }}/management/">{{_ "Manage" }}</a></li>
 
   {{!-- Learn for all --}}
   <li id="nav-handlebars"><a href="/learn" id="nav_learn" class="home-navlink">{{_ "Learn" }}</a></li>
 
   {{!-- Login --}}
-  <li><a href="#" class="not-logged-in-only" data-toggle="modal" data-target="#loginModal" title="" id="nav_login">{{_ "Login" }}</a></li>
-  <li><a href="" id="nav_signup" class="not-logged-in-only" title="">{{_ "Sign Up" }}</a></li>
+  <li><a href="#" class="guest display-none" data-toggle="modal" data-target="#loginModal" title="" id="nav_login">{{_ "Login" }}</a></li>
+  <li><a href="" id="nav_signup" class="guest display-none" title="">{{_ "Sign Up" }}</a></li>
 
   <hr class="nav-divider">
-  <hr class="nav-divider admin-only">
+  <hr class="nav-divider admin display-none">
 
   {{!-- Farthest right nav is logged in user dropdown --}}
   <li class="dropdown " id="user-name">
-    <a href="#" class="logged-in-only dropdown-toggle" data-toggle="dropdown" id="user-name-a">
+    <a href="#" class="logged-in display-none dropdown-toggle" data-toggle="dropdown" id="user-name-a">
         <span id="username">{{!-- Username injected here w/ js --}}</span>
       <span class="caret hidden-xs"></span>
     </a>
 
     <ul class="dropdown-menu" data-no-collapse="true" role="menu">
-      <li class="student-only" role="presentation">
-        <span class="student-only" id="points">
+      <li class="student display-none" role="presentation">
+        <span class="student display-none" id="points">
           {{!-- Points injected here w/ js --}}
         </span>
       </li>
-      <li role="presentation" class="divider student-only"></li>
+      <li role="presentation" class="divider student display-none"></li>
       {{!-- Student account management --}}
-      <li role="presentation" class="motivational-feature student-only">
-        <a role="menuitem" tabindex="-1" href="" id="nav_progress" title="" class="student-only">
+      <li role="presentation" class="motivational-feature student display-none">
+        <a role="menuitem" tabindex="-1" href="" id="nav_progress" title="" class="student display-none">
           {{_ "My Progress" }}
         </a>
       </li>
-      <li role="presentation" class="divider student-only"></li>
+      <li role="presentation" class="divider student display-none"></li>
       {{!-- Logout goes at the bottom! --}}
       <li role="presentation" id="logout">
-        <a role="menuitem" tabindex="-1" id="nav_logout" class="logged-in-only" title="" href="#">
+        <a role="menuitem" tabindex="-1" id="nav_logout" class="logged-in display-none" title="" href="#">
           {{_ "Logout" }}
         </a>
       </li>

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -106,7 +106,7 @@ input[type="submit"] {
 .nav-tabs li a:active {
     border: 0;
     border-radius: 5px 15px 0 0;
-    margin: 0;
+    margin: 0 0 6px 0;
     background-color: #5AA685;
     color: #5AA685;
     -webkit-transition: all 80ms ease-out;
@@ -141,6 +141,9 @@ a#user-name-a.dropdown-toggle {
     border-top: 2px solid #5AA685;
     border-right: 2px solid #5AA685;
 }
+a#user-name-a.dropdown-toggle {
+    margin-bottom: 0px;
+}
 .navbar ul li.dropdown,
 .navbar ul li.dropdown.open {
     padding-right: 0;
@@ -150,12 +153,15 @@ a#user-name-a.dropdown-toggle {
 #points {
     text-align: left;
 }
-
+#points-tab {
+    padding: 10px 0px 5px 0px;
+}
 .navbar ul li.dropdown.open a {
     color: #5AA685;
 }
 .dropdown-menu {
     min-width: 0;
+    text-align: left;
 }
 .navbar ul li.dropdown.open ul.dropdown-menu li a,
 .navbar ul li.dropdown.open ul.dropdown-menu li span {

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -262,6 +262,9 @@ form .input-group {
 .navbar-toggle .icon-bar {
     background-color: #fff;
 }
+.display-none {
+    display: none !important;
+}
 /* ======= Logged in student only ======== */
 .relative-block{
     position: relative;

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -118,7 +118,7 @@ a:hover {
     color: darkRed;
 }
 
-#nav_addstudent, #nav_addteacher, #nav_admin, #nav_coachreports, #nav_watch, #nav_practice, #nav_signup, #nav_login, #nav_update, #nav_logout, #nav_registerdevice, #nav_tests {
+#nav_addstudent, #nav_addteacher, #nav_admin, #nav_coachreports, #nav_watch, #nav_practice, #nav_update, #nav_registerdevice, #nav_tests {
     display: none;
 }
 

--- a/kalite/distributed/static/js/distributed/distributed-server.js
+++ b/kalite/distributed/static/js/distributed/distributed-server.js
@@ -194,6 +194,20 @@ var StatusModel = Backbone.Model.extend({
         points = points || 0;
         // add the points that existed at page load and the points earned since page load, to get the total current points
         this.set("points", this.get("points") + points);
+    },
+
+    pageType: function() {
+
+        if ( window.location.pathname.search(Urls.coach_reports()) > -1 ) {
+            return "teachPage";
+        } 
+        if ( window.location.pathname.search(Urls.learn()) > -1 ) {
+            return "learnPage";
+        } 
+        if ( window.location.pathname.search(Urls.zone_redirect()) > -1 || window.location.pathname.search("/update/") > -1 ) {
+            return "managePage";
+        }
+        
     }
 
 });

--- a/kalite/distributed/static/js/distributed/distributed-server.js
+++ b/kalite/distributed/static/js/distributed/distributed-server.js
@@ -5,7 +5,7 @@
 
 // Functions related to loading the page
 
-function toggle_state(state, status){
+function toggle_state(state, status) {
     $("." + (status ? "not-" : "") + state + "-only").hide();
     $("." + (!status ? "not-" : "") + state + "-only").show();
     // Use display block setting instead of inline to prevent misalignment of navbar items.
@@ -188,7 +188,6 @@ var StatusModel = Backbone.Model.extend({
             toggle_state("admin", self.get("is_admin")); // combination of teachers & super-users
             $('.navbar-right').show();
         });
-
     },
 
     update_total_points: function(points) {
@@ -425,3 +424,19 @@ $(function() {
     });
 
 });
+
+
+/*This function addresses Bootstrap's limitation of having a dropdown menu in an already collapsed menu*/
+function collapsedNav() {
+    var data_toggle = document.getElementById("user-name-a");
+    var menu = document.getElementById("user-name");
+        if ( $('body').innerWidth() <= 750 ) {
+            data_toggle.removeAttribute("data-toggle");
+            menu.classList.add("open");
+      } else {
+            data_toggle.setAttribute("data-toggle", "dropdown");
+            menu.classList.remove("open");
+      }
+};
+window.addEventListener("resize", collapsedNav);
+window.addEventListener("pageshow", collapsedNav);

--- a/kalite/distributed/static/js/distributed/distributed-server.js
+++ b/kalite/distributed/static/js/distributed/distributed-server.js
@@ -441,7 +441,7 @@ $(function() {
 
 
 /*This function addresses Bootstrap's limitation of having a dropdown menu in an already collapsed menu*/
-/*function collapsedNav() {
+function collapsedNav() {
     var data_toggle = document.getElementById("user-name-a");
     var menu = document.getElementById("user-name");
         if ( $('body').innerWidth() <= 750 ) {
@@ -452,5 +452,3 @@ $(function() {
             menu.classList.remove("open");
       }
 };
-window.addEventListener("resize", collapsedNav);
-window.addEventListener("pageshow", collapsedNav);*/

--- a/kalite/distributed/static/js/distributed/distributed-server.js
+++ b/kalite/distributed/static/js/distributed/distributed-server.js
@@ -427,7 +427,7 @@ $(function() {
 
 
 /*This function addresses Bootstrap's limitation of having a dropdown menu in an already collapsed menu*/
-function collapsedNav() {
+/*function collapsedNav() {
     var data_toggle = document.getElementById("user-name-a");
     var menu = document.getElementById("user-name");
         if ( $('body').innerWidth() <= 750 ) {
@@ -439,4 +439,4 @@ function collapsedNav() {
       }
 };
 window.addEventListener("resize", collapsedNav);
-window.addEventListener("pageshow", collapsedNav);
+window.addEventListener("pageshow", collapsedNav);*/

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -731,7 +731,9 @@ window.ExercisePracticeView = ExerciseWrapperBaseView.extend({
         // once it changes, for updating the "total points" in the nav bar display
         this.status_points = this.log_model.get("points");
 
+
         if ( !window.statusModel.get("is_django_user") ) {
+
             this.progress_view = this.add_subview(ExerciseProgressView, {
                 el: this.$(".exercise-progress-wrapper"),
                 model: this.log_model,

--- a/kalite/distributed/static/js/distributed/navigation/views.js
+++ b/kalite/distributed/static/js/distributed/navigation/views.js
@@ -1,7 +1,0 @@
-window.TopLevelNavigationView = BaseView.extend ({
-		events: {
-			'click a': 'clickLink',
-		}
-
-		
-	});

--- a/kalite/distributed/static/js/distributed/navigation/views.js
+++ b/kalite/distributed/static/js/distributed/navigation/views.js
@@ -1,0 +1,7 @@
+window.TopLevelNavigationView = BaseView.extend ({
+		events: {
+			'click a': 'clickLink',
+		}
+
+		
+	});

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -315,3 +315,57 @@ window.UserView = BaseView.extend({
         this.model.logout();
     }
 });
+
+/* Check the type of user
+- guest: 'guest-user'
+- teacher: 'teacher-nav'
+- admin: 'admin-nav'
+- student: 'student-user'
+assign the api call to the appropriate css class
+if not current user, insert display-none css class */
+
+/* This view uses API to toggle which navbar items are displayed to the user */ 
+window.ToggleNavbarView = BaseView.extend ({
+
+    template: HB.template("user/navigation"),
+
+    initialize: function() {
+        _.bindAll(this);
+        this.listenTo(this.model, "change", this.render);
+        $("body").append(this.el);
+    },
+
+    render: function() {
+        var self = this;
+
+        this.$el.html(this.template());
+
+        /*if ( window.statusModel.get("is_logged_in")) {
+            //identifies a teacher user
+            if ( window.statusModel.get("is_admin") && !window.statusModel.get("is_django_user") ) {
+                console.log("working so far");
+                var element = 
+                self.getElementsByClassName("teacher-nav").classList.remove("display-none");
+
+            }
+            //identifies a super user
+            else if ( window.statusModel.get("is_django_user")) {
+
+            }
+            //identifies a general admin user
+            else if ( window.statusModel.get("is_admin") ) {
+
+            }
+            //identifies a student user 
+            else if ( !window.statusModel.get("is_admin") && !window.statusModel.get("is_django_user") ) {
+
+            }
+        } 
+        // shows tabs for guest user
+        else {
+
+        }*/
+        return this;  
+    }
+});
+var toggleNavbarView = new ToggleNavbarView({model: statusModel, el: "#top-nav"});

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -316,56 +316,38 @@ window.UserView = BaseView.extend({
     }
 });
 
-/* Check the type of user
-- guest: 'guest-user'
-- teacher: 'teacher-nav'
-- admin: 'admin-nav'
-- student: 'student-user'
-assign the api call to the appropriate css class
-if not current user, insert display-none css class */
-
-/* This view uses API to toggle which navbar items are displayed to the user */ 
+/* This view toggles which navbar items are displayed to the user */ 
 window.ToggleNavbarView = BaseView.extend ({
 
     template: HB.template("user/navigation"),
 
     initialize: function() {
-        _.bindAll(this);
+
+        _.bindAll(this);        
         this.listenTo(this.model, "change", this.render);
-        $("body").append(this.el);
+        this.$el.html(this.template());
+
     },
 
     render: function() {
-        var self = this;
 
-        this.$el.html(this.template());
+        this.userView = new UserView({ model: this.model, el: "#topnav" });
 
-        /*if ( window.statusModel.get("is_logged_in")) {
-            //identifies a teacher user
-            if ( window.statusModel.get("is_admin") && !window.statusModel.get("is_django_user") ) {
-                console.log("working so far");
-                var element = 
-                self.getElementsByClassName("teacher-nav").classList.remove("display-none");
+        // logged in
+        if ( this.model.get("is_logged_in") ) {
 
+            if ( this.model.get("is_admin") ) { // admin
+                if ( this.model.get("is_django_user") ) { // superuser
+                    this.$(".teacher-manage").hide();
+                } else { // teacher
+                    this.$(".admin-manage").hide();
+                }
+            } else { // student
+                this.$(".admin-toggle").hide();
             }
-            //identifies a super user
-            else if ( window.statusModel.get("is_django_user")) {
+        } else { // guest
+            this.$(".admin-toggle").hide();
+        }       
 
-            }
-            //identifies a general admin user
-            else if ( window.statusModel.get("is_admin") ) {
-
-            }
-            //identifies a student user 
-            else if ( !window.statusModel.get("is_admin") && !window.statusModel.get("is_django_user") ) {
-
-            }
-        } 
-        // shows tabs for guest user
-        else {
-
-        }*/
-        return this;  
     }
 });
-var toggleNavbarView = new ToggleNavbarView({model: statusModel, el: "#top-nav"});

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -323,7 +323,7 @@ window.ToggleNavbarView = BaseView.extend ({
 
     initialize: function() {
 
-        _.bindAll(this);        
+        _.bindAll(this);
         this.listenTo(this.model, "change", this.render);
         $("topnav").append(this.template());
 
@@ -331,46 +331,20 @@ window.ToggleNavbarView = BaseView.extend ({
 
     render: function() {
         
-        this.facility_id = {"facility_id": this.model.get("facility_id")};
-        this.$el.html(this.template(this.facility_id));
+        this.$el.html(this.template(this.model.attributes));
         
         this.userView = new UserView({ model: this.model, el: "#topnav" });
         $("#topnav").prepend(new AutoCompleteView().$el);
-        
-        // GUEST
-        if ( !this.model.get("is_logged_in") ) {
-            this.$(".guest").removeClass("display-none");
-        }
-        // ALL LOGGED IN
-        if ( this.model.get("is_logged_in") ) {
-            this.$(".logged-in").removeClass("display-none");
-        }
-        // ALL USERS - slight lag in tabs appearing, seems unnecessary but ensures that all tabs appear at the same time
-        if ( this.model.get("is_logged_in") || !this.model.get("is_logged_in") ) {
-            this.$(".learn-tab").removeClass("display-none");
-        }
-        // STUDENTS
-        if ( this.model.get("is_logged_in") && !this.model.get("is_admin") ) {
-            this.$(".student").removeClass("display-none");
-        }
-        // TEACHER
-        if ( !this.model.get("is_django_user") && this.model.get("is_admin") ) {
-            this.$(".teacher").removeClass("display-none");
-        }
-        // ADMINS
-        if ( this.model.get("is_django_user") ) {
-            this.$(".admin").removeClass("display-none");
+
+        // activates nav tab according to current page
+        if ( this.model.pageType() == "teachPage" ) {
+            this.$(".teach-tab").addClass("active");
+        } else if ( this.model.pageType() == "learnPage" ) {
+            this.$(".learn-tab").addClass("active");
+        } else if ( this.model.pageType() == "managePage" ) {
+            this.$(".manage-tab").addClass("active");   
         }
 
-        // ACTIVATES NAV TAB ACCORDING TO CURRENT PAGE
-        if ( onTeachPage ) {
-            this.$(".teach-tab").addClass("active");
-        } else if ( onManagePage ) {
-            this.$(".manage-tab").addClass("active");
-        } else if ( onLearnPage ) {
-            this.$(".learn-tab").addClass("active");
-        }
-       
     }
 
 });

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -326,28 +326,37 @@ window.ToggleNavbarView = BaseView.extend ({
         _.bindAll(this);        
         this.listenTo(this.model, "change", this.render);
         this.$el.html(this.template());
-
     },
 
     render: function() {
 
         this.userView = new UserView({ model: this.model, el: "#topnav" });
+        this.facility_id = {"facility_id": this.model.get("facility_id")};
+        this.$el.html(this.template(this.facility_id));
 
-        // logged in
+        // GUEST
+        if ( !this.model.get("is_logged_in") ) {
+            this.$(".guest").removeClass("display-none");
+        }
+
+        // ALL LOGGED IN
         if ( this.model.get("is_logged_in") ) {
+            this.$(".logged-in").removeClass("display-none");
+        }
 
-            if ( this.model.get("is_admin") ) { // admin
-                if ( this.model.get("is_django_user") ) { // superuser
-                    this.$(".teacher-manage").hide();
-                } else { // teacher
-                    this.$(".admin-manage").hide();
-                }
-            } else { // student
-                this.$(".admin-toggle").hide();
-            }
-        } else { // guest
-            this.$(".admin-toggle").hide();
-        }       
+        // STUDENTS
+        if ( this.model.get("is_logged_in") && !this.model.get("is_admin") ) {
+            this.$(".student").removeClass("display-none");
+        }
+
+        // TEACHER
+        if ( !this.model.get("is_django_user") && this.model.get("is_admin") ) {
+            this.$(".teacher").removeClass("display-none");
+        }
+        // ADMINS
+        if ( this.model.get("is_django_user") ) {
+            this.$(".admin").removeClass("display-none");
+        }
 
     }
 });

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -325,30 +325,31 @@ window.ToggleNavbarView = BaseView.extend ({
 
         _.bindAll(this);        
         this.listenTo(this.model, "change", this.render);
-        this.$el.html(this.template());
+        $("#topnav").append(this.template(this.facility_id));
+
     },
 
     render: function() {
 
         this.userView = new UserView({ model: this.model, el: "#topnav" });
         this.facility_id = {"facility_id": this.model.get("facility_id")};
-        this.$el.html(this.template(this.facility_id));
-
+        
         // GUEST
         if ( !this.model.get("is_logged_in") ) {
             this.$(".guest").removeClass("display-none");
         }
-
         // ALL LOGGED IN
         if ( this.model.get("is_logged_in") ) {
             this.$(".logged-in").removeClass("display-none");
         }
-
+        // ALL USERS - ensures all tabs appear at the same time
+        if ( this.model.get("is_logged_in") || !this.model.get("is_logged_in") ) {
+            this.$(".learn-tab").removeClass("display-none");
+        }
         // STUDENTS
         if ( this.model.get("is_logged_in") && !this.model.get("is_admin") ) {
             this.$(".student").removeClass("display-none");
         }
-
         // TEACHER
         if ( !this.model.get("is_django_user") && this.model.get("is_admin") ) {
             this.$(".teacher").removeClass("display-none");

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -325,14 +325,17 @@ window.ToggleNavbarView = BaseView.extend ({
 
         _.bindAll(this);        
         this.listenTo(this.model, "change", this.render);
-        $("#topnav").append(this.template(this.facility_id));
+        $el.append(this.template());
 
     },
 
     render: function() {
-
-        this.userView = new UserView({ model: this.model, el: "#topnav" });
+        
         this.facility_id = {"facility_id": this.model.get("facility_id")};
+        this.$el.html(this.template(this.facility_id));
+        
+        this.userView = new UserView({ model: this.model, el: "#topnav" });
+        $("#topnav").prepend(new AutoCompleteView().$el);
         
         // GUEST
         if ( !this.model.get("is_logged_in") ) {
@@ -342,7 +345,7 @@ window.ToggleNavbarView = BaseView.extend ({
         if ( this.model.get("is_logged_in") ) {
             this.$(".logged-in").removeClass("display-none");
         }
-        // ALL USERS - ensures all tabs appear at the same time
+        // ALL USERS - slight lag in tabs appearing, seems unnecessary but ensures that all tabs appear at the same time
         if ( this.model.get("is_logged_in") || !this.model.get("is_logged_in") ) {
             this.$(".learn-tab").removeClass("display-none");
         }
@@ -359,5 +362,13 @@ window.ToggleNavbarView = BaseView.extend ({
             this.$(".admin").removeClass("display-none");
         }
 
+    },
+
+    // sets a tab with the active css class
+    active_tab: function(id) {
+        console.log(id);
+        var x = id.addClass("active");
+        console.log(x);
     }
+
 });

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -316,7 +316,7 @@ window.UserView = BaseView.extend({
     }
 });
 
-/* This view toggles which navbar items are displayed to the user */ 
+/* This view toggles which navbar items are displayed to each type of user */ 
 window.ToggleNavbarView = BaseView.extend ({
 
     template: HB.template("user/navigation"),
@@ -325,7 +325,7 @@ window.ToggleNavbarView = BaseView.extend ({
 
         _.bindAll(this);        
         this.listenTo(this.model, "change", this.render);
-        $el.append(this.template());
+        $("topnav").append(this.template());
 
     },
 
@@ -362,13 +362,16 @@ window.ToggleNavbarView = BaseView.extend ({
             this.$(".admin").removeClass("display-none");
         }
 
-    },
-
-    // sets a tab with the active css class
-    active_tab: function(id) {
-        console.log(id);
-        var x = id.addClass("active");
-        console.log(x);
+        // ACTIVATES NAV TAB ACCORDING TO CURRENT PAGE
+        if ( onTeachPage ) {
+            this.$(".teach-tab").addClass("active");
+        } else if ( onManagePage ) {
+            this.$(".manage-tab").addClass("active");
+        } else if ( onLearnPage ) {
+            this.$(".learn-tab").addClass("active");
+        }
+       
     }
 
 });
+

--- a/kalite/distributed/templates/admin/base.html
+++ b/kalite/distributed/templates/admin/base.html
@@ -3,10 +3,6 @@
 {% load admin_static i18n %}
 {% load url from future %}
 
-{% block i18n_do_not_translate %}
-    {% block admin_active %}active{% endblock admin_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block headcss %}
     <link rel="stylesheet" type="text/css" href="{% block stylesheet %}{% static "admin/css/base.css" %}{% endblock %}" />
     {% block extrastyle %}{% endblock %}

--- a/kalite/distributed/templates/admin/login.html
+++ b/kalite/distributed/templates/admin/login.html
@@ -2,10 +2,6 @@
 {% load i18n admin_static %}
 {% load url from future %}
 
-{% block i18n_do_not_translate %}
-    {% block login_active %}active{% endblock login_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block bodyclass %}{% trans "login" %}{% endblock %}
 
 {% block nav-global %}{% endblock %}

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -135,6 +135,7 @@
         <script type="text/javascript" src="{% static 'js/khan-lite.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/distributed/distributed-server.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/jquery.qtip.min.js' %}"></script>
+        <script type="text/javascript" src="{% static 'js/distributed/navigation/views.js' %}"></script>
 
         {% endcompress %}
 

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -158,6 +158,8 @@
         $(function() {
           window.statusModel.fetch_data();
           window.toggleNavbarView = new ToggleNavbarView({model: statusModel, el: "#topnav"});
+          window.addEventListener("resize", collapsedNav);
+          window.addEventListener("pageshow", collapsedNav);
         });
         </script>
 

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -8,9 +8,9 @@
 {% get_current_language as lang_code %}
 <html lang="{{ lang_code }}">
     <head>
-        <!--[if lt IE 9]>
+        <!--[if lt IE 9]> 
               <script src="{% static "js/html5shiv.js" %}"></script>
-        <![endif]-->
+        <![endif] -->
 
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta name="wot-verification" content="075abe861486e6bb3ab9"/>
@@ -159,7 +159,8 @@
         });
         $(function() {
           window.statusModel.fetch_data();
-          window.userView = new UserView({model: statusModel, el: "#user-name"});
+          //window.userView = new UserView({model: statusModel, el: "#user-name"});
+          window.toggleNavbarView = new ToggleNavbarView({model: statusModel, el: "#topnav"});
           window.autoCompleteView = new AutoCompleteView();
           $("#topnav").prepend(window.autoCompleteView.$el);
         });
@@ -191,12 +192,13 @@
                           </div>    
                                                    
                       </div>
+
+
                       
 
                       <div class="collapse navbar-collapse top-nav" role="navigation" aria-label="Main menu">
+
                           <ul class="nav navbar-nav navbar-right nav-tabs" id="topnav" role="tablist">
-                            <!-- For all users -->
-                            {# Search box #}
                             <li>
                               <form class="navbar-form" action="{% url 'search' %}" method="get" id="search-box" role="search">
                                 {% comment %}translators: this will appear in the navigation bar. please try to keep it as short as possible.{% endcomment %}
@@ -206,112 +208,9 @@
                                 </div>
                               </form>
                             </li>
-                            <!-- For logged in admins -->
-                            {% if request.is_admin and not request.session.facility_user.facility %}
-                              {# Teach for admins => coachreports #}
-                              <li class="admin-nav {% block teach_active_admins %}{% endblock teach_active_admins %}">
-                                <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="teacher-only">
-                                  {% trans "Teach" %}
-                                </a>
-                              </li>
-                            {% endif %}
-
-                            {# Manage for admins => zone control panel #}
-                            {% if request.is_django_user %}
-                            <li class="admin-nav {% block manage_active_admins %}{% endblock manage_active_admins %}">
-                              <a href="{% url 'zone_redirect' %}" id="manage" class="">
-                                {% trans "Manage" %}
-                              </a>
-                            </li>
-                            {% endif %}
-                            <!-- End for logged in admins -->
-
-                            <!-- For logged in teachers -->
-                            {# Teach for teachers => coachreports #}
-                            <li class="teacher-nav display-none {% block teach_active_teachers %}{% endblock teach_active_teachers %}">
-                              <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="teacher-only">
-                                {% trans "Teach" %}
-                              </a>
-                            </li>
-
-                            {# Manage for teachers => facility management #}
-                            {% if request.session.facility_user.facility %}
-                              <li class="teacher-nav display-none {% block manage_active_teachers %}{% endblock manage_active_teachers %}">
-                                <a href="{% url 'facility_management' zone_id=None facility_id=request.session.facility_user.facility.id %}" id="manage" class="">
-                                  {% trans "Manage" %}
-                                </a>
-                              </li>
-                            {% endif %}
-                            <!-- End for logged in teachers -->
-
-                            <!-- Universal Learn tab -->
-                            {# Learn for all #}
-                            <li class="{% block learn_active %}{% endblock learn_active %}">
-                              <a href="{% url 'learn' %}" id="nav_learn" class="home-navlink">
-                                {% trans "Learn" %}
-                              </a>
-                            </li>
-
-                            <!-- For logged out users  -->
-                            {# Login #}
-                            <li class="guest-nav {% block login_active %}{% endblock login_active %}">
-                              <a href="#" class="not-logged-in-only" data-toggle="modal" data-target="#loginModal" title="{% trans 'Login' %}" id="nav_login">
-                                {% trans "Login" %}
-                              </a>
-                            </li>
-
-                            {% if not restricted %}
-                              <li class="guest-nav {% block signup_active %}{% endblock signup_active %}">
-                                <a href="{% url 'facility_user_signup' %}" id="nav_signup" class="not-logged-in-only" title="{% trans 'Register to start tracking your progress' %}">
-                                  {% trans "Sign Up" %}
-                                </a>
-                              </li>
-                            {% endif %}
-                            
-                            <hr class="nav-divider student-nav student-only">
-                            {% if request.is_admin or request.session.facility_user.facility %}
-                            <hr class="nav-divider admin-only">
-                            {% endif %}
-
-                            <!-- Farthest right nav is logged in user dropdown -->
-                            <li class="dropdown {% block help_active %}{% endblock help_active %}{% block progress_active %}{% endblock progress_active %}" id="user-name">
-                              <a href="#" class="logged-in-only dropdown-toggle" data-toggle="dropdown" id="user-name-a">
-                                  <span id="username">
-                                    <!-- Username injected here w/ js -->
-                                  </span>
-                                <span class="caret hidden-xs"></span>
-                              </a>
-
-                              <ul class="dropdown-menu" data-no-collapse="true" role="menu">
-                                <li class="student-only student-nav" role="presentation">
-                                  <span class="student-only student-nav" id="points">
-                                    <!-- Points injected here w/ js -->
-                                  </span>
-                                </li>
-                                <li role="presentation" class="divider student-only student-nav"></li>
-                                {# Student account management #}
-                                <li role="presentation" class="motivational-feature student-only student-nav">
-                                  <a role="menuitem" tabindex="-1" href="{% url 'account_management' %}" id="nav_progress" title="{% trans 'My Progress'%}" class="student-only">
-                                    {% trans "My Progress" %}
-                                  </a>
-                                </li>
-                                <!-- TODO-BLOCKER(jamalex): re-enable these links once non-playlist "my progress" works, and help link is meaningful again -->
-                                <!--
-                                <li role="presentation">
-                                  <a role="menuitem" tabindex="-1" href="{% url 'help' %}" id="nav_help">{% trans "Help" %}</a>
-                                </li> -->
-                                <li role="presentation" class="divider student-only student-nav"></li>
-                                <!-- Logout goes at the bottom! -->
-                                <li role="presentation" id="logout">
-                                  <a role="menuitem" tabindex="-1" id="nav_logout" class="logged-in-only" title="{% trans 'Logout'%}" href="#">
-                                    {% trans "Logout" %}
-                                  </a>
-                                </li>
-                              </ul>
-                            </li>
-
-                          </ul>
-                        </div>
+                           
+                        </ul>
+                      </div>
                   </div>
               </div>
           </div>

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -96,22 +96,6 @@
         $(function() {
             FastClick.attach(document.body);
         });
-
-         /* TODO(jtamiace): Backbonify this function and this page... when the time comes.
-            This function addresses Bootstrap's limitation of having a dropdown menu in an already collapsed menu*/
-          function collapsedNav(e) {
-            if ( $('body').innerWidth() <= 750 ) {
-                document.getElementById("user-name-a").removeAttribute("data-toggle");
-                document.getElementById("user-name").classList.add("open");
-              } 
-            if ( $('body').innerWidth() >= 751 ) {
-                document.getElementById("user-name-a").setAttribute("data-toggle", "dropdown");
-                document.getElementById("user-name").classList.remove("open");
-              }
-            };
-          window.addEventListener("resize", collapsedNav, false);
-          window.addEventListener("pageshow", collapsedNav, true);
-
         </script>
         <script type="text/javascript" src="{% static 'js/underscore-min.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/backbone/backbone.js' %}"></script>
@@ -135,7 +119,6 @@
         <script type="text/javascript" src="{% static 'js/khan-lite.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/distributed/distributed-server.js' %}"></script>
         <script type="text/javascript" src="{% static 'js/jquery.qtip.min.js' %}"></script>
-        <script type="text/javascript" src="{% static 'js/distributed/navigation/views.js' %}"></script>
 
         {% endcompress %}
 
@@ -205,25 +188,29 @@
                                   <img src="/data/{{ channel }}/images/horizontal-logo-small.png" alt="{{ channel_data.channel_name }} {% trans 'logo' %}">
                               </a>
                               <div class="pull-right visible-xs sitepoint" id="points-xs"></div>
-                          </div>                             
+                          </div>    
+                                                   
                       </div>
+                      
 
                       <div class="collapse navbar-collapse top-nav" role="navigation" aria-label="Main menu">
                           <ul class="nav navbar-nav navbar-right nav-tabs" id="topnav" role="tablist">
-
+                            <!-- For all users -->
+                            {# Search box #}
+                            <li>
+                              <form class="navbar-form" action="{% url 'search' %}" method="get" id="search-box" role="search">
+                                {% comment %}translators: this will appear in the navigation bar. please try to keep it as short as possible.{% endcomment %}
+                                <div class="input-group">
+                                  <input type="text" name="query" id="search" class="form-control" placeholder="{% trans 'Topic, video, exercise...' %}" aria-label="{% trans 'Search for' %}" />
+                                  <button id="search-button" class="btn btn-default" type="submit" aria-label="{% trans 'Submit' %}"><i class="glyphicon glyphicon-search" aria-hidden="true"></i></button>
+                                </div>
+                              </form>
+                            </li>
                             <!-- For logged in admins -->
-                            {% if request.is_admin and is_config_package_nalanda and not request.session.facility_user.facility %}
-                              {# Teach for admins => assigning playlists for Nalanda #}
-                              <li class="{% block teach_active_admins-nalanda %}{% endblock teach_active_admins-nalanda %}">
-                                <a href="{% url 'assign_playlists' %}" id="nav_coachreports" class="admin-only">
-                                  {% trans "Teach" %}
-                                </a>
-                              </li>
-                            {% endif %}
-                            {% if request.is_admin and not request.session.facility_user.facility and not is_config_package_nalanda %}
+                            {% if request.is_admin and not request.session.facility_user.facility %}
                               {# Teach for admins => coachreports #}
-                              <li class="{% block teach_active_admins %}{% endblock teach_active_admins %}">
-                                <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="admin-only">
+                              <li class="admin-nav {% block teach_active_admins %}{% endblock teach_active_admins %}">
+                                <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="teacher-only">
                                   {% trans "Teach" %}
                                 </a>
                               </li>
@@ -231,8 +218,8 @@
 
                             {# Manage for admins => zone control panel #}
                             {% if request.is_django_user %}
-                            <li class="{% block manage_active_admins %}{% endblock manage_active_admins %}">
-                              <a href="{% url 'zone_redirect' %}" id="manage" class="admin-only">
+                            <li class="admin-nav {% block manage_active_admins %}{% endblock manage_active_admins %}">
+                              <a href="{% url 'zone_redirect' %}" id="manage" class="">
                                 {% trans "Manage" %}
                               </a>
                             </li>
@@ -241,7 +228,7 @@
 
                             <!-- For logged in teachers -->
                             {# Teach for teachers => coachreports #}
-                            <li class="{% block teach_active_teachers %}{% endblock teach_active_teachers %}">
+                            <li class="teacher-nav display-none {% block teach_active_teachers %}{% endblock teach_active_teachers %}">
                               <a href="{% url 'tabular_view' %}" id="nav_coachreports" class="teacher-only">
                                 {% trans "Teach" %}
                               </a>
@@ -249,8 +236,8 @@
 
                             {# Manage for teachers => facility management #}
                             {% if request.session.facility_user.facility %}
-                              <li class="{% block manage_active_teachers %}{% endblock manage_active_teachers %}">
-                                <a href="{% url 'facility_management' zone_id=None facility_id=request.session.facility_user.facility.id %}" id="manage" class="teacher-only">
+                              <li class="teacher-nav display-none {% block manage_active_teachers %}{% endblock manage_active_teachers %}">
+                                <a href="{% url 'facility_management' zone_id=None facility_id=request.session.facility_user.facility.id %}" id="manage" class="">
                                   {% trans "Manage" %}
                                 </a>
                               </li>
@@ -267,27 +254,27 @@
 
                             <!-- For logged out users  -->
                             {# Login #}
-                            <li class="{% block login_active %}{% endblock login_active %}">
+                            <li class="guest-nav {% block login_active %}{% endblock login_active %}">
                               <a href="#" class="not-logged-in-only" data-toggle="modal" data-target="#loginModal" title="{% trans 'Login' %}" id="nav_login">
                                 {% trans "Login" %}
                               </a>
                             </li>
 
                             {% if not restricted %}
-                              <li class="{% block signup_active %}{% endblock signup_active %}">
+                              <li class="guest-nav {% block signup_active %}{% endblock signup_active %}">
                                 <a href="{% url 'facility_user_signup' %}" id="nav_signup" class="not-logged-in-only" title="{% trans 'Register to start tracking your progress' %}">
                                   {% trans "Sign Up" %}
                                 </a>
                               </li>
                             {% endif %}
                             
-                            <hr class="nav-divider student-only">
+                            <hr class="nav-divider student-nav student-only">
                             {% if request.is_admin or request.session.facility_user.facility %}
                             <hr class="nav-divider admin-only">
                             {% endif %}
 
                             <!-- Farthest right nav is logged in user dropdown -->
-                            <li class="dropdown {% block help_active %}{% endblock help_active %}{% block progress_active %}{% endblock progress_active %} " id="user-name">
+                            <li class="dropdown {% block help_active %}{% endblock help_active %}{% block progress_active %}{% endblock progress_active %}" id="user-name">
                               <a href="#" class="logged-in-only dropdown-toggle" data-toggle="dropdown" id="user-name-a">
                                   <span id="username">
                                     <!-- Username injected here w/ js -->
@@ -296,14 +283,14 @@
                               </a>
 
                               <ul class="dropdown-menu" data-no-collapse="true" role="menu">
-                                <li class="student-only" role="presentation">
-                                  <span class="student-only" id="points">
+                                <li class="student-only student-nav" role="presentation">
+                                  <span class="student-only student-nav" id="points">
                                     <!-- Points injected here w/ js -->
                                   </span>
                                 </li>
-                                <li role="presentation" class="divider student-only"></li>
+                                <li role="presentation" class="divider student-only student-nav"></li>
                                 {# Student account management #}
-                                <li role="presentation" class="motivational-feature student-only">
+                                <li role="presentation" class="motivational-feature student-only student-nav">
                                   <a role="menuitem" tabindex="-1" href="{% url 'account_management' %}" id="nav_progress" title="{% trans 'My Progress'%}" class="student-only">
                                     {% trans "My Progress" %}
                                   </a>
@@ -313,7 +300,7 @@
                                 <li role="presentation">
                                   <a role="menuitem" tabindex="-1" href="{% url 'help' %}" id="nav_help">{% trans "Help" %}</a>
                                 </li> -->
-                                <li role="presentation" class="divider student-only"></li>
+                                <li role="presentation" class="divider student-only student-nav"></li>
                                 <!-- Logout goes at the bottom! -->
                                 <li role="presentation" id="logout">
                                   <a role="menuitem" tabindex="-1" id="nav_logout" class="logged-in-only" title="{% trans 'Logout'%}" href="#">

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -51,9 +51,7 @@
             window.onerror=function(msg){
                 window.js_errors = window.js_errors || [];
                 window.js_errors.push(msg);
-            }
-            var onManagePage, onTeachPage, onLearnPage = false;
-            
+            }           
         </script>
 
         {% if request.in_context_localized %}

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -52,7 +52,7 @@
                 window.js_errors = window.js_errors || [];
                 window.js_errors.push(msg);
             }
-
+            var onManagePage, onTeachPage, onLearnPage = false;
             
         </script>
 

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -181,7 +181,7 @@
                           {# collapse entire menu #}
                           <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse" aria-hidden="true" id="navbar_toggle">
                               <span class="icon-bar"></span>
-                              <span class="icon-bar"></span>
+                              <span class="icon-bar"></span> 
                               <span class="icon-bar"></span>
                           </button>
                           <div class="navbar-brand">
@@ -191,29 +191,15 @@
                               <div class="pull-right visible-xs sitepoint" id="points-xs"></div>
                           </div>    
                                                    
+                      </div>             
+
+                      <div class="collapse navbar-collapse top-nav" id="nav" role="navigation" aria-label="Main menu">
+                          <ul class="nav navbar-nav navbar-right nav-tabs" id="topnav" role="tablist"></ul>
                       </div>
 
-
-                      
-
-                      <div class="collapse navbar-collapse top-nav" role="navigation" aria-label="Main menu">
-
-                          <ul class="nav navbar-nav navbar-right nav-tabs" id="topnav" role="tablist">
-                            <li>
-                              <form class="navbar-form" action="{% url 'search' %}" method="get" id="search-box" role="search">
-                                {% comment %}translators: this will appear in the navigation bar. please try to keep it as short as possible.{% endcomment %}
-                                <div class="input-group">
-                                  <input type="text" name="query" id="search" class="form-control" placeholder="{% trans 'Topic, video, exercise...' %}" aria-label="{% trans 'Search for' %}" />
-                                  <button id="search-button" class="btn btn-default" type="submit" aria-label="{% trans 'Submit' %}"><i class="glyphicon glyphicon-search" aria-hidden="true"></i></button>
-                                </div>
-                              </form>
-                            </li>
-                           
-                        </ul>
-                      </div>
-                  </div>
-              </div>
-          </div>
+                    </div>
+                </div>
+            </div>
           {# End Header / Navbar #}
 
             {# Body #}

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -159,10 +159,7 @@
         });
         $(function() {
           window.statusModel.fetch_data();
-          //window.userView = new UserView({model: statusModel, el: "#user-name"});
           window.toggleNavbarView = new ToggleNavbarView({model: statusModel, el: "#topnav"});
-          window.autoCompleteView = new AutoCompleteView();
-          $("#topnav").prepend(window.autoCompleteView.$el);
         });
         </script>
 
@@ -173,7 +170,7 @@
     <body class="{% block bodyclass %}{% endblock %}">
         <div id="wrapper">
 
-            {# Header & Navbar #}
+            {# Header / Navbar #}
             <div class="navbar kalite-navbar header-footer-bg" role="banner">
               <div class="container">
                   <div class="row">
@@ -193,7 +190,7 @@
                                                    
                       </div>             
 
-                      <div class="collapse navbar-collapse top-nav" id="nav" role="navigation" aria-label="Main menu">
+                      <div class="collapse navbar-collapse top-nav" role="navigation" aria-label="Main menu">
                           <ul class="nav navbar-nav navbar-right nav-tabs" id="topnav" role="tablist"></ul>
                       </div>
 

--- a/kalite/distributed/templates/distributed/base_teach.html
+++ b/kalite/distributed/templates/distributed/base_teach.html
@@ -11,6 +11,13 @@
 
 {% block headcss %}{{block.super}}{% endblock headcss %}
 
+<script>
+    $(function() {
+        window.toggleNavbarView.active_tab("#teach-tab");
+        //somehow call the associated li nav bar element on this page
+    });
+</script>
+
 {% block subnavbar %}
 
 <!-- Prevents nav bar from showing up for students/guests on learn tab -->

--- a/kalite/distributed/templates/distributed/base_teach.html
+++ b/kalite/distributed/templates/distributed/base_teach.html
@@ -4,19 +4,8 @@
 {% load i18n %}
 {% load my_filters %}
 
-{% block i18n_do_not_translate %}
-    {% block teach_active_teachers %}active{% endblock teach_active_teachers %}
-    {% block teach_active_admins %}active{% endblock teach_active_admins %}
-{% endblock i18n_do_not_translate %}
-
 {% block headcss %}{{block.super}}{% endblock headcss %}
 
-<script>
-    $(function() {
-        window.toggleNavbarView.active_tab("#teach-tab");
-        //somehow call the associated li nav bar element on this page
-    });
-</script>
 
 {% block subnavbar %}
 

--- a/kalite/distributed/templates/distributed/homepage.html
+++ b/kalite/distributed/templates/distributed/homepage.html
@@ -20,12 +20,14 @@
         if (window.parent.frames.length === 0) {
             window.location = "{% url 'load_test' %}";
         }
+
     </script>
     {% endif %}
 
     <script type="text/javascript">
      var ALL_PLAYLISTS_URL = "{% url 'api_dispatch_list' resource_name='playlist' %}";
      var VIEW_PLAYLIST_TEMPLATE_URL = "/playlists/view/%(playlist_id)s/";
+     var onTeachPage, onManagePage, onLearnPage = false;
     </script>
 
     <script>

--- a/kalite/distributed/templates/distributed/homepage.html
+++ b/kalite/distributed/templates/distributed/homepage.html
@@ -3,10 +3,6 @@
 {% load i18n %}
 {% load staticfiles %}
 
-{% block i18n_do_not_translate %}
-    {% block home_active %}active{% endblock home_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/distributed/homepage.css' %}">
 {% endblock headcss %}

--- a/kalite/distributed/templates/distributed/homepage.html
+++ b/kalite/distributed/templates/distributed/homepage.html
@@ -27,7 +27,6 @@
     <script type="text/javascript">
      var ALL_PLAYLISTS_URL = "{% url 'api_dispatch_list' resource_name='playlist' %}";
      var VIEW_PLAYLIST_TEMPLATE_URL = "/playlists/view/%(playlist_id)s/";
-     var onTeachPage, onManagePage, onLearnPage = false;
     </script>
 
     <script>

--- a/kalite/distributed/templates/distributed/learn.html
+++ b/kalite/distributed/templates/distributed/learn.html
@@ -79,7 +79,6 @@
         window.ALL_TOPICS_URL = "{% url 'topic_tree' channel='%(channel_name)s' %}";
 
         var onLearnPage = true; 
-        var onTeachPage, onManagePage = false;
     </script>
     
     {% if load_perseus_assets %}

--- a/kalite/distributed/templates/distributed/learn.html
+++ b/kalite/distributed/templates/distributed/learn.html
@@ -3,12 +3,6 @@
 
 {% block title %}{% trans "Learn" %}{% endblock title %}
 
-{% block i18n_do_not_translate %}
-    {% block learn_active %}active{% endblock learn_active %}
-    {% block learn_subnav_active %}active{% endblock learn_subnav_active %}
-    {% block teach_active_teachers %}{% endblock teach_active_teachers %}
-{% endblock i18n_do_not_translate %}
-
 {% block headcss %}{{ block.super }}
 
     <style id="exercise-inline-style"></style> <!-- Used by KA to dynamically add styling to the exercise -->

--- a/kalite/distributed/templates/distributed/learn.html
+++ b/kalite/distributed/templates/distributed/learn.html
@@ -70,9 +70,7 @@
         window.imageResourcesPath = "{% static 'pdfjs/web/images/' %}";
         window.cMapUrl = "{% static 'pdfjs/web/cmaps/' %}";
         window.flash_swf = "{% static "video-js/video-js.swf" %}";
-        window.ALL_TOPICS_URL = "{% url 'topic_tree' channel='%(channel_name)s' %}";
-
-        var onLearnPage = true; 
+        window.ALL_TOPICS_URL = "{% url 'topic_tree' channel='%(channel_name)s' %}"; 
     </script>
     
     {% if load_perseus_assets %}

--- a/kalite/distributed/templates/distributed/learn.html
+++ b/kalite/distributed/templates/distributed/learn.html
@@ -77,6 +77,9 @@
         window.cMapUrl = "{% static 'pdfjs/web/cmaps/' %}";
         window.flash_swf = "{% static "video-js/video-js.swf" %}";
         window.ALL_TOPICS_URL = "{% url 'topic_tree' channel='%(channel_name)s' %}";
+
+        var onLearnPage = true; 
+        var onTeachPage, onManagePage = false;
     </script>
     
     {% if load_perseus_assets %}

--- a/kalite/facility/api_resources.py
+++ b/kalite/facility/api_resources.py
@@ -158,7 +158,7 @@ class FacilityUserResource(ModelResource):
 
 
     def generate_status(self, request, **kwargs):
-        # Build a list of messages to pass to the user.
+        #Build a list of messages to pass to the user.
         #   Iterating over the messages removes them from the
         #   session storage, thus they only appear once.
 

--- a/kalite/facility/templates/facility/facility.html
+++ b/kalite/facility/templates/facility/facility.html
@@ -11,10 +11,6 @@
     {% trans "Facility" %}
 {% endblock title %}
 
-{% block i18n_do_not_translate %}
-    {% block facility_active %}active{% endblock facility_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block headcss %}
     <style>
         #map_canvas {

--- a/kalite/facility/templates/facility/facility_selection.html
+++ b/kalite/facility/templates/facility/facility_selection.html
@@ -24,8 +24,6 @@
 
 
 {% block content %}
-    {% block manage_nav %}{% endblock manage_nav %}
-    {% block facility_active %}active{% endblock facility_active %}
     {{ path_template }}
     <div id="facility_list_container">
         <section id="facility_list">

--- a/kalite/facility/templates/facility/facility_user.html
+++ b/kalite/facility/templates/facility/facility_user.html
@@ -3,11 +3,6 @@
 
 {% block title %}{% trans title %}{% endblock title %}
 
-{% block i18n_do_not_translate %}
-    {% block users_active %}active{% endblock %}
-    {% block signup_active %}active{% endblock signup_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block headcss %}{{ block.super }}
     <style>
         #id_group {

--- a/kalite/playlist/templates/playlist/assign_playlists.html
+++ b/kalite/playlist/templates/playlist/assign_playlists.html
@@ -3,14 +3,6 @@
 {% load i18n %}
 {% load staticfiles %}
 
-{% block i18n_do_not_translate %}
-  {% block home_active %}active{% endblock home_active %}
-  {% block playlist_active %}playlists-active active-tab active-nav{% endblock playlist_active %}
-  {% block teacher_active %}active{% endblock teacher_active %}
-  {% block assign_playlists_active %}active{% endblock assign_playlists_active %}
-  {% block teach_active_admins-nalanda %}active{% endblock teach_active_admins-nalanda %}
-{% endblock i18n_do_not_translate %}
-
 {% block headcss %}{{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static 'css/playlist/assign_playlists.css' %}">
 {% endblock headcss %}

--- a/kalite/student_testing/templates/student_testing/current_unit.html
+++ b/kalite/student_testing/templates/student_testing/current_unit.html
@@ -3,10 +3,6 @@
 {% load i18n %}
 {% load staticfiles %}
 
-{% block current_unit_active %}units-active active-tab active-nav{% endblock current_unit_active %}
-{% block teacher_active %}active{% endblock teacher_active %}
-{% block admin_active %}active{% endblock admin_active %}
-
 {% block title %}{% trans "Current Unit" %}{{ block.super }}{% endblock %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/student_testing/templates/student_testing/test_list.html
+++ b/kalite/student_testing/templates/student_testing/test_list.html
@@ -3,12 +3,6 @@
 {% load i18n %}
 {% load staticfiles %}
 
-{% block i18n_do_not_translate %}
-    {% block exams-active %}exams-active active-tab active-nav{% endblock exams-active %}
-    {% block teacher_active %}active{% endblock teacher_active %}
-    {% block admin_active %}active{% endblock admin_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block title %}{% trans "Tests" %}{{ block.super }}{% endblock %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/updates/templates/updates/base.html
+++ b/kalite/updates/templates/updates/base.html
@@ -10,6 +10,9 @@
     <script type="text/javascript">
         var GET_SERVER_INFO_URL = "{% url 'get_server_info' %}";
         var UPDATE_SOFTWARE_URL = "{% url 'start_update_kalite' %}"
+
+        var onManagePage = true; 
+        var onTeachPage, onLearnPage = false;
     </script>
     <script type="text/javascript" src="{% static 'js/updates/base.js' %}"></script>
 

--- a/kalite/updates/templates/updates/base.html
+++ b/kalite/updates/templates/updates/base.html
@@ -12,7 +12,6 @@
         var UPDATE_SOFTWARE_URL = "{% url 'start_update_kalite' %}"
 
         var onManagePage = true; 
-        //var onTeachPage, onLearnPage = false;
     </script>
     <script type="text/javascript" src="{% static 'js/updates/base.js' %}"></script>
 

--- a/kalite/updates/templates/updates/base.html
+++ b/kalite/updates/templates/updates/base.html
@@ -12,7 +12,7 @@
         var UPDATE_SOFTWARE_URL = "{% url 'start_update_kalite' %}"
 
         var onManagePage = true; 
-        var onTeachPage, onLearnPage = false;
+        //var onTeachPage, onLearnPage = false;
     </script>
     <script type="text/javascript" src="{% static 'js/updates/base.js' %}"></script>
 

--- a/kalite/updates/templates/updates/base.html
+++ b/kalite/updates/templates/updates/base.html
@@ -9,9 +9,7 @@
 {% block headjs %}{{ block.super }}
     <script type="text/javascript">
         var GET_SERVER_INFO_URL = "{% url 'get_server_info' %}";
-        var UPDATE_SOFTWARE_URL = "{% url 'start_update_kalite' %}"
-
-        var onManagePage = true; 
+        var UPDATE_SOFTWARE_URL = "{% url 'start_update_kalite' %}" 
     </script>
     <script type="text/javascript" src="{% static 'js/updates/base.js' %}"></script>
 

--- a/kalite/updates/templates/updates/update_languages.html
+++ b/kalite/updates/templates/updates/update_languages.html
@@ -3,12 +3,6 @@
 {% load staticfiles %}
 {% load compress %}
 
-{% block i18n_do_not_translate %}
-    {% block languages_active %}active active-tab active-nav{% endblock languages_active %}
-    {% block users_active %}active{% endblock users_active %}
-    {% block manage_active %}active{% endblock manage_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block title %}{% trans "Update Languages" %}{% endblock %}
 
 {% block headcss %}{{ block.super }}

--- a/kalite/updates/templates/updates/update_languages.html
+++ b/kalite/updates/templates/updates/update_languages.html
@@ -5,6 +5,10 @@
 
 {% block title %}{% trans "Update Languages" %}{% endblock %}
 
+{% block i18n_do_not_translate %}
+    {% block languages_active %}active{% endblock languages_active %}
+{% endblock i18n_do_not_translate %}
+
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/updates/update_languages.css' %}" />
 {% endblock headcss %}

--- a/kalite/updates/templates/updates/update_software.html
+++ b/kalite/updates/templates/updates/update_software.html
@@ -5,10 +5,6 @@
 
 {% block title %}{% trans "Update Software" %}{% endblock %}
 
-{% block i18n_do_not_translate %}
-    {% block facility_active %}active{% endblock facility_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/bootstrap.min.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'css/bootstrap-fileupload.min.css' %}" />

--- a/kalite/updates/templates/updates/update_videos.html
+++ b/kalite/updates/templates/updates/update_videos.html
@@ -5,6 +5,10 @@
 
 {% block title %}{% trans "Update Videos" %}{% endblock %}
 
+{% block i18n_do_not_translate %}    
+    {% block video_active %}active{% endblock video_active %}
+{% endblock i18n_do_not_translate %}
+
 {% block headcss %}{{ block.super }}
     <link rel="stylesheet" type="text/css" href="{% static 'css/jquery-ui/plugins/ui.dynatree.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'css/updates/update_videos.css' %}" />

--- a/kalite/updates/templates/updates/update_videos.html
+++ b/kalite/updates/templates/updates/update_videos.html
@@ -3,12 +3,6 @@
 {% load staticfiles %}
 {% load i18n_filters %}
 
-{% block i18n_do_not_translate %}
-    {% block users_active %}active{% endblock users_active %}
-    {% block manage_active %}active{% endblock manage_active %}
-    {% block video_active %}active{% endblock video_active %}
-{% endblock i18n_do_not_translate %}
-
 {% block title %}{% trans "Update Videos" %}{% endblock %}
 
 {% block headcss %}{{ block.super }}


### PR DESCRIPTION
Looks the same as the current one, so no screenshots necessary.

The view for the nav bar listens to the statusModel for they type of user (student, teacher, guest, etc.) and displays the appropriate tabs with appropriate activation according to which page the user is on. 
URL's are currently hardcoded.

Will be adding a few commits shortly for cleaning up the no-longer-needed django blocks on templates that used to activate the tabs, but just wanted the put this PR now since the code is functional.