### PR TITLE
Git install migrate

### DIFF
--- a/kalite/distributed/management/commands/gitmigrate.py
+++ b/kalite/distributed/management/commands/gitmigrate.py
@@ -1,0 +1,47 @@
+import os
+import shutil
+
+from distutils.dir_util import copy_tree
+
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings; logging = settings.LOG
+
+from optparse import make_option
+
+
+class Command(BaseCommand):
+    """
+    This command takes an argument for the path to a git based installation of KA Lite.
+    It then copies the database file from there to the current location of KA Lite (if the two are different).
+    """
+    option_list = BaseCommand.option_list + (
+        make_option(
+            '--path',
+            action='store',
+            dest='path',
+            default=None,
+            help="Git Install Path"
+        ),
+    )
+
+    def handle(self, *args, **options):
+        try:
+            path = options.get("path") or args[0]
+        except IndexError:
+            path = None
+
+        if not path:
+            # This is necessary, as simply specifying "" means you are trying to migrate something onto itself
+            raise CommandError("Must specify a path to migrate the Git installed version of KA Lite from")
+
+        if not os.path.exists(os.path.join(path, "kalite", "database", "data.sqlite")):
+            raise CommandError("No database file found to migrate")
+        else:
+            shutil.copy2(os.path.join(path, "kalite", "database", "data.sqlite"), os.path.join(os.environ.get("KALITE_DIR"), "kalite", "database", "data.sqlite"))
+            logging.info("Database file successfully copied")
+
+        if not os.path.exists(os.path.join(path, "content")):
+            raise CommandError("No content folder find to migrate")
+        else:
+            output = copy_tree(os.path.join(path, "content"), os.path.join(os.environ.get("KALITE_DIR"), "content"), update=True)
+            logging.info("Copied {files} files from the previous content folder".format(files=len(output)))

--- a/kalite/distributed/management/commands/gitmigrate.py
+++ b/kalite/distributed/management/commands/gitmigrate.py
@@ -4,7 +4,6 @@ import shutil
 from distutils.dir_util import copy_tree
 
 from django.core.management.base import BaseCommand, CommandError
-from django.conf import settings; logging = settings.LOG
 
 from optparse import make_option
 
@@ -37,11 +36,17 @@ class Command(BaseCommand):
         if not os.path.exists(os.path.join(path, "kalite", "database", "data.sqlite")):
             raise CommandError("No database file found to migrate")
         else:
+            print("-------------------------------------------------------------------")
+            print("Attempting to copy Database file from previous installation")
+            print("-------------------------------------------------------------------\n")
             shutil.copy2(os.path.join(path, "kalite", "database", "data.sqlite"), os.path.join(os.environ.get("KALITE_DIR"), "kalite", "database", "data.sqlite"))
-            logging.info("Database file successfully copied")
+            print("***Database file successfully copied***\n")
 
         if not os.path.exists(os.path.join(path, "content")):
             raise CommandError("No content folder find to migrate")
         else:
+            print("-------------------------------------------------------------------")
+            print("Attempting to copy content files from previous installation")
+            print("-------------------------------------------------------------------\n")
             output = copy_tree(os.path.join(path, "content"), os.path.join(os.environ.get("KALITE_DIR"), "content"), update=True)
-            logging.info("Copied {files} files from the previous content folder".format(files=len(output)))
+            print("***Copied {files} files from the previous content folder***\n".format(files=len(output)))

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -158,6 +158,11 @@ class Command(BaseCommand):
             dest='force-assessment-item-dl',
             default=False,
             help='Downloads assessment items from the url specified by settings.ASSESSMENT_ITEMS_ZIP_URL, without interaction'),
+        make_option('-g', '--git-migrate',
+            action='store',
+            dest='git_migrate_path',
+            default=None,
+            help='Runs the git migrate management command to migrate from previous installations of KA Lite using Git'),
     )
 
     def handle(self, *args, **options):
@@ -203,6 +208,11 @@ class Command(BaseCommand):
             if options["interactive"]:
                 if not raw_input_yn("Do you wish to continue and install it as root?"):
                     raise CommandError("Aborting script.\n")
+
+        git_migrate_path = options["git_migrate_path"]
+
+        if git_migrate_path:
+            call_command("gitmigrate", path=git_migrate_path)
 
         install_clean = not kalite.is_installed()
         database_kind = settings.DATABASES["default"]["ENGINE"]

--- a/sphinx-docs/installguide/release_notes.rst
+++ b/sphinx-docs/installguide/release_notes.rst
@@ -1,6 +1,21 @@
 Release Notes
 =============
 
+0.14.0
+------
+
+General
+^^^^^^^
+Installation from source (using ``git``) is no longer supported for end-users.
+If you have previously installed from source, in order to upgrade you must first install KA Lite again in a separate location using one of the supported installers.
+Then you can migrate your data from your old installation to your new one using the command::
+
+    kalite manage setup --git-migrate [/path/to/your/old/installation/]
+
+You *must* use the ``kalite`` command that comes with your new installation.
+The path you should specify is the base project directory -- it should contain the ``kalite`` directory, which should in turn contain the ``database`` directory.
+Follow the on-screen prompts to complete the migration.
+
 0.13.0
 ------
 


### PR DESCRIPTION
This fixes the first part of #3335. Needs specific changes in the installers to leverage this new option on setup.

Summary of changes:
* Adds a management command to migrate from a previous installation somewhere else in the file system (presumably git)
* Copies database file from old install to new
* Copies content files from old install to new
* Adds option to setup management command to pass in a path to migrate from
* Calls gitmigrate command before setting up the database to avoid creating a database and then destroying it

@aronasorman Take a peek.