### PR TITLE
Serve built docs within app

### DIFF
--- a/kalite/distributed/management/commands/sphinx_docs_preprocess.py
+++ b/kalite/distributed/management/commands/sphinx_docs_preprocess.py
@@ -1,0 +1,26 @@
+import os
+import re
+
+from django.core.management.base import NoArgsCommand
+
+from kalite.settings import USER_DATA_ROOT
+from os import walk
+
+class Command(NoArgsCommand):
+    """
+    Pre-process html files in sphinx-docs.
+    At the moment, this just means making static file references (css, js) use an absolute href.
+    """
+
+    def handle_noargs(*args, **kwargs):
+        expr = re.compile(r'(href|src)="(\.\./)*(_static|_images)/')
+        repl = r'\1="/static/\3/'
+        docs_path = os.path.join(USER_DATA_ROOT, "sphinx-docs", "_build", "html")
+        for dirpath, dirnames, filenames in walk(docs_path):
+            for filename in filenames:
+                if ".html" in filename:
+                    with open(os.path.join(dirpath, filename), "r+") as f:
+                        preprocess = f.read()
+                        postprocess = expr.sub(repl, preprocess)
+                        f.seek(0)
+                        f.write(postprocess)

--- a/kalite/distributed/urls.py
+++ b/kalite/distributed/urls.py
@@ -40,6 +40,9 @@ urlpatterns += patterns('',
     url(r'^securesync/', include(securesync.urls)),
 )
 
+urlpatterns += patterns(__package__ + '.views',
+    url(r'^documentation/(?P<doc_url>(.*\.html$|$))', 'sphinx_docs', name='sphinx_docs'),
+)
 
 # TODO: This should only be in DEBUG settings and the HTTP server should be
 # serving it otherwise. Cherrypy is currently serving it through modifications

--- a/kalite/distributed/views.py
+++ b/kalite/distributed/views.py
@@ -5,6 +5,7 @@ Views for the KA Lite app are wide-ranging, and include:
 * Administrative pages
 and more!
 """
+import os
 import sys
 from annoying.decorators import render_to
 from annoying.functions import get_object_or_None
@@ -14,7 +15,7 @@ from django.contrib.auth.models import User
 from django.conf import settings; logging = settings.LOG
 from django.contrib import messages
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseNotFound, HttpResponseRedirect, HttpResponseServerError
+from django.http import HttpResponseNotFound, HttpResponseRedirect, HttpResponseServerError, HttpResponse
 from django.template import RequestContext
 from django.template.loader import render_to_string
 from django.utils.safestring import mark_safe
@@ -23,7 +24,7 @@ from django.utils.translation import ugettext as _
 from fle_utils.internet.classes import JsonResponseMessageError
 from fle_utils.internet.functions import get_ip_addresses, set_query_params
 from fle_utils.internet.webcache import backend_cache_page
-from kalite import topic_tools
+from kalite import topic_tools, ROOT_DATA_PATH
 from kalite.shared.decorators.auth import require_admin
 from securesync.api_client import BaseClient
 from securesync.models import Device, SyncSession, Zone
@@ -249,3 +250,15 @@ def handler_500(request):
         "value": unicode(value),
     }
     return HttpResponseServerError(render_to_string("distributed/500.html", context, context_instance=RequestContext(request)))
+
+def sphinx_docs(request, doc_url):
+    if not doc_url:
+        doc_url = "index.html"
+    split_doc_url = doc_url.split("/")
+    doc_location = os.path.join(ROOT_DATA_PATH, "sphinx-docs", "_build", "html", *split_doc_url)
+    if os.path.exists(doc_location):
+        with open(doc_location) as f:
+            html_str = f.read()
+        return HttpResponse(html_str)
+    else:
+        return handler_404(request)

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -336,7 +336,14 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
 TEMPLATE_DIRS = tuple()  # will be filled recursively via INSTALLED_APPS
 # libraries common to all apps
-STATICFILES_DIRS = (os.path.join(_data_path, 'static-libraries'),)
+built_docs_path = os.path.join(_data_path, "sphinx-docs", "_build", "html")
+if os.path.exists(built_docs_path):
+    STATICFILES_DIRS = (
+        os.path.join(_data_path, 'static-libraries'),
+        built_docs_path,
+    )
+else:
+    STATICFILES_DIRS = (os.path.join(_data_path, 'static-libraries'),)
 
 DEFAULT_ENCODING = 'utf-8'
 


### PR DESCRIPTION
What's inside:
* In `kalite.settings.base`, the `STATICFILES_DIRS` setting includes `os.path.join(_data_path, "sphinx-docs", "_build", "html")` if it exists. For me, this resolved to `/usr/share/kalite/sphinx-docs/_build/html`. This is so the included static files in that directory are served by Django.
* A new view and url that serves documentation pages (html files only) found in the directory `[[ROOT_DATA_PATH]]/sphinx-docs/build/html`, or serves a 404 page if the file doesn't exist. The url matches e.g. `documentation/`, `documentation/usermanual/userman_admin.html`.
* A management command (`sphinx_docs_preprocess`) to preprocess bundled docs during the build process. This is necessary so that `img` tags and references to css and js files resolve correctly. This is meant to be used in the build process, after building or otherwise obtaining docs.

Todo: Include an access point to the docs somewhere in the app itself... suggestions?