### PR TITLE
Js reverse 404 fix

### DIFF
--- a/kalite/distributed/management/commands/kaserve.py
+++ b/kalite/distributed/management/commands/kaserve.py
@@ -139,8 +139,6 @@ class Command(BaseCommand):
         logging.info("Copying static media...")
         call_command("collectstatic", interactive=False, verbosity=0)
 
-        call_command("collectstatic_js_reverse", interactive=False)
-
         if options['startuplock']:
             os.unlink(options['startuplock'])
         

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -63,11 +63,7 @@
             <script type="text/javascript" src="//cdn.crowdin.com/jipt/jipt.js"></script>
         {% endif %}
 
-        {% if debug %}
         <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
-        {% else %}
-        <script src="{% static 'django_js_reverse/js/reverse.js' %}"></script>
-        {% endif %}
 
         {% compress js file basejs %}
 

--- a/kalite/distributed/urls.py
+++ b/kalite/distributed/urls.py
@@ -116,6 +116,13 @@ if settings.DEBUG:
     urlpatterns += patterns('',
         url(r'^jsreverse/$', 'django_js_reverse.views.urls_js', name='js_reverse'),
     )
+else:
+    from django.views.decorators.cache import cache_page
+    from django_js_reverse.views import urls_js
+    urlpatterns += patterns('',
+        url(r'^jsreverse/$', cache_page(60 * 60 * 24 * 365)(urls_js), name='js_reverse'),  # Cached for 1 year
+    )
+
 
 handler403 = __package__ + '.views.handler_403'
 handler404 = __package__ + '.views.handler_404'


### PR DESCRIPTION
Use a cached view instead of a static file if `DEBUG=False`. Fixes #3744.