### PR TITLE
Disable wheels (because of pip 7.0)

### DIFF
--- a/kalite/version.py
+++ b/kalite/version.py
@@ -5,7 +5,7 @@ from kalite.shared.utils import open_json_or_yml
 # THIS IS USED BY settings.py.  NEVER import settings.py here; hard-codes only!
 MAJOR_VERSION = "0"
 MINOR_VERSION = "14"
-PATCH_VERSION = "dev10"
+PATCH_VERSION = "dev11"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 # Wheel issue with data files.
 # https://bitbucket.org/pypa/wheel/issue/92/bdist_wheel-makes-absolute-data_files
-[bdist_wheel]
-universal = 1
+# [bdist_wheel]
+# universal = 1
 
 [metadata]
 description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,16 @@ from setuptools.command.install_scripts import install_scripts
 
 import kalite
 
+# Since pip 7.0.1, bdist_wheel has started to be called automatically when
+# the sdist was being installed. Let's not have that.
+# By raising an exception,
+
+if 'bdist_wheel' in sys.argv:
+    raise RuntimeError(
+        "Harmless: Because of a bug in Wheel, we do not support bdist_wheel. "
+        "See: https://bitbucket.org/pypa/wheel/issue/92/bdist_wheel-makes-absolute-data_files"
+    )
+
 # Path of setup.py, used to resolve path of requirements.txt file
 where_am_i = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
Apparently with the latest version of pip, instead of calling "setup.py install", it tries "setup.py bdist_wheel" first, which will create a broken .whl package. By raising an exception, pip falls back to "setup.py install".