### PR TITLE
Spawn processes by default for OS X whenever we call call_command_async

### DIFF
--- a/python-packages/fle_utils/django_utils/command.py
+++ b/python-packages/fle_utils/django_utils/command.py
@@ -131,7 +131,15 @@ def call_command_async(cmd, *args, **kwargs):
     that stringify in a way that commands can parse
     (which will work for str, bool, int, etc).
     """
+    #  Workaround for #3704. It seems like running cron for downloading videos
+    # as a different thread on the same process in OS X results in a normal exit.
+    # That's it, the kalite executable just quits, no segfaults or anything.
+    # The workaround for now is to spawn subprocesses by default on OS X,
+    # and have everyone else spawn threads.
+    is_osx = sys.platform == 'darwin'
+    in_proc = kwargs.pop('in_proc', not is_osx)
     in_proc = kwargs.pop('in_proc', True)
+    
     if in_proc:
         return call_command_threaded(cmd, *args, **kwargs)
     else:


### PR DESCRIPTION
Workaround for #3704. Running videodownload on OS X results in a strange quitting behaviour by the python process if run as a thread. If run as a process, it should work fine, albeit it might take longer. Good enough for now.