### PR TITLE
Eliminates reference to topic tree node children as anything but ids

### DIFF
--- a/kalite/coachreports/models.py
+++ b/kalite/coachreports/models.py
@@ -124,6 +124,8 @@ class PlaylistProgress(PlaylistProgressParent):
             else:
                 ex_status = "complete"
 
+            # Oh Quizzes, we hardly knew ye!
+            # TODO (rtibbles): Sort out the status of Quizzes, and either reinstate them or remove them.
             # Compute quiz stats
             # quiz_exists, quiz_log, quiz_pct_score = cls.get_quiz_log(user, (p.get("entries") or p.get("children")), p.get("id"))
             # if quiz_log:
@@ -260,6 +262,10 @@ class PlaylistProgressDetail(PlaylistProgressParent):
                         "path": leaf_node["path"],
                     }
 
+            # Oh Quizzes, we hardly knew ye!
+            # TODO (rtibbles): Sort out the status of Quizzes, and either reinstate them or remove them.
+            # Quizzes were introduced to provide a way of practicing multiple types of exercise at once
+            # However, there is currently no way to access them, and the manner for generating them (from the now deprecated Playlist models) is inaccessible
             # elif kind == "Quiz":
             #     entity_id = playlist["id"]
             #     if quiz_log:


### PR DESCRIPTION
Fixes #3743 - except it doesn't. But fixes the only possible places I can find in the code that might be associated with this.

Summary of changes:
* Fully deprecates Playlists in student progress reports.
* Eliminates reference to topic tree node children as anything but ids.

@MCGallaspy 