### PR TITLE
Multi dbs

### DIFF
--- a/kalite/main/migrations/0037_auto__add_assessmentitem__add_index_attemptlog_user_exercise_id_contex.py
+++ b/kalite/main/migrations/0037_auto__add_assessmentitem__add_index_attemptlog_user_exercise_id_contex.py
@@ -1,25 +1,30 @@
 # -*- coding: utf-8 -*-
 from south.utils import datetime_utils as datetime
-from south.db import db
+from south.db import db, dbs
 from south.v2 import SchemaMigration
 from django.db import models
-
 
 class Migration(SchemaMigration):
 
     def forwards(self, orm):
         # Adding model 'AssessmentItem'
-        db.create_table(u'main_assessmentitem', (
+        dbs["topic_tools"].create_table(u'main_assessmentitem', (
             ('id', self.gf('django.db.models.fields.CharField')(max_length=50, primary_key=True)),
             ('item_data', self.gf('django.db.models.fields.TextField')()),
             ('author_names', self.gf('django.db.models.fields.CharField')(max_length=200)),
         ))
-        db.send_create_signal(u'main', ['AssessmentItem'])
+        dbs["topic_tools"].send_create_signal(u'main', ['AssessmentItem'])
+
+        # Adding index on 'AttemptLog', fields ['user', 'exercise_id', 'context_type']
+        db.create_index(u'main_attemptlog', ['user_id', 'exercise_id', 'context_type'])
+
 
     def backwards(self, orm):
+        # Removing index on 'AttemptLog', fields ['user', 'exercise_id', 'context_type']
+        db.delete_index(u'main_attemptlog', ['user_id', 'exercise_id', 'context_type'])
 
         # Deleting model 'AssessmentItem'
-        db.delete_table(u'main_assessmentitem')
+        dbs["topic_tools"].delete_table(u'main_assessmentitem')
 
 
     models = {

--- a/kalite/main/router.py
+++ b/kalite/main/router.py
@@ -1,0 +1,51 @@
+class TopicToolsRouter():
+    """
+    A router to control database operations for the following models in the main app:
+    * AssessmentItem
+
+    This is meant to be a "static" database -- used so this data exposes Django ORM methods, and can be conservatively
+    loaded into memory, but not modified by an end user. The only writes should be during the installation setup.
+
+    See: https://docs.djangoproject.com/en/1.5/topics/db/multi-db/#database-routers
+    """
+    MODELS = ("AssessmentItem", )
+
+    def db_for_read(self, model, **hints):
+        """
+        Send requests for specific Models to the topic_tools db.
+        """
+        self._the_db_or_none(model)
+
+    def db_for_write(self, model, **hints):
+        """
+        Send requests for specific Models to the topic_tools db.
+        """
+        self._the_db_or_none(model)
+
+    def _the_db_or_none(self, model):
+        """
+        Given a model, choose the right DB depending on its name. Returning None in this case will cause it to fall back
+        to the default router.
+        """
+        if model.__class__.__name__ in self.MODELS:
+            return "topic_tools"
+        else:
+            return None
+
+    def allow_relation(self, obj1, obj2, **hints):
+        """
+        Allow relations between the given models only.
+        """
+        if obj1.__class__.__name__ in self.MODELS and obj2.__class__.__name__ in self.MODELS:
+            return True
+        return None
+
+    def allow_syncdb(self, db, model):
+        """
+        Make sure the given models only appear in the topic_tools db.
+        """
+        if db == 'topic_tools':
+            return model.__class__.__name__ in self.MODELS
+        elif model.__class__.__name__ in self.MODELS:
+            return False  # Don't sync these models to any other DB
+        return None

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -193,6 +193,7 @@ if IS_SOURCE:
     
     # This is the legacy location kalite/database/data.sqlite
     DEFAULT_DATABASE_PATH = os.path.join(_data_path, "kalite", "database", "data.sqlite")
+    TT_DATABASE_PATH = os.path.join(_data_path, "kalite", "database", "topic_tools.sqlite")
 
     MEDIA_ROOT = os.path.join(_data_path, "kalite", "media")
     STATIC_ROOT = os.path.join(_data_path, "kalite", "static")
@@ -215,6 +216,12 @@ else:
         os.mkdir(DEFAULT_DATABASE_PATH)
     
     DEFAULT_DATABASE_PATH = os.path.join(DEFAULT_DATABASE_PATH, 'default.sqlite')
+
+    TT_DATABASE_PATH = os.path.join(USER_DATA_ROOT, "database",)
+    if not os.path.exists(TT_DATABASE_PATH):
+        os.mkdir(TT_DATABASE_PATH)
+
+    TT_DATABASE_PATH = os.path.join(TT_DATABASE_PATH, 'topic_tools.sqlite')
     
     # Stuff that can be served by the HTTP server is located the same place
     # for convenience and security
@@ -240,11 +247,18 @@ STATIC_ROOT = getattr(local_settings, "STATIC_ROOT", STATIC_ROOT)
 MEDIA_URL = getattr(local_settings, "MEDIA_URL", "/media/")
 STATIC_URL = getattr(local_settings, "STATIC_URL", "/static/")
 DEFAULT_DATABASE_PATH = getattr(local_settings, "DATABASE_PATH", DEFAULT_DATABASE_PATH)
-
+TT_DATABASE_PATH = getattr(local_settings, "TT_DATABASE_PATH", TT_DATABASE_PATH)
 DATABASES = getattr(local_settings, "DATABASES", {
     "default": {
         "ENGINE": getattr(local_settings, "DATABASE_TYPE", "django.db.backends.sqlite3"),
         "NAME": DEFAULT_DATABASE_PATH,
+        "OPTIONS": {
+            "timeout": 60,
+        },
+    },
+    "topic_tools": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": TT_DATABASE_PATH,
         "OPTIONS": {
             "timeout": 60,
         },

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -265,6 +265,8 @@ DATABASES = getattr(local_settings, "DATABASES", {
     }
 })
 
+DATABASE_ROUTERS = ["kalite.main.router.TopicToolsRouter", ]
+
 INTERNAL_IPS = getattr(local_settings, "INTERNAL_IPS", ("127.0.0.1",))
 ALLOWED_HOSTS = getattr(local_settings, "ALLOWED_HOSTS", ['*'])
 


### PR DESCRIPTION
I get the following error when I try to run the migrations:
```sh
Traceback (most recent call last):
  File "python-packages/django/core/management/base.py", line 224, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "python-packages/django/core/management/base.py", line 263, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/ka-lite/kalite/distributed/management/commands/setup.py", line 271, in handle
    call_command("migrate", merge=True, verbosity=options.get("verbosity"))
  File "python-packages/django/core/management/__init__.py", line 161, in call_command
    return klass.execute(*args, **defaults)
  File "python-packages/django/core/management/base.py", line 263, in execute
    output = self.handle(*args, **options)
  File "python-packages/south/management/commands/migrate.py", line 111, in handle
    ignore_ghosts = ignore_ghosts,
  File "python-packages/south/migration/__init__.py", line 220, in migrate_app
    success = migrator.migrate_many(target, workplan, database)
  File "python-packages/south/migration/migrators.py", line 254, in migrate_many
    result = migrator.__class__.migrate_many(migrator, target, migrations, database)
  File "python-packages/south/migration/migrators.py", line 329, in migrate_many
    result = self.migrate(migration, database)
  File "python-packages/south/migration/migrators.py", line 133, in migrate
    result = self.run(migration, database)
  File "python-packages/south/migration/migrators.py", line 114, in run
    return self.run_migration(migration, database)
  File "python-packages/south/migration/migrators.py", line 84, in run_migration
    migration_function()
  File "python-packages/south/migration/migrators.py", line 60, in <lambda>
    return (lambda: direction(orm))
  File "/home/vagrant/ka-lite/kalite/main/migrations/0037_auto__add_assessmentitem__add_index_attemptlog_user_exercise_i
d_contex.py", line 14, in forwards
    ('author_names', self.gf('django.db.models.fields.CharField')(max_length=200)),
  File "python-packages/south/db/generic.py", line 47, in _cache_clear
    return func(self, table, *args, **opts)
  File "python-packages/south/db/generic.py", line 361, in create_table
    "columns": ', '.join([col for col in columns if col]),
  File "python-packages/south/db/generic.py", line 282, in execute
    cursor.execute(sql, params)
  File "python-packages/django/db/backends/util.py", line 41, in execute
    return self.cursor.execute(sql, params)
  File "python-packages/django/db/backends/sqlite3/base.py", line 366, in execute
    six.reraise(utils.DatabaseError, utils.DatabaseError(*tuple(e.args)), sys.exc_info()[2])
  File "python-packages/django/db/backends/sqlite3/base.py", line 362, in execute
    return Database.Cursor.execute(self, query, params)
DatabaseError: table "main_assessmentitem" already exists
```

The table doesn't exist, as you can discover by trying to use it. But `syncdb` also doesn't create the table, since it expects south to.

```sh
Traceback (most recent call last):
  File "python-packages/django/core/management/base.py", line 224, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "python-packages/django/core/management/base.py", line 263, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/ka-lite/kalite/main/management/commands/init_assessment_items.py", line 18, in handle
    ai, _ = AssessmentItem.objects.get_or_create(id=k)
  File "python-packages/django/db/models/manager.py", line 146, in get_or_create
    return self.get_query_set().get_or_create(**kwargs)
  File "python-packages/django/db/models/query.py", line 470, in get_or_create
    return self.get(**lookup), False
  File "python-packages/django/db/models/query.py", line 382, in get
    num = len(clone)
  File "python-packages/django/db/models/query.py", line 90, in __len__
    self._result_cache = list(self.iterator())
  File "python-packages/django/db/models/query.py", line 301, in iterator
    for row in compiler.results_iter():
  File "python-packages/django/db/models/sql/compiler.py", line 775, in results_iter
    for rows in self.execute_sql(MULTI):
  File "python-packages/django/db/models/sql/compiler.py", line 840, in execute_sql
    cursor.execute(sql, params)
  File "python-packages/django/db/backends/util.py", line 41, in execute
    return self.cursor.execute(sql, params)
  File "python-packages/django/db/backends/sqlite3/base.py", line 366, in execute
    six.reraise(utils.DatabaseError, utils.DatabaseError(*tuple(e.args)), sys.exc_info()[2])
  File "python-packages/django/db/backends/sqlite3/base.py", line 362, in execute
    return Database.Cursor.execute(self, query, params)
DatabaseError: no such table: main_assessmentitem
```

Any thoughts on this?