### PR TITLE
Sidebar initial size fix

### DIFF
--- a/kalite/distributed/static/js/distributed/topics/views.js
+++ b/kalite/distributed/static/js/distributed/topics/views.js
@@ -318,7 +318,11 @@ window.TopicContainerInnerView = BaseView.extend({
             alwaysVisible: true
         });
 
-        $(window).resize();
+        // Ensure these are called once in order to get the right size initially.
+        _.defer( function() {
+            self.window_resize_callback();
+            self.window_scroll_callback();
+        });
 
         return this;
     },


### PR DESCRIPTION
Ensures the sidebar's size is calculated correctly even if the user doesn't resize or scroll the window.