### PR TITLE
Add option to only run behave tests

### DIFF
--- a/kalite/distributed/management/commands/test.py
+++ b/kalite/distributed/management/commands/test.py
@@ -1,0 +1,26 @@
+"""
+Override the built-in test command, in order to define custom options.
+In particular, we'd like to be able to run only behave tests.
+"""
+from optparse import make_option
+
+from django.core.management.commands.test import Command as TestCommand
+
+class Command(TestCommand):
+    """
+    We just want to add an extra option to the builtin test command.
+    This class doesn't handle the extra logic of that option; instead it's in our test runner.
+    See kalite.testing.testrunner
+    """
+    option_list = TestCommand.option_list + (
+        make_option(
+            '--bdd-only',
+            action='store_true',
+            dest='bdd_only',
+            default=False,
+            help="Only run the behave "
+        ),
+    )
+
+    def handle(self, *test_labels, **options):
+        super(Command, self).handle(*test_labels, **options)

--- a/kalite/distributed/management/commands/test.py
+++ b/kalite/distributed/management/commands/test.py
@@ -21,6 +21,3 @@ class Command(TestCommand):
             help="Only run the behave "
         ),
     )
-
-    def handle(self, *test_labels, **options):
-        super(Command, self).handle(*test_labels, **options)

--- a/kalite/distributed/management/commands/test.py
+++ b/kalite/distributed/management/commands/test.py
@@ -4,7 +4,10 @@ In particular, we'd like to be able to run only behave tests.
 """
 from optparse import make_option
 
-from django.core.management.commands.test import Command as TestCommand
+try:
+    from south.management.commands.test import Command as TestCommand
+except ImportError:
+    from django.core.management.commands.test import Command as TestCommand
 
 class Command(TestCommand):
     """

--- a/kalite/testing/testrunner.py
+++ b/kalite/testing/testrunner.py
@@ -104,6 +104,10 @@ class KALiteTestRunner(DjangoTestSuiteRunner):
         #   start the server.  They may have multiple servers open at once.
         if not os.environ.get('DJANGO_LIVE_TEST_SERVER_ADDRESS',""):
             os.environ['DJANGO_LIVE_TEST_SERVER_ADDRESS'] = "localhost:9000-9999"
+
+        self._bdd_only = kwargs["bdd_only"]  # Extra options from our custom test management command are passed into
+                                             # the constructor, but not the build_suite function where we need them.
+
         return super(KALiteTestRunner, self).__init__(*args, **kwargs)
 
     def run_tests(self, test_labels=None, extra_tests=None, **kwargs):
@@ -170,4 +174,7 @@ class KALiteTestRunner(DjangoTestSuiteRunner):
                 # build a test suite for this directory
                 extra_tests.append(self.make_bdd_test_suite(features_dir))
 
-        return super(KALiteTestRunner, self).build_suite(test_labels, extra_tests, **kwargs)
+        suite = super(KALiteTestRunner, self).build_suite(test_labels, extra_tests, **kwargs)
+        if self._bdd_only:
+            suite._tests = filter(lambda x: type(x).__name__ == "DjangoBehaveTestCase", suite._tests)
+        return suite


### PR DESCRIPTION
@66eli77 @rtibbles 
Overrides the builtin `test` management command, just to add an extra option, `--bdd-only` that only runs behave tests. You can specify an app label to only run tests in that app, so 

```sh
bin/kalite manage test distributed --bdd-only
```

only runs the behave tests in the distributed app. Depends on the implementation details of `DjangoTestSuiteRunner`, and so may not be safe on different versions of Django unfortunately.