### PR TITLE
Consolidate ports

### DIFF
--- a/kalite/distributed/settings.py
+++ b/kalite/distributed/settings.py
@@ -131,7 +131,9 @@ POINTS_PER_VIDEO = getattr(local_settings, 'POINTS_PER_VIDEO', 750)
 # Ports & Accessibility
 ########################
 
-PRODUCTION_PORT = getattr(local_settings, "PRODUCTION_PORT", 8008)
+PRODUCTION_PORT = getattr(local_settings, "PRODUCTION_PORT", None)
+if not PRODUCTION_PORT:
+    PRODUCTION_PORT = os.environ.get("KALITE_LISTEN_PORT", 8008)
 
 #proxy port is used by nginx and is used by Raspberry Pi optimizations
 PROXY_PORT = getattr(local_settings, "PROXY_PORT", None)

--- a/kalite/django_cherrypy_wsgiserver/cherrypyserver.py
+++ b/kalite/django_cherrypy_wsgiserver/cherrypyserver.py
@@ -129,7 +129,7 @@ def stop_server(pidfile):
 
 
 def run_cherrypy_server(host="127.0.0.1", port=None, threads=None, daemonize=False, pidfile=None, autoreload=False, startuplock=None):
-    port = port or getattr(settings, "CHERRYPY_PORT", 8008)
+    port = port or getattr(settings, "PRODUCTION_PORT", 8008)
     threads = threads or getattr(settings, "CHERRYPY_THREAD_COUNT", 18)
 
     if daemonize:

