### PR TITLE
Daemonize with Popen, remove redundant daemonize function

### DIFF
--- a/kalite/django_cherrypy_wsgiserver/cherrypyserver.py
+++ b/kalite/django_cherrypy_wsgiserver/cherrypyserver.py
@@ -135,14 +135,6 @@ def run_cherrypy_server(host="127.0.0.1", port=None, threads=None, daemonize=Fal
     if daemonize:
         if not pidfile:
             pidfile = '~/cpwsgi_%d.pid' % port
-        
-        # benjaoming: stopping the server is an explicit logic that has already
-        # been implemented other places. Killing some process related to a
-        # possibly out-dated pidfile is not exactly best practice
-        # stop_server(pidfile)
-
-        from django.utils.daemonize import become_daemon
-        become_daemon()
 
         fp = open(pidfile, 'w')
         fp.write("%d\n" % os.getpid())

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -352,6 +352,11 @@ def manage(command, args=[], in_background=False):
             kwargs = {'creationflags': subprocess.CREATE_NEW_PROCESS_GROUP}
         else:
             kwargs = {}
+
+        kwargs.update({
+            "stdout": open("kalite.log", "a"),
+            "stderr": subprocess.STDOUT,
+        })
         subprocess.Popen(
             [sys.executable, os.path.abspath(sys.argv[0]), "manage", command] + args,
             **kwargs
@@ -419,7 +424,7 @@ def start(debug=False, args=[], skip_job_scheduler=False):
         ] + (["--production"] if not debug else []),
         args
     )
-    manage('kaserve', args)
+    manage('kaserve', args, in_background=True)
 
 
 def stop(args=[], sys_exit=True):


### PR DESCRIPTION
Just a preview of what I'm suggesting in #3541. In particular, I'm open to better suggestions for logging, and we'll need to test this on Windows. Also, any suggestions on how to manage subprocesses to prevent process leaks? Edit: I'm thinking for the start command we should kill all child processes if the server dies, as a sort of insurance policy.

Edit: @rtibbles @aronasorman @jamalex 