### PR TITLE
don't load the settings during function eval.

### DIFF
--- a/kalite/i18n/__init__.py
+++ b/kalite/i18n/__init__.py
@@ -163,12 +163,16 @@ def get_id2oklang_map(video_id, force=False):
         return ID2OKLANG_MAP
 
 
-def get_youtube_id(video_id, lang_code=settings.LANGUAGE_CODE):
+def get_youtube_id(video_id, lang_code=None):
     """Given a video ID, return the youtube ID for the given language.
     If lang_code is None, return the base / default youtube_id for the given video_id.
     If youtube_id for the given lang_code is not found, function returns None.
     Accepts lang_code in ietf format
     """
+
+    if not lang_code:
+        lang_code = settings.LANGUAGE_CODE
+
     if not lang_code or lang_code == "en":  # looking for the base/default youtube_id
         return video_id
     return get_dubbed_video_map(lcode_to_ietf(lang_code)).get(video_id)
@@ -405,9 +409,9 @@ def select_best_available_language(target_code, available_codes=None):
 
     # Scrub the input
     target_code = lcode_to_django_lang(target_code)
-    
+
     store_cache = False
-    
+
     # Only use cache when available_codes is trivial, i.e. not a set of
     # language codes
     if available_codes is None:
@@ -418,7 +422,7 @@ def select_best_available_language(target_code, available_codes=None):
             available_codes = get_installed_language_packs().keys()
 
     # logging.debug("choosing best language among %s" % (available_codes))
-    
+
     # Make it a tuple so we can hash it
     available_codes = [lcode_to_django_lang(lc) for lc in available_codes if lc]
 
@@ -438,11 +442,11 @@ def select_best_available_language(target_code, available_codes=None):
 
     # if actual_code != target_code:
     #    logging.debug("Requested code %s, got code %s" % (target_code, actual_code))
-    
+
     # Store in cache when available_codes are not set
     if store_cache:
         __select_best_available_language[target_code] = actual_code
-    
+
     return actual_code
 
 

--- a/kalite/playlist/models.py
+++ b/kalite/playlist/models.py
@@ -136,12 +136,15 @@ class VanillaPlaylist:
 
         return playlists
 
-    def get_playlist_entries(playlist, entry_type, language=settings.LANGUAGE_CODE):
+    def get_playlist_entries(playlist, entry_type, language=None):
         """
         Given a VanillaPlaylist, inspect its 'entries' attribute and return a list
         containing corresponding nodes for each item from the topic tree.
         entry_type should be "Exercise" or "Video".
         """
+        if not language:
+            language = settings.LANGUAGE_CODE
+
         unprepared = filter(lambda e: e["entity_kind"]==entry_type, playlist.entries)
         prepared = []
         for entry in unprepared:

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -52,7 +52,14 @@ if not os.path.exists(settings.CHANNEL_DATA_PATH):
 # Globals that can be filled
 TOPICS          = None
 CACHE_VARS.append("TOPICS")
-def get_topic_tree(force=False, annotate=False, channel=settings.CHANNEL, language=settings.LANGUAGE_CODE, parent=None):
+def get_topic_tree(force=False, annotate=False, channel=None, language=None, parent=None):
+
+    if not channel:
+        channel = settings.CHANNEL
+
+    if not language:
+        language = settings.LANGUAGE_CODE
+
     global TOPICS, TOPICS_FILEPATHS
     if not TOPICS:
         TOPICS = {}
