### PR TITLE
Moves MathJax loading outside of DjangoCompressed block to prevent 404 errors when loading files that are not present and MathJax does not need

### DIFF
--- a/kalite/distributed/templates/distributed/learn.html
+++ b/kalite/distributed/templates/distributed/learn.html
@@ -75,11 +75,10 @@
     
     {% if load_perseus_assets %}
         <!-- START PERSEUS STUFF -->
-        <script type="text/x-mathjax-config" src="{% static "perseus/ke/third_party/MathJax/2.1/config/KAthJax-8f02f65cba7722b3e529bd9dfa6ac25d.js" %}"></script>
+        <script src="{% static "perseus/ke/third_party/MathJax/2.1/MathJax.js" True %}?config={% static "perseus/ke/third_party/MathJax/2.1/config/KAthJax-8f02f65cba7722b3e529bd9dfa6ac25d" %}"></script>
         {% compress js file perseusjs_1 %}
         <script src="{% static "perseus/lib/es5-shim.js" %}"></script>
         <script src="{% static "perseus/lib/react-with-addons.js" %}"></script>
-        <script src="{% static "perseus/ke/third_party/MathJax/2.1/MathJax.js" %}"></script>
         <script src="{% static "perseus/lib/katex/katex.js" %}"></script>
         <script src="{% static "perseus/lib/mathquill/mathquill-basic.js" %}"></script>
         <script src="{% static "perseus/lib/kas.js" %}"></script>


### PR DESCRIPTION
Fixes #3755

Summary of changes:
See title.