### PR TITLE
For inclusion: add scandir dependency.

### DIFF
--- a/kalite/contentload/tests/unpack_assessment_zip.py
+++ b/kalite/contentload/tests/unpack_assessment_zip.py
@@ -2,6 +2,7 @@ import StringIO
 import json
 import os
 import requests
+import scandir
 import tempfile
 import zipfile
 from mock import patch, MagicMock, mock_open
@@ -27,7 +28,7 @@ class UnpackAssessmentZipCommandTests(KALiteTestCase):
         _, self.zipfile_path = tempfile.mkstemp()
         with open(self.zipfile_path, "w") as f:
             zf = zipfile.ZipFile(f, "w")
-            for dirpath, _, filenames in os.walk(os.path.join(os.path.dirname(__file__), "fixtures")):
+            for dirpath, _, filenames in scandir.walk(os.path.join(os.path.dirname(__file__), "fixtures")):
                 # this toplevel for loop should only do one loop, but
                 # it's in a for loop nonetheless since it's more idiomatic
                 for filename in filenames:
@@ -99,7 +100,7 @@ class UnpackAssessmentZipUtilityFunctionTests(KALiteTestCase):
         _, self.zipfile_path = tempfile.mkstemp()
         with open(self.zipfile_path, "w") as f:
             zf = zipfile.ZipFile(f, "w")
-            for dirpath, _, filenames in os.walk(os.path.join(os.path.dirname(__file__), "fixtures")):
+            for dirpath, _, filenames in scandir.walk(os.path.join(os.path.dirname(__file__), "fixtures")):
                 # this toplevel for loop should only do one loop, but
                 # it's in a for loop nonetheless since it's more idiomatic
                 for filename in filenames:

--- a/kalite/i18n/management/commands/i18nize_templates.py
+++ b/kalite/i18n/management/commands/i18nize_templates.py
@@ -1,6 +1,10 @@
 import logging
 import os
+import scandir
 import subprocess
+
+from django.conf import settings
+
 
 from django.conf import settings; logging = settings.LOG
 from django.core.management.base import AppCommand
@@ -15,7 +19,7 @@ def i18nize_parser(parse_dir, extensions, parse_file, ignores):
     files with the extensions specified.
     """
     filenames_to_process = []
-    for dirpath, dirnames, filenames in os.walk(parse_dir):
+    for dirpath, dirnames, filenames in scandir.walk(parse_dir):
         logging.info("==> Looking for template file/s at %s" % dirpath)
         for filename in filenames:
             full_filename = os.path.join(dirpath, filename)

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -20,19 +20,19 @@ Each node in the topic tree comes with lots of metadata, including:
 * kind (Topic, Exercise, Video)
 and more.
 """
+import copy
+import json
 import os
 import re
-import json
-import copy
+import scandir
 
 from django.conf import settings; logging = settings.LOG
 from django.contrib import messages
 from django.utils.translation import gettext as _
-
-from fle_utils.general import softload_json, json_ascii_decoder
+from fle_utils.general import json_ascii_decoder, softload_json
 from kalite import i18n
-
 from kalite.main import models as main_models
