### PR TITLE
Fix for 3840: adds url to my progress page

### DIFF
--- a/kalite/distributed/hbtemplates/user/navigation.handlebars
+++ b/kalite/distributed/hbtemplates/user/navigation.handlebars
@@ -31,7 +31,7 @@
       <li role="presentation" class="divider"></li>
       {{!-- Student account management --}}
       <li role="presentation" class="motivational-feature">
-        <a role="menuitem" tabindex="-1" id="nav_progress">
+        <a href="{{ url "student_view" }}" role="menuitem" tabindex="-1" id="nav_progress">
           {{_ "My Progress" }}
         </a>
       </li>


### PR DESCRIPTION
Fixes https://github.com/learningequality/ka-lite/issues/3840

My Progress now links to the student progress report page