### PR TITLE
Searchbar fixes

### DIFF
--- a/kalite/distributed/hbtemplates/search/search-item.handlebars
+++ b/kalite/distributed/hbtemplates/search/search-item.handlebars
@@ -1,1 +1,5 @@
-<span class='autocomplete {{#unless available }}un{{/unless}}available'><span class = 'dropdown-icon icon-{{ kind }}'>&nbsp;</span><span>{{ title }}</span></span>&nbsp;
+<span class='autocomplete {{#unless available }}un{{/unless}}available'>
+    <span class = 'dropdown-icon icon-{{ kind }}'>&nbsp;</span>
+    <span>{{ title }}</span>
+    <span>({{ kind }})</span>
+</span>&nbsp;

--- a/kalite/distributed/static/css/distributed/search_autocomplete.css
+++ b/kalite/distributed/static/css/distributed/search_autocomplete.css
@@ -29,7 +29,9 @@
 .navbar-collapse a.ui-corner-all.ui-state-focus span.autocomplete.icon-Document.available {
     color: white;
 }
-.navbar-collapse .ui-menu .ui-menu-item a{
+.navbar-collapse .ui-menu .ui-menu-item a,
+.navbar-collapse .ui-menu .ui-menu-item a.ui-state-focus {
+    margin: -1px 0 0 0;
     outline: 0;
     padding-top: 10px;
     padding-bottom: 0;
@@ -37,6 +39,7 @@
     border: 0px;
     padding-left: 16px;
 }
+
 .navbar-collapse .ui-menu .ui-menu-item span {
     font-weight: 300;
     font-size: 0.95em;

--- a/kalite/distributed/static/css/distributed/search_autocomplete.css
+++ b/kalite/distributed/static/css/distributed/search_autocomplete.css
@@ -33,11 +33,17 @@
 .navbar-collapse .ui-menu .ui-menu-item a.ui-state-focus {
     margin: -1px 0 0 0;
     outline: 0;
-    padding-top: 10px;
-    padding-bottom: 0;
     border-radius: 6px;
     border: 0px;
-    padding-left: 16px;
+    padding-left: 0.5em;
+    overflow: hidden;
+}
+
+/* ensure these elements have the same height */
+.navbar-collapse .ui-menu .ui-menu-item a,
+.navbar-collapse .ui-menu .ui-menu-item a.ui-state-focus,
+.navbar-collapse .ui-menu .ui-menu-item .dropdown-icon {
+    height: 2em;
 }
 
 .navbar-collapse .ui-menu .ui-menu-item span {
@@ -46,12 +52,17 @@
     padding-right: 0;
 }
 
+/* inner spans */
+.navbar-collapse .ui-menu .ui-menu-item span > span {
+    text-transform: none;
+}
+
 .navbar-collapse .ui-menu .ui-menu-item .dropdown-icon {
     font-weight: 300;
     font-size: 1em;
     padding-right: 16px;
     float: left;
-    height: 30px;
+    padding-top: 0.3em;
 }
 
 .navbar-collapse .available {

--- a/kalite/distributed/static/js/distributed/search/views.js
+++ b/kalite/distributed/static/js/distributed/search/views.js
@@ -116,6 +116,14 @@ window.AutoCompleteView = BaseView.extend({
             return compvalue;
         });
 
+        // Then sort again by availability!
+        ids_filtered.sort(function(id1, id2) {
+            var node1 = self._nodes[id1];
+            var node2 = self._nodes[id2];
+            var compvalue = node1.available ? (node2.available ? 0 : 1) : (node2.available ? -1 : 0);
+            return -1 * compvalue;  // Reverse the order; it's apparently reversed again in display.
+        });
+
         // From the filtered titles, produce labels (html) and values (for doing stuff)
         var results = [];
 

--- a/kalite/distributed/static/js/distributed/search/views.js
+++ b/kalite/distributed/static/js/distributed/search/views.js
@@ -131,7 +131,8 @@ window.AutoCompleteView = BaseView.extend({
             var label = this.item_template(node);
             results.push({
                 label: label,
-                value: ids_filtered[i]
+                value: node.title,
+                data_value: ids_filtered[i]
             });
         }
 
@@ -140,7 +141,7 @@ window.AutoCompleteView = BaseView.extend({
 
     select_item: function( event, ui ) {
         // When they click a specific item, just go there (if we recognize it)
-        var id = ui.item.value;
+        var id = ui.item.data_value;
         if (this._nodes && id in this._nodes && this._nodes[id]) {
             if ("channel_router" in window) {
                 window.channel_router.navigate(this._nodes[id].path, {trigger: true});

--- a/kalite/distributed/static/js/distributed/search/views.js
+++ b/kalite/distributed/static/js/distributed/search/views.js
@@ -117,12 +117,20 @@ window.AutoCompleteView = BaseView.extend({
         });
 
         // Then sort again by availability!
-        ids_filtered.sort(function(id1, id2) {
-            var node1 = self._nodes[id1];
-            var node2 = self._nodes[id2];
+        // Use the original ordering to make Array.prototype.sort stable
+        ids_with_ind = _.map(ids_filtered, function(id, index) {
+            return { "id": id,  "index": index };
+        });
+        ids_with_ind.sort(function(el1, el2) {
+            var node1 = self._nodes[el1.id];
+            var node2 = self._nodes[el2.id];
             var compvalue = node1.available ? (node2.available ? 0 : 1) : (node2.available ? -1 : 0);
+            if (compvalue === 0) {
+                compvalue = el1.index < el2.index ? 1 : -1;
+            }
             return -1 * compvalue;  // Reverse the order; it's apparently reversed again in display.
         });
+        ids_filtered = _.map(ids_with_ind, function(el) { return el.id; });
 
         // From the filtered titles, produce labels (html) and values (for doing stuff)
         var results = [];


### PR DESCRIPTION
Fixes #3578. I couldn't figure out what happened to the `0.13.x` styling, so I just tried my own. Perhaps the only contentious thing here is that search result elements have a fixed height; overflow is hidden, instead of increasing the result item's height.

Also fixes #3349 and #3345.

Screenshot:
![ss](https://cloud.githubusercontent.com/assets/8888020/7893285/0954b42c-0611-11e5-95ed-eb0badbc0e87.png)