@@ -134,7 +141,11 @@ def get_topic_tree(force=False, annotate=False, channel=settings.CHANNEL, langua
 
 NODE_CACHE = None
 CACHE_VARS.append("NODE_CACHE")
-def get_node_cache(node_type=None, force=False, language=settings.LANGUAGE_CODE):
+def get_node_cache(node_type=None, force=False, language=None):
+
+    if not language:
+        language = settings.LANGUAGE_CODE
+
     global NODE_CACHE
     if NODE_CACHE is None or force:
         NODE_CACHE = generate_node_cache()
@@ -145,7 +156,11 @@ def get_node_cache(node_type=None, force=False, language=settings.LANGUAGE_CODE)
 
 EXERCISES          = None
 CACHE_VARS.append("EXERCISES")
-def get_exercise_cache(force=False, language=settings.LANGUAGE_CODE):
+def get_exercise_cache(force=False, language=None):
+
+    if not language:
+        language = settings.LANGUAGE_CODE
+
     global EXERCISES, EXERCISES_FILEPATH
     if EXERCISES is None:
         EXERCISES = {}
@@ -214,7 +229,11 @@ def get_exercise_cache(force=False, language=settings.LANGUAGE_CODE):
 
 LEAFED_TOPICS = None
 CACHE_VARS.append("LEAFED_TOPICS")
-def get_leafed_topics(force=False, language=settings.LANGUAGE_CODE):
+def get_leafed_topics(force=False, language=None):
+
+    if not language:
+        language = settings.LANGUAGE_CODE
+
     global LEAFED_TOPICS
     if LEAFED_TOPICS is None or force:
         topic_cache = get_node_cache(language=language)["Topic"]
@@ -230,7 +249,11 @@ def create_thumbnail_url(thumbnail):
 
 CONTENT          = None
 CACHE_VARS.append("CONTENT")
-def get_content_cache(force=False, annotate=False, language=settings.LANGUAGE_CODE):
+def get_content_cache(force=False, annotate=False, language=None):
+
+    if not language:
+        language = settings.LANGUAGE_CODE
+
     global CONTENT, CONTENT_FILEPATH
 
     if CONTENT is None:
@@ -364,17 +387,20 @@ def generate_slug_to_video_id_map(node_cache=None):
     return slug2id_map
 
 
-def generate_node_cache(topictree=None, language=settings.LANGUAGE_CODE):
+def generate_node_cache(topictree=None, language=None):
     """
     Given the KA Lite topic tree, generate a dictionary of all Topic, Exercise, and Content nodes.
     """
 
+    if not language:
+        language = settings.LANGUAGE_CODE
+
     if not topictree:
         topictree = get_topic_tree(language=language)
     node_cache = {}
-    
+
     node_cache["Topic"] = dict([(node.get("id"), node) for node in topictree])
-    
+
     node_cache["Exercise"] = get_exercise_cache(language=language)
     node_cache["Content"] = get_content_cache(language=language)
 

--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -235,11 +235,15 @@ def delete_language_pack(request):
     return JsonResponse({"success": _("Successfully deleted language pack for %(lang_name)s.") % {"lang_name": get_language_name(lang_code)}})
 
 
-def annotate_topic_tree(node, level=0, statusdict=None, remote_sizes=None, lang_code=settings.LANGUAGE_CODE):
+def annotate_topic_tree(node, level=0, statusdict=None, remote_sizes=None, lang_code=None):
     # Not needed when on an api request (since translation.activate is already called),
     #   but just to do things right / in an encapsulated way...
     # Though to be honest, this isn't quite right; we should be DE-activating translation
     #   at the end.  But with so many function exit-points... just a nightmare.
+
+    if not lang_code:
+        lang_code = settings.LANGUAGE_CODE
+
     if level == 0:
         translation.activate(lang_code)
 

--- a/python-packages/fle_utils/internet/webcache.py
+++ b/python-packages/fle_utils/internet/webcache.py
@@ -54,13 +54,20 @@ def calc_last_modified(request, *args, **kwargs):
     return last_modified
 
 
-def backend_cache_page(handler, cache_time=settings.CACHE_TIME, cache_name=settings.CACHE_NAME):
+def backend_cache_page(handler, cache_time=None, cache_name=None):
     """
     Applies all logic for getting a page to cache in our backend,
     and never in the browser, so we can control things from Django/Python.
 
     This function does this all with the settings we want, specified in settings.
     """
+
+    if not cache_time:
+        cache_time = settings.CACHE_TIME
+
+    if not cache_name:
+        cache_name = settings.CACHE_NAME
+
     if caching_is_enabled():
         @condition(last_modified_func=partial(calc_last_modified, cache_name=cache_name))
         @cache_control(no_cache=True)  # must appear before @cache_page

--- a/python-packages/securesync/engine/models.py
+++ b/python-packages/securesync/engine/models.py
@@ -448,7 +448,11 @@ class DeferredSignSyncedModel(SyncedModel):
     Synced model that defers signing until it's time to sync. This helps with CPU efficency because
     we don't need to recalculate the model signature every time the model is updated and saved.
     """
-    def save(self, sign=settings.CENTRAL_SERVER, *args, **kwargs):
+    def save(self, sign=None, *args, **kwargs):
+
+        if not sign:
+            sign = settings.CENTRAL_SERVER
+
         super(DeferredSignSyncedModel, self).save(*args, sign=sign, **kwargs)
 
     class Meta:  # needed to clear out the app_name property from SyncedClass.Meta
@@ -461,12 +465,16 @@ class DeferredCountSyncedModel(DeferredSignSyncedModel):
     Defer incrementing counters until syncing. This helps with IO efficiency because we don't need to
     update the counter_position on our device's metadata model everytime this model is saved.
     """
-    def save(self, increment_counters=settings.CENTRAL_SERVER, *args, **kwargs):
+    def save(self, increment_counters=None, *args, **kwargs):
         """
         Note that increment_counters will set counters to None,
         and that if the object must be created, counter will be incremented
         and temporarily set, to create the object ID.
         """
+
+        if not increment_counters:
+            increment_counters = settings.CENTRAL_SERVER
+
         super(DeferredCountSyncedModel, self).save(*args, increment_counters=increment_counters, **kwargs)
 
     def set_id(self):


### PR DESCRIPTION
This causes a circular import where a settings module imports this
module at the toplevel. Doing that import forces django to load the
LazySettings attributes, which causes an import of all settings modules,
which causes this module to get loaded, which forces django to load the
LazySettings attributes...

Loading settings at actual function call avoids this circular import.