### PR TITLE
Some logging is better than none

### DIFF
--- a/kalite/django_cherrypy_wsgiserver/cherrypyserver.py
+++ b/kalite/django_cherrypy_wsgiserver/cherrypyserver.py
@@ -142,7 +142,12 @@ def run_cherrypy_server(host="127.0.0.1", port=None, threads=None, daemonize=Fal
         # stop_server(pidfile)
 
         from django.utils.daemonize import become_daemon
-        become_daemon()
+        kalite_home = os.environ.get("KALITE_HOME", None)
+        logfile = os.path.join(kalite_home, "kalite.log") if (kalite_home and os.environ.get("NAIVE_LOGGING", False)) else None
+        if logfile:
+            become_daemon(out_log=logfile, err_log=logfile)
+        else:
+            become_daemon()
 
         with open(pidfile, 'w') as f:
             f.write("%d\n" % os.getpid())

--- a/sphinx-docs/developer_docs/index.rst
+++ b/sphinx-docs/developer_docs/index.rst
@@ -8,3 +8,4 @@ Useful stuff our devs think that the rest of our devs ought to know about.
     Javascript Unit Tests <javascript_testing>
     Behavior-Driven Integration Tests <behave_testing>
     Profiling KA Lite <profiling>
+    Logging <logging>

--- a/sphinx-docs/developer_docs/logging.rst
+++ b/sphinx-docs/developer_docs/logging.rst
@@ -6,6 +6,7 @@ If you wish to view output from the server, you have a few options:
 *  Start the server using the command `kalite manage kaserve --production`.
    This will start the server using CherryPy and a single thread, with output going to stdout and stderr.
 *  If you wish to capture the output from `kalite start`, then you need to do two thing:
+
    *  Opt-in by setting the value of the environment variable NAIVE_LOGGING to "True".
       It is opt-in because there is no rotation or control on log file size.
    *  Ensure that you have write permissions in the directory pointed to by the environment variable KALITE_HOME.

--- a/sphinx-docs/developer_docs/logging.rst
+++ b/sphinx-docs/developer_docs/logging.rst
@@ -2,6 +2,7 @@ Logging
 =======
 
 If you wish to view output from the server, you have a few options:
+
 *  Start the server using the command `kalite manage kaserve --production`.
    This will start the server using CherryPy and a single thread, with output going to stdout and stderr.
 *  If you wish to capture the output from `kalite start`, then you need to do two thing:

--- a/sphinx-docs/developer_docs/logging.rst
+++ b/sphinx-docs/developer_docs/logging.rst
@@ -3,9 +3,9 @@ Logging
 
 If you wish to view output from the server, you have a few options:
 
-*  Start the server using the command `kalite manage kaserve --production`.
+*  Start the server using the command ``kalite manage kaserve --production``.
    This will start the server using CherryPy and a single thread, with output going to stdout and stderr.
-*  If you wish to capture the output from `kalite start`, then you need to do two thing:
+*  If you wish to capture the output from ``kalite start``, then you need to do two thing:
 
    *  Opt-in by setting the value of the environment variable NAIVE_LOGGING to "True".
       It is opt-in because there is no rotation or control on log file size.

--- a/sphinx-docs/developer_docs/logging.rst
+++ b/sphinx-docs/developer_docs/logging.rst
@@ -1,0 +1,11 @@
+Logging
+=======
+
+If you wish to view output from the server, you have a few options:
+*  Start the server using the command `kalite manage kaserve --production`.
+   This will start the server using CherryPy and a single thread, with output going to stdout and stderr.
+*  If you wish to capture the output from `kalite start`, then you need to do two thing:
+   *  Opt-in by setting the value of the environment variable NAIVE_LOGGING to "True".
+      It is opt-in because there is no rotation or control on log file size.
+   *  Ensure that you have write permissions in the directory pointed to by the environment variable KALITE_HOME.
+      The output will be logged to the file KALITE_HOME/kalite.log.


### PR DESCRIPTION
Here's some logging. It's opt-in, since it doesn't use any rotation. A simpler solution than #3800 for now. In general it's possible to use fancy logfiles with rotation using the `logging` module, but since we import that from settings I'm not touching it right now.