--- a/kalite/django_cherrypy_wsgiserver/cherrypyserver.py
+++ b/kalite/django_cherrypy_wsgiserver/cherrypyserver.py
@@ -144,9 +144,9 @@ def run_cherrypy_server(host="127.0.0.1", port=None, threads=None, daemonize=Fal
         from django.utils.daemonize import become_daemon
         become_daemon()
 
-        fp = open(pidfile, 'w')
-        fp.write("%d\n" % os.getpid())
-        fp.close()
+        with open(pidfile, 'w') as f:
+            f.write("%d\n" % os.getpid())
+            f.write(port)
 
     cherrypy.config.update({
         'server.socket_host': host,

--- a/kalite/django_cherrypy_wsgiserver/management/commands/runcherrypyserver.py
+++ b/kalite/django_cherrypy_wsgiserver/management/commands/runcherrypyserver.py
@@ -50,7 +50,7 @@ Examples:
 
 CPWSGI_OPTIONS = {
     'host': '127.0.0.1', # changed from localhost to avoid ip6 problem -clm
-    'port': getattr(settings, "CHERRYPY_PORT", 8008),   # changed from 8088 to 8000 to follow django devserver default
+    'port': getattr(settings, "PRODUCTION_PORT", 8008),   # changed from 8088 to 8000 to follow django devserver default
     'threads': getattr(settings, "CHERRPY_THREAD_COUNT", 50),
     'daemonize': False,
     'pidfile': None,

--- a/kalite/django_cherrypy_wsgiserver/settings.py
+++ b/kalite/django_cherrypy_wsgiserver/settings.py
@@ -13,5 +13,4 @@ DEBUG = getattr(local_settings, "DEBUG", False)
 
 # 18 threads seems a sweet spot
 CHERRYPY_THREAD_COUNT = getattr(local_settings, "CHERRYPY_THREAD_COUNT", 18)
-CHERRPY_PORT = getattr(local_settings, "CHERRYPY_PORT", 8008)
 

--- a/kalite/settings/__init__.py
+++ b/kalite/settings/__init__.py
@@ -30,11 +30,6 @@ from .base import *
 
 import_installed_app_settings(INSTALLED_APPS, globals())
 
-# TODO(benjaoming): Why on earth is there both a PRODUCTION_PORT and a CHERRYPY_PORT !?
-# Mesa confused!
-# TODO(benjaoming): Furthermore, this is dependent on kalite.distributed.settings
-# so there's no way that kalite.distributed was ever decoupled from kalite
-CHERRYPY_PORT = getattr(local_settings, "CHERRYPY_PORT", PRODUCTION_PORT)
 TEST_RUNNER = KALITE_TEST_RUNNER
 
 ########################
@@ -62,7 +57,6 @@ if package_selected("RPi"):
     PRODUCTION_PORT = getattr(local_settings, "PRODUCTION_PORT", 7007)
     PROXY_PORT = getattr(local_settings, "PROXY_PORT", 8008)
     assert PRODUCTION_PORT != PROXY_PORT, "PRODUCTION_PORT and PROXY_PORT must not be the same"
-    CHERRYPY_PORT = PRODUCTION_PORT  # re-do above override AGAIN.
     #SYNCING_THROTTLE_WAIT_TIME = getattr(local_settings, "SYNCING_THROTTLE_WAIT_TIME", 1.0)
     #SYNCING_MAX_RECORDS_PER_REQUEST = getattr(local_settings, "SYNCING_MAX_RECORDS_PER_REQUEST", 10)
 

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -6,13 +6,13 @@ Supported by Foundation for Learning Equality
 www.learningequality.org
 
 Usage:
-  kalite start [options] [--port=<arg>] [--skip-job-scheduler] [DJANGO_OPTIONS ...]
-  kalite stop [options] [DJANGO_OPTIONS ...]
-  kalite restart [options] [--skip-job-scheduler] [DJANGO_OPTIONS ...]
-  kalite status [job-scheduler] [options]
-  kalite shell [options] [DJANGO_OPTIONS ...]
-  kalite test [options] [DJANGO_OPTIONS ...]
-  kalite manage COMMAND [options] [DJANGO_OPTIONS ...]
+  kalite [options] [--skip-job-scheduler] start [DJANGO_OPTIONS ...]
+  kalite [options] stop [DJANGO_OPTIONS ...]
+  kalite [options] [--skip-job-scheduler] restart [DJANGO_OPTIONS ...]
+  kalite [job-scheduler] status [options]
+  kalite [options] shell [DJANGO_OPTIONS ...]
+  kalite [options] test [DJANGO_OPTIONS ...]
+  kalite [options] manage COMMAND [DJANGO_OPTIONS ...]
   kalite -h | --help
   kalite --version
 

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -625,7 +625,7 @@ def profile_memory():
     atexit.register(handle_exit)
 
 if __name__ == "__main__":
-    arguments = docopt(__doc__, version=str(VERSION))
+    arguments = docopt(__doc__, version=str(VERSION), options_first=True)
 
     if arguments['start']:
         if arguments["--port"]:

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -611,6 +611,8 @@ if __name__ == "__main__":
     arguments = docopt(__doc__, version=str(VERSION))
 
     if arguments['start']:
+        if arguments["--port"]:
+            os.environ["KALITE_LISTEN_PORT"] = arguments["--port"]
         start(
             debug=arguments['--debug'],
             skip_job_scheduler=arguments['--skip-job-scheduler'],

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -6,7 +6,7 @@ Supported by Foundation for Learning Equality
 www.learningequality.org
 
 Usage:
-  kalite start [options] [--skip-job-scheduler] [DJANGO_OPTIONS ...]
+  kalite start [options] [--port=<arg>] [--skip-job-scheduler] [DJANGO_OPTIONS ...]
   kalite stop [options] [DJANGO_OPTIONS ...]
   kalite restart [options] [--skip-job-scheduler] [DJANGO_OPTIONS ...]
   kalite status [job-scheduler] [options]
@@ -24,6 +24,7 @@ Options:
   --debug               Output debug messages (for development)
   --skip-job-scheduler  For `kalite start`: Skips running the job scheduler
                         (useful for dev)
+  --port=<arg>          A port number the server will listen on.
   DJANGO_OPTIONS        All options are passed on to the django manage command.
                         Notice that all django options must be place *last* and
                         should not be mixed with other options.
@@ -373,14 +374,6 @@ def start(debug=False, args=[], skip_job_scheduler=False):
     # TODO: What does not the production=true actually do and how can we
     # control the log level and which log files to write to
 
-    # Deal with command-line options that affect the django settings module
-    for i, arg in enumerate(args):
-        match = re.search(r"port=(?P<port>\d+)", arg)
-        if match:
-            os.environ["KALITE_LISTEN_PORT"] = match.group("port")
-            del args[i]
-            break
-
     if os.path.exists(STARTUP_LOCK):
         try:
             pid = int(open(STARTUP_LOCK).read())
@@ -615,7 +608,7 @@ def profile_memory():
     atexit.register(handle_exit)
 
 if __name__ == "__main__":
-    arguments = docopt(__doc__, version=str(VERSION), options_first=True)
+    arguments = docopt(__doc__, version=str(VERSION))
 
     if arguments['start']:
         start(


### PR DESCRIPTION
Changes:
* Now there's only PRODUCTION_PORT and PROXY_PORT; redundant setting CHERRYPY_PORT was removed.
* `kalite start` now takes an argument of the form `port=[[some number]]`, sets the environment variable `KALITE_LISTEN_PORT` from that value. Ex: `kalite start port=38008`.
* PRODUCTION_PORT will be set using this preference order:
  *  First from `local_settings.py`, then from `os.environ["KALITE_LISTEN_PORT"]`, and then defaults to 8008.

Fixes #3749.