+
 
 TOPICS_FILEPATHS = {
     settings.CHANNEL: os.path.join(settings.CHANNEL_DATA_PATH, "topics.json")
@@ -255,7 +255,7 @@ def get_content_cache(force=False, annotate=False, language=settings.LANGUAGE_CO
         subtitle_langs = {}
 
         if os.path.exists(i18n.get_srt_path()):
-            for (dirpath, dirnames, filenames) in os.walk(i18n.get_srt_path()):
+            for (dirpath, dirnames, filenames) in scandir.walk(i18n.get_srt_path()):
                 # Only both looking at files that are inside a 'subtitles' directory
                 if dirpath.split("/")[-1] == "subtitles":
                     lc = dirpath.split("/")[-2]
@@ -370,9 +370,9 @@ def generate_node_cache(topictree=None, language=settings.LANGUAGE_CODE):
     if not topictree:
         topictree = get_topic_tree(language=language)
     node_cache = {}
-    
+
     node_cache["Topic"] = dict([(node.get("id"), node) for node in topictree])
-    
+
     node_cache["Exercise"] = get_exercise_cache(language=language)
     node_cache["Content"] = get_content_cache(language=language)
 

--- a/python-packages/fle_utils/build/management/commands/generate_blacklist.py
+++ b/python-packages/fle_utils/build/management/commands/generate_blacklist.py
@@ -1,11 +1,10 @@
 import fnmatch
 import os
-import sys
-import warnings
-from datetime import datetime
-from threading import Thread
-from time import sleep, time
+import scandir
 from optparse import make_option
+
+from django.conf import settings
+
 
 from django.conf import settings; logging = settings.LOG
 from django.core.management.base import BaseCommand, CommandError
@@ -35,7 +34,7 @@ def get_app_subdirectory_paths(subdir):
 
 def get_paths_matching_pattern(pattern, starting_directory=KA_LITE_PATH):
     paths = []
-    for root, dirs, files in os.walk(KA_LITE_PATH):
+    for root, dirs, files in scandir.walk(KA_LITE_PATH):
         # root = make_path_relative(root)
         paths += [os.path.join(root, d) for d in dirs if fnmatch.fnmatch(d, pattern)]
         paths += [os.path.join(root, f) for f in files if fnmatch.fnmatch(f, pattern)]
@@ -44,7 +43,7 @@ def get_paths_matching_pattern(pattern, starting_directory=KA_LITE_PATH):
 
 def get_paths_ending_with(substring, starting_directory=KA_LITE_PATH):
     paths = []
-    for root, dirs, files in os.walk(KA_LITE_PATH):
+    for root, dirs, files in scandir.walk(KA_LITE_PATH):
         # root = make_path_relative(root)
         paths += [os.path.join(root, d) for d in dirs if os.path.join(root, d).endswith(substring)]
         paths += [os.path.join(root, f) for f in files if os.path.join(root, f).endswith(substring)]

--- a/python-packages/fle_utils/testing/code_testing.py
+++ b/python-packages/fle_utils/testing/code_testing.py
@@ -1,8 +1,11 @@
 import copy
-import glob
-import importlib
 import os
 import re
+import importlib
+import scandir
+
+from django.conf import settings
+
 
 from django.conf import settings; logging = settings.LOG
 from django.utils import unittest
@@ -10,7 +13,7 @@ from django.utils import unittest
 
 def get_module_files(module_dirpath, file_filter_fn):
     source_files = []
-    for root, dirs, files in os.walk(module_dirpath):  # Recurse over all files
+    for root, dirs, files in scandir.walk(module_dirpath):  # Recurse over all files
         source_files += [os.path.join(root, f) for f in files if file_filter_fn(f)]  # Filter py files
     return source_files
 
@@ -219,4 +222,3 @@ class FLECodeTest(unittest.TestCase):
     #         "\n\t".join(self.our_app_dependencies[app]),
     #     ) for app in bad_reversals if bad_reversals[app]])
     #     self.assertFalse(any([app for app, bi in bad_reversals.iteritems() if bi]), "Found unreported app dependencies in URL reversals:\n%s" % bad_reversals_text)
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ django-js-reverse==0.5.0
 ply==3.4
 # used by django-js-reverse
 slimit==0.8.1
+scandir==1.0

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import absolute_import, print_function, unicode_literals
+
+import logging
 import os
 import re
-import logging
-import pkg_resources
+import scandir
 import shutil
 import sys
-
 from distutils import log
-from setuptools import setup, find_packages
-from setuptools.command.install_scripts import install_scripts
 
 import kalite
+import pkg_resources
+from setuptools import find_packages, setup
+from setuptools.command.install_scripts import install_scripts
+
 
 # Path of setup.py, used to resolve path of requirements.txt file
 where_am_i = os.path.dirname(os.path.realpath(__file__))
@@ -122,7 +122,7 @@ def gen_data_files(*dirs):
     results = []
 
     for src_dir in dirs:
-        for root, dirs, files in os.walk(src_dir):
+        for root, dirs, files in scandir.walk(src_dir):
             results.append((root, map(lambda f: os.path.join(root, f), files)))
     return results
 
@@ -208,37 +208,37 @@ class my_install_scripts(install_scripts):
 # If it's a static build, we invoke pip to bundle dependencies in python-packages
 # This would be the case for commands "bdist" and "sdist"
 if STATIC_BUILD:
-    
+
     manifest_content = file(os.path.join(where_am_i, 'MANIFEST.in.dist'), 'r').read()
     manifest_content += "\n" + "recursive-include dist-packages *"
     file(os.path.join(where_am_i, 'MANIFEST.in'), "w").write(manifest_content)
-    
+
     sys.stderr.write(
         "This is a static build... invoking pip to put static dependencies in "
         "dist-packages/\n"
     )
-    
+
     STATIC_DIST_PACKAGES_DOWNLOAD_CACHE = os.path.join(where_am_i, 'dist-packages-downloads')
     STATIC_DIST_PACKAGES_TEMP = os.path.join(where_am_i, 'dist-packages-temp')
-    
+
     # Create directory where dynamically created dependencies are put
     if not os.path.exists(STATIC_DIST_PACKAGES_DOWNLOAD_CACHE):
         os.mkdir(STATIC_DIST_PACKAGES_DOWNLOAD_CACHE)
-    
+
     # Should remove the temporary directory always
     if os.path.exists(STATIC_DIST_PACKAGES_TEMP):
         print("Removing previous temporary sources for pip {}".format(STATIC_DIST_PACKAGES_TEMP))
         shutil.rmtree(STATIC_DIST_PACKAGES_TEMP)
-    
+
     # Install from pip
-    
+
     # Code modified from this example:
     # http://threebean.org/blog/2011/06/06/installing-from-pip-inside-python-or-a-simple-pip-api/
     import pip.commands.install
-    
+
     # Ensure we get output from pip
     enable_log_to_stdout('pip.commands.install')
-    
+
     def install_distributions(distributions):
         command = pip.commands.install.InstallCommand()
         opts, ___ = command.parser.parse_args([])
@@ -253,17 +253,17 @@ if STATIC_BUILD:
         command.run(opts, distributions)
         # requirement_set.source_dir = STATIC_DIST_PACKAGES_TEMP
         # requirement_set.install(opts)
-    
+
     # Install requirements into dist-packages
     if DIST_BUILDING_COMMAND:
         install_distributions(STATIC_REQUIREMENTS)
-    
+
     # Empty the requirements.txt file
 
 
 # It's not a build command with --static or it's not a build command at all
 else:
-    
+
     # If the dist-packages directory is non-empty
     if os.listdir(STATIC_DIST_PACKAGES):
         # If we are building something or running from the source
@@ -282,10 +282,10 @@ else:
             # everything in the requirements.txt file
             DIST_REQUIREMENTS = []
             DIST_NAME = 'ka-lite-static'
-            
+
             if "ka-lite" in get_installed_packages():
                 raise RuntimeError("Already installed ka-lite so cannot install ka-lite-static")
-    
+
     # No dist-packages/ and not building, so must be installing the dynamic
     # version
     elif not DIST_BUILDING_COMMAND:
@@ -297,7 +297,7 @@ else:
         manifest_content = file(os.path.join(where_am_i, 'MANIFEST.in.dist'), 'r').read()
         manifest_content += "\n" + "recursive-include dist-packages *"
         file(os.path.join(where_am_i, 'MANIFEST.in'), "w").write(manifest_content)
-    
+
 
 # All files from dist-packages are always included
 data_files += map(


### PR DESCRIPTION
scandir claims to be faster than os.walk. I have not tested this claim
myself, but I trust reddit.

Oh, and it's also part of python 3.5. Surely we can't say no to that??

PR created for discussion.