### PR TITLE
Install guide fix

### DIFF
--- a/kalite/distributed/management/commands/initdconfig.py
+++ b/kalite/distributed/management/commands/initdconfig.py
@@ -6,8 +6,7 @@ import sys
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-script_template = """
-#! /bin/sh
+script_template = """#! /bin/sh
 
 # Author: Jamie Alexandre, 2012
 #

--- a/scripts/runatboot.sh
+++ b/scripts/runatboot.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 SCRIPT_DIR=`dirname "${BASH_SOURCE[0]}"`
-KALITE_DIR=$SCRIPT_DIR/../kalite
+BASE_DIR=$SCRIPT_DIR/..
 pyexec=`"$SCRIPT_DIR/python.sh"`
 
 UNAME=`uname`
 if [ "$UNAME" == "Darwin" ]; then
     F=/$HOME/Library/LaunchAgents/org.learningequality.kalite.plist
-    "$pyexec" "$KALITE_DIR/manage.py" initdconfig > "$F"
+    "$pyexec" "$BASE_DIR/bin/kalite" manage initdconfig > "$F"
     chmod 644 "$F"
 elif [ "$UNAME" == "Linux" ]; then
-    "$pyexec" "$KALITE_DIR/manage.py" initdconfig > /etc/init.d/kalite
+    "$pyexec" "$BASE_DIR/bin/kalite" manage initdconfig > /etc/init.d/kalite
     chmod 755 /etc/init.d/kalite
     update-rc.d kalite defaults
 fi

--- a/sphinx-docs/installguide/install_linux.rst
+++ b/sphinx-docs/installguide/install_linux.rst
@@ -15,12 +15,11 @@ Linux Installation Guide
 #. Enter *git clone https://github.com/learningequality/ka-lite.git* to download KA Lite.
 #. Switch into the newly downloaded ka-lite directory with *cd ka-lite*
 #. Run the install script with *./setup_unix.sh*.
-#. **IF** you want the server to start automatically in the background when your system boots and you did not choose this option during setup then:
-	* Setup the server (one time) to automatically run in the background
-	* Enter *sudo ./runatboot.sh* in the terminal from inside the ka-lite/scripts directory
-	* Use *sudo service kalite stop* to stop the server
-	* OR *sudo service kalite start* to start the server.
-#. **IF** the automatic background option was not chosen, start the server by running *kalite* in the ka-lite/bin directory.
+#. **IF** you want the server to start automatically in the background when your system boots:
+	* Enter *sudo ./runatboot.sh* in the terminal from inside the ka-lite/scripts directory. Note that if this step does not succeed, you will not be able to start or stop the server using the two commands described below!
+	* To start the server the for the first time, run *sudo service kalite start*. Subsequently the server should start automatically at boot.
+	* Use *sudo service kalite stop* or *sudo service kalite start* to stop and start the server at any other time.
+#. **IF** the automatic background option was not chosen or *sudo ./runatboot.sh* did not succeed, start and stop the server by running *kalite start* and *kalite stop* in the ka-lite/bin directory.
 #. KA Lite should be accessible from http://127.0.0.1:8008/ 
 	* Replace *127.0.0.1* with the computer's external IP address or domain name to access it from another computer.
 


### PR DESCRIPTION
Fixes #3654. In particular, `initdconfig` script template had what could be an error (the shebang was not the first character, but actually a newline character), `runatboot.sh` definitely had an error (could produce undesirable output, since it was using a deprecated command), and the documentation was amended to clarify the options.