### PR TITLE
Load either the json or yml version file.

### DIFF
--- a/kalite/distributed/management/commands/compileymltojson.py
+++ b/kalite/distributed/management/commands/compileymltojson.py
@@ -1,0 +1,41 @@
+from __future__ import print_function
+
+import json
+import os
+import yaml
+
+from django.core.management.base import NoArgsCommand
+
+BLACKLISTED_YAML_FILES = [
+    ".travis.yml",
+    "circle.yml"
+]
+
+
+class Command(NoArgsCommand):
+
+    def handle_noargs(*args, **kwargs):
+        # avoid using django.conf.settings, for that sweet fast startup
+        # time
+        project_root = os.environ.get("KALITE_DIR")
+        for root, _, files in os.walk(project_root):
+            for f in files:
+                full_name = os.path.join(root, f)
+                if (full_name.endswith(".yml") and
+                    "node_modules" not in root and
+                    f not in BLACKLISTED_YAML_FILES):
+                    print(full_name)
+                    yml_to_json(full_name)
+
+
+def yml_to_json(filename):
+    """Convert a .yml file into a json file and save it to the same
+    directory.
+    """
+    jsonfilename = "{0}.json".format(*os.path.splitext(filename))
+
+    with open(filename, "r") as f:
+        contents = yaml.load(f)
+
+    with open(jsonfilename, "w") as f:
+        json.dump(contents, f)

--- a/kalite/shared/utils.py
+++ b/kalite/shared/utils.py
@@ -1,0 +1,28 @@
+import os
+
+def open_json_or_yml(file_name):
+    """Try to load either the JSON or YAML version of a file.
+
+    If DEBUG is True, try to load the file with a yml prefix. If
+    DEBUG = False, try to load the json version first.
+
+    Args:
+        file_name: The name of the file to be loaded.
+
+    Returns:
+        A dictionary structure that reflects the yaml structure.
+
+    """
+
+    try:
+        import json
+        # ensure that it has the json extension
+        json_file = "{0}.json".format(*os.path.splitext(file_name))
+        with open(json_file, "r") as f:
+            return json.load(f)
+    except IOError:
+        import yaml
+        # ensure that it has the yml extension
+        yml_file = "{0}.yml".format(*os.path.splitext(file_name))
+        with open(yml_file, "r") as f:
+            return yaml.load(f)

--- a/kalite/version.py
+++ b/kalite/version.py
@@ -1,30 +1,13 @@
 import os
 
+from kalite.shared.utils import open_json_or_yml
+
 # THIS IS USED BY settings.py.  NEVER import settings.py here; hard-codes only!
 MAJOR_VERSION = "0"
 MINOR_VERSION = "14"
 PATCH_VERSION = "dev3"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
-
-
-def load_yaml(file_name):
-    """Creates a dictionary from an yaml file.
-
-    Args:
-        file_name: The name of the file to be loaded.
-
-    Returns:
-        A dictionary structure that reflects the yaml structure.
-    """
-
-    # Has to be imported here as version.py is a dependency of setup.py which
-    # may be run before dependencies are installed
-    import yaml
-
-    with open(file_name, "r") as f:
-        return yaml.load(f)
-
 
 def VERSION_INFO():
     """
@@ -43,4 +26,4 @@ def VERSION_INFO():
     # this file. Importing it on top will lead to circular imports.
     from django.conf import settings
 
-    return load_yaml(os.path.join(settings.CONTENT_DATA_PATH, "version.yml"))
+    return open_json_or_yml(os.path.join(settings.CONTENT_DATA_PATH, "version.yml"))


### PR DESCRIPTION
Fixes #3562. Summary of `open_json_or_yml` algorithm:

Attempt to load a json version of the file first, by changing the file extension to `json`. If it's not present, load the `yml` version by changing the extension to `yml`.

~~todo: a management command that "compiles" all the yaml files into json.~~

You can compile all relevant yml files into json by running `kalite manage compileymltojson`. For now it just compiles `version.yml`.