### PR TITLE
Fixes redirect for modal login.

### DIFF
--- a/kalite/distributed/features/login.feature
+++ b/kalite/distributed/features/login.feature
@@ -40,4 +40,4 @@ Feature: Logging into KA Lite
         and I enter my username correctly
         and I enter my password correctly
         and I click the login button
-        then the page should reload
+        then the login button should disappear

--- a/kalite/distributed/features/steps/login.py
+++ b/kalite/distributed/features/steps/login.py
@@ -64,7 +64,7 @@ def impl(context):
 def impl(context):
     login_button = find_css_class_with_wait(context, "login-btn")
     # Grab an element reference from the current page. Used to test a page reload later.
-    context.wait_elem = context.browser.find_element_by_tag_name("body")
+    context.wait_elem = context.browser.find_element_by_id("nav_login")
     login_button.click()
 
 @then('a tooltip should appear on the username box only')
@@ -83,7 +83,7 @@ def impl(context):
 def impl(context):
     assert check_single_popover(context, "password")
 
-@then('the page should reload')
+@then('the login button should disappear')
 def impl(context):
     assert WebDriverWait(context.browser, PAGE_RELOAD_TIMEOUT).until(
         EC.staleness_of(context.wait_elem)

--- a/kalite/distributed/settings.py
+++ b/kalite/distributed/settings.py
@@ -36,8 +36,8 @@ def USER_FACING_PORT():
 #  we migrate to a newer version of Django.  Older versions require these
 #  to be set if using the login_required decorator.
 # TODO(benjaoming): Use reverse_lazy for this sort of stuff
-LOGIN_URL = "/securesync/login/"
-LOGOUT_URL = "/securesync/logout/"
+LOGIN_URL = "?login=true"
+LOGOUT_URL = "/securesync/api/user/logout/"
 
 INSTALLED_APPS = (
     "django.contrib.messages",

--- a/kalite/distributed/settings.py
+++ b/kalite/distributed/settings.py
@@ -36,7 +36,7 @@ def USER_FACING_PORT():
 #  we migrate to a newer version of Django.  Older versions require these
 #  to be set if using the login_required decorator.
 # TODO(benjaoming): Use reverse_lazy for this sort of stuff
-LOGIN_URL = "?login=true"
+LOGIN_URL = "/?login=true"
 LOGOUT_URL = "/securesync/api/user/logout/"
 
 INSTALLED_APPS = (

--- a/kalite/distributed/static/js/distributed/distributed-server.js
+++ b/kalite/distributed/static/js/distributed/distributed-server.js
@@ -145,15 +145,15 @@ var StatusModel = Backbone.Model.extend({
 
     handle_login_logout_success: function(data, status, response, callback) {
         if (data.redirect) {
-            window.location = data.redirect;
+            response.redirect = data.redirect;
+        }
+        this.fetch_data();
+        if (callback) {
+            callback(response);
         } else {
-            // TODO (rtibbles) Reinstate the code below once
-            // the front end app responds better to statusModel changes
-            window.location.reload();
-            // self.load_status();
-            // if (callback) {
-            //     callback(response);
-            // }
+            if (data.redirect) {
+                window.location = data.redirect;
+            }
         }
     },
 

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -315,10 +315,8 @@ window.UserView = BaseView.extend({
             var options = {};
             var next = getParamValue("next");
             var login = getParamValue("login");
-            if (login || this.login_start_open) {
+            if (login) {
                 options.start_open = true;
-
-                delete this.login_start_open;
             }
             if (next) {
                 options.next = next;

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -13,18 +13,22 @@ window.LoginModalView = BaseView.extend({
 
     render: function() {
         this.$el.html(this.template());
+        // If we don't want for render to complete, often, the containing element for the login is missing
         _.defer(this.addLoginView);
     },
 
     addLoginView: function() {
         if (this.loginView) {
+            // If loginView already exists rerender and set this.next on it so it has URL redirect info
             this.loginView.render();
             this.loginView.next = this.next;
         } else {
+            // Otherwise create a new login view, and close the model when the login successfully completes
             this.loginView = new LoginView({model: this.model, el: "#login-container", next: this.next});
             this.listenTo(this.loginView, "login_success", this.close_modal);
         }
         if (this.start_open) {
+            // If the start_open option is flagged, show the modal straight away.
             this.show_modal();
         }
     },
@@ -312,19 +316,32 @@ window.UserView = BaseView.extend({
                 this.totalPointViewXs = new TotalPointView({model: this.model, el: "#points-xs"});
             }
         } else {
+            // User is not logged in, so initialize the login modal
             var options = {};
+            /* 
+            *  Check the GET params to see if there is a 'next'
+            *  This means that someone has tried to access an unauthorized page, but we want them to
+            *  login before accessing this page
+            */
             var next = getParamValue("next");
+            // Check the GET params to see if a 'login' flag has been set
+            // If this is the case, the modal should start open
             var login = getParamValue("login");
             if (login) {
+                // Set an option for the modal to start open
                 options.start_open = true;
             }
             if (next) {
+                // Set the option for the URL redirect after login success
                 options.next = next;
             }
             if (this.loginModalView) {
+                // If there is already a loginModalView for some reason, just set the above options on it
+                // and rerender
                 this.loginModalView.set_options(options);
                 this.loginModalView.render();
             } else {
+                // Otherwise just start the modal view with these options, but add in the statusModel with it
                 options.model = this.model;
                 this.loginModalView = new LoginModalView(options);
             }

--- a/kalite/distributed/views.py
+++ b/kalite/distributed/views.py
@@ -232,7 +232,7 @@ def handler_403(request, *args, **kwargs):
         return JsonResponseMessageError(_("You must be logged in with an account authorized to view this page (API)."), status=403)
     else:
         messages.error(request, mark_safe(_("You must be logged in with an account authorized to view this page.")))
-        return HttpResponseRedirect(set_query_params(reverse("homepage"), {"next": request.get_full_path()}))
+        return HttpResponseRedirect(set_query_params(reverse("homepage"), {"next": request.get_full_path(), "login": True}))
 
 @render_to("distributed/perseus.html")
 def perseus(request):


### PR DESCRIPTION
Fixes #3538

Summary of changes:
* Use next GET param to determine redirect location.
* If no next GET param, then use any supplied redirect from the API response
* Alter the 403 handler view to add login=true to the GET param to trigger the modal.
