### PR TITLE
Fixes #3742: flickering learn tab

### DIFF
--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -362,13 +362,14 @@ window.ToggleNavbarView = BaseView.extend ({
     initialize: function() {
 
         _.bindAll(this);
-        this.listenTo(this.model, "change:client_server_time_diff", this.render);
+        this.listenTo(this.model, "change:is_logged_in", this.render);
         $("topnav").append(this.template());
         $(window).on("resize", this.collapsed_nav);
     },
 
     render: function() {
         
+        console.log("called");
         this.$el.html(this.template(this.model.attributes));
         
         this.userView = new UserView({ model: this.model, el: "#topnav" });

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -368,8 +368,7 @@ window.ToggleNavbarView = BaseView.extend ({
     },
 
     render: function() {
-        
-        console.log("called");
+
         this.$el.html(this.template(this.model.attributes));
         
         this.userView = new UserView({ model: this.model, el: "#topnav" });

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -362,7 +362,7 @@ window.ToggleNavbarView = BaseView.extend ({
     initialize: function() {
 
         _.bindAll(this);
-        this.listenTo(this.model, "change", this.render);
+        this.listenTo(this.model, "change:client_server_time_diff", this.render);
         $("topnav").append(this.template());
         $(window).on("resize", this.collapsed_nav);
     },


### PR DESCRIPTION
Fixes https://github.com/learningequality/ka-lite/issues/3742

All of the tabs still toggle correctly and the learn tab no longer flickers on a video, but I'm not too sure if this is the best approach. 