### PR TITLE
Coach report bug fixes

### DIFF
--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -163,7 +163,7 @@ def aggregate_learner_logs(request):
         "complete": log.complete,
         "struggling": getattr(log, "struggling", None),
         "progress": getattr(log, "streak_progress", getattr(log, "progress", None)),
-        "content": get_exercise_cache().get(getattr(log, "exercise_id"), get_content_cache().get(getattr(log, "video_id", getattr(log, "content_id", "")), {})),
+        "content": get_exercise_cache().get(getattr(log, "exercise_id", ""), get_content_cache().get(getattr(log, "video_id", getattr(log, "content_id", "")), {})),
         } for log in output_logs[:event_limit]]
     output_dict["total_time_logged"] = UserLogSummary.objects\
         .filter(user__in=learners, last_activity_datetime__gte=start_date, last_activity_datetime__lte=end_date)\

--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -152,7 +152,8 @@ def aggregate_learner_logs(request):
             output_dict["exercise_attempts"] = AttemptLog.objects.filter(user__in=learners,
                 timestamp__gte=start_date,
                 timestamp__lte=end_date).count()
-            output_dict["exercise_mastery"] = round(log_objects.aggregate(Avg("streak_progress"))["streak_progress__avg"])
+            if log_objects.aggregate(Avg("streak_progress"))["streak_progress__avg"] is not None:
+                output_dict["exercise_mastery"] = round(log_objects.aggregate(Avg("streak_progress"))["streak_progress__avg"])
         output_logs.extend(log_objects)
 
     # Report total time in hours

--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -139,24 +139,26 @@ def aggregate_learner_logs(request):
             latest_activity_timestamp__lte=end_date, **obj_ids).order_by("-latest_activity_timestamp")
 
 
-        if id_field == "video":
-            output_dict["content_time_spent"] += log_objects.aggregate(Sum("total_seconds_watched"))["total_seconds_watched__sum"]
-        elif id_field == "content":
-            output_dict["content_time_spent"] += log_objects.aggregate(Sum("time_spent"))["time_spent__sum"]
-        elif id_field == "exercise":
+        if log_type == "video":
+            output_dict["content_time_spent"] += log_objects.aggregate(Sum("total_seconds_watched"))["total_seconds_watched__sum"] or 0
+        elif log_type == "content":
+            output_dict["content_time_spent"] += log_objects.aggregate(Sum("time_spent"))["time_spent__sum"] or 0
+        elif log_type == "exercise":
             output_dict["exercise_attempts"] = AttemptLog.objects.filter(user__in=learners,
-                latest_activity_timestamp__gte=start_date,
-                latest_activity_timestamp__lte=end_date).count()
-            output_dict["exercise_mastery"] = log_objects.aggregate(Avg("streak_progress"))["streak_progress__avg"]
+                timestamp__gte=start_date,
+                timestamp__lte=end_date).count()
+            output_dict["exercise_mastery"] = round(log_objects.aggregate(Avg("streak_progress"))["streak_progress__avg"])
         output_logs.extend(log_objects)
 
+    # Report total time in hours
+    output_dict["content_time_spent"] = round(output_dict["content_time_spent"]/3600.0,1)
     output_logs.sort(key=lambda x: x.latest_activity_timestamp, reverse=True)
     output_dict["learner_events"] = [{
         "learner": log.user.get_name(),
         "complete": log.complete,
         "struggling": getattr(log, "struggling", None),
         "progress": getattr(log, "streak_progress", getattr(log, "progress", None)),
-        "content": get_exercise_cache().get(getattr(log, "exercise_id"), get_content_cache().get(getattr(log, "video_id", getattr(log, "content_id")), {})),
+        "content": get_exercise_cache().get(getattr(log, "exercise_id"), get_content_cache().get(getattr(log, "video_id", getattr(log, "content_id", "")), {})),
         } for log in output_logs[:event_limit]]
     output_dict["total_time_logged"] = UserLogSummary.objects\
         .filter(user__in=learners, last_activity_datetime__gte=start_date, last_activity_datetime__lte=end_date)\

--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -28,7 +28,7 @@ def get_learners_from_GET(request):
         # Do this to ensure that we never return more than one facility's worth of anything.
         learner_filter = Q(facility__pk__in=facility_ids)
 
-    return FacilityUser.objects.filter(learner_filter).order_by("last_name")
+    return FacilityUser.objects.filter(learner_filter & Q(is_teacher=False)).order_by("last_name")
 
 def return_log_type_details(log_type, topic_ids=None):
     fields = ["user", "points", "complete", "completion_timestamp", "completion_counter"]

--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -99,7 +99,12 @@ def learner_logs(request):
     return JsonResponse({
         "logs": output_logs,
         "contents": output_objects,
-        "learners": [learner for learner in learners.values("first_name", "last_name", "username", "pk")],
+        "learners": [{
+            "first_name": learner.first_name,
+            "last_name": learner.last_name,
+            "username": learner.username,
+            "pk": learner.pk
+            } for learner in learners],
         "page": page,
         "pages": pages,
         "limit": limit

--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -99,6 +99,7 @@ def learner_logs(request):
     return JsonResponse({
         "logs": output_logs,
         "contents": output_objects,
+        # Sometimes 'learners' gets collapsed to a list from the Queryset. This insures against that eventuality.
         "learners": [{
             "first_name": learner.first_name,
             "last_name": learner.last_name,

--- a/kalite/coachreports/features/coachreports.feature
+++ b/kalite/coachreports/features/coachreports.feature
@@ -8,6 +8,7 @@ Feature: Coach reports
         Given there is no data
         And I am on the coach report
         Then I should see a warning
+        And there should be no Show Tabular Report button
 
     Scenario: I teach two groups
         Given there are two groups

--- a/kalite/coachreports/features/steps/coachreports.py
+++ b/kalite/coachreports/features/steps/coachreports.py
@@ -39,6 +39,10 @@ def step_impl(context):
     warning = find_css_class_with_wait(context, "alert-warning")
     assert warning, "No warning shown."
 
+@then(u"there should be no Show Tabular Report button")
+def impl(context):
+    assert_no_element_by_css_selector(context, "#show_tabular_report")
+
 @then(u"I should be taken to the learner's progress report page")
 def impl(context):
     assert reverse("student_view") in context.browser.current_url, "Assertion failed. {url} not in {current_url}".format(url=reverse("student_view"), current_url=context.browser.current_url)
@@ -100,6 +104,7 @@ def impl(context, learner, progress_verbs, exercise):
             log.attempts = 25
         for i in range(0, log.attempts):
             attempt_log, created = AttemptLog.objects.get_or_create(exercise_id=exercise, user=user, seed=i, timestamp=datetime.datetime.now())
+        log.latest_activity_timestamp = datetime.datetime.now()
         log.save()
 
 @then(u'I should see the "{exercise}" marked for "{learner}" as "{progress_text}" and coloured "{progress_colour}"')
@@ -168,10 +173,13 @@ def impl(context):
     exercises = random.sample(get_exercise_cache().keys(), 10)
     for user in FacilityUser.objects.all():
         for exercise in exercises:
-            log, created = ExerciseLog.objects.get_or_create(exercise_id=exercise, user=user)
-            log.streak_progress = 100
-            log.attempts = 15
-            log.save()
+            log, created = ExerciseLog.objects.get_or_create(
+                exercise_id=exercise,
+                user=user,
+                streak_progress=100,
+                attempts=15,
+                latest_activity_timestamp=datetime.datetime.now()
+                )
 
 
 @given(u"there are two groups")

--- a/kalite/coachreports/hbtemplates/coach_nav/detailspanel.handlebars
+++ b/kalite/coachreports/hbtemplates/coach_nav/detailspanel.handlebars
@@ -3,18 +3,20 @@
 </div>
 
 {{#if collection}}
-<div class="body"></div>
+<div class="body detailspanel"></div>
 
 {{#if pages }}
-<nav>
-	<ul class="pagination">
-		<li><a href="#" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
-		{{#each pages}}
-		<li><a href="#">{{ this }}</a></li>
-		{{/each}}
-		<li><a href="#" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
-	</ul>
-</nav>
+<div class="nav">
+    <nav>
+        <ul class="pagination">
+            <li><a href="#" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
+            {{#each pages}}
+            <li><a href="#">{{ this }}</a></li>
+            {{/each}}
+            <li><a href="#" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
+        </ul>
+    </nav>
+</div>
 {{/if}}
 {{else}}
 <div class="well">

--- a/kalite/coachreports/hbtemplates/coach_nav/detailspanel.handlebars
+++ b/kalite/coachreports/hbtemplates/coach_nav/detailspanel.handlebars
@@ -9,11 +9,11 @@
 <div class="nav">
     <nav>
         <ul class="pagination">
-            <li><a href="#" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a></li>
+            <li{{#ifcond page "===" 1 }} class="disabled"><span{{else}}><a href="#" class="pagination-link" value="previous"{{/ifcond}} aria-label="{{_ "Previous" }}"><span aria-hidden="true">&laquo;</span></{{#ifcond page "===" 1 }}span{{else}}a{{/ifcond}}></li>
             {{#each pages}}
-            <li><a href="#">{{ this }}</a></li>
+            <li{{#ifcond this "===" ../page }} class="active"><span{{else}}><a href="#" class="pagination-link" value="{{ this }}"{{/ifcond}}>{{ this }}</{{#ifcond this "===" page }}span{{else}}a{{/ifcond}}></li>
             {{/each}}
-            <li><a href="#" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
+            <li{{#ifcond page "===" pages.length }} class="disabled"><span{{else}}><a href="#" class="pagination-link" aria-label="{{_ "Next" }}" value="next"{{/ifcond}}><span aria-hidden="true">&raquo;</span></{{#ifcond page "===" pages.length }}span{{else}}a{{/ifcond}}></li>
         </ul>
     </nav>
 </div>

--- a/kalite/coachreports/hbtemplates/coach_nav/detailspanelbody.handlebars
+++ b/kalite/coachreports/hbtemplates/coach_nav/detailspanelbody.handlebars
@@ -1,37 +1,40 @@
 <div class="tabbable tabs-left">
-	<ul class="nav nav-tabs">
-		{{#each collection}}
-		<li class="detail-tab {{#if correct }}correct{{else}}incorrect{{/if}}{{#if @first}} active{{/if}}">
-			<a href="#{{ id }}" data-toggle="tab" aria-expanded="true">Question {{ math @index "+" 1 }}</a>
-		</li>
-		{{/each}}
-	</ul>
-	<div class="tab-content">
-		{{#each collection}}
-		<div class="tab-pane {{#if @first}}active{{/if}}" id="{{ id }}">
-			<p class="detail-tab {{#if correct }}correct">{{_ "Correct" }}{{else}}incorrect">{{_ "Incorrect" }}{{/if}}</p>
-			<p>{{_ "Time taken" }}: {{ math time_taken "/" 1000 }} {{_ "seconds" }}</p>
-			<table class="table table-striped table-bordered details-table">
-			<thead>
-			<tr>
-				<th>{{_ "Attempt" }}</th>
-				<th>{{_ "Action" }}</th>
-				<th>{{_ "Time" }}</th>
-				<th>{{_ "Status" }}</th>
-			</tr>
-			</thead>
-			<tbody>
-			{{#each response_log }}
-			<tr>
-				<td>{{ math @index "+" 1  }}</td>
-				<td>{{ type }}{{#if answer}}: {{answer}}{{/if}}</td>
-				<td>{{ datetime timestamp }}</td>
-				<td>{{#ifcond correct "===" true}}{{_ "Correct" }}{{else}}{{#ifcond correct "===" false }}{{_ "Incorrect" }}{{/ifcond}}{{/ifcond}}</td>
-			</tr>
-			{{/each}}
-			</tbody>
-			</table>
-		</div>
-		{{/each}}
-	</div>
+    <ul class="nav nav-tabs">
+        {{#each collection}}
+        <li role="presentation" class="detail-tab {{#if correct }}correct{{else}}incorrect{{/if}}{{#if @first}} active{{/if}}">
+            <a href="#{{ id }}" data-toggle="tab" aria-expanded="true">Question {{ math @index "+" 1 }}</a>
+        </li>
+        {{/each}}
+    </ul>
+    <div class="tab-content">
+        {{#each collection}}
+        <div class="tab-pane {{#if @first}}active{{/if}}" id="{{ id }}">
+            <p class="detail-tab {{#if correct }}correct">{{_ "Correct" }}{{else}}incorrect">{{_ "Incorrect" }}{{/if}}</p>
+            {{#if time_taken }}<p>{{_ "Time taken" }}: {{ math time_taken "/" 1000 }} {{_ "seconds" }}</p>{{/if}}
+            {{#if points }}<p>{{_ "Points" }}: {{ points }}</p>{{/if}}
+            {{#if response_log }}
+                <table class="table table-striped table-bordered details-table">
+                <thead>
+                <tr>
+                    <th>{{_ "Attempt" }}</th>
+                    <th>{{_ "Action" }}</th>
+                    <th>{{_ "Time" }}</th>
+                    <th>{{_ "Status" }}</th>
+                </tr>
+                </thead>
+                <tbody>
+                {{#each response_log }}
+                <tr>
+                    <td>{{ math @index "+" 1  }}</td>
+                    <td>{{ type }}{{#if answer}}: {{answer}}{{/if}}</td>
+                    <td>{{ datetime timestamp }}</td>
+                    <td>{{#ifcond correct "===" true}}{{_ "Correct" }}{{else}}{{#ifcond correct "===" false }}{{_ "Incorrect" }}{{/ifcond}}{{/ifcond}}</td>
+                </tr>
+                {{/each}}
+                </tbody>
+                </table>
+            {{/if}}
+        </div>
+        {{/each}}
+    </div>
 </div>

--- a/kalite/coachreports/hbtemplates/coach_nav/detailspanelbody.handlebars
+++ b/kalite/coachreports/hbtemplates/coach_nav/detailspanelbody.handlebars
@@ -2,7 +2,7 @@
     <ul class="nav nav-tabs">
         {{#each collection}}
         <li role="presentation" class="detail-tab {{#if correct }}correct{{else}}incorrect{{/if}}{{#if @first}} active{{/if}}">
-            <a href="#{{ id }}" data-toggle="tab" aria-expanded="true">Question {{ math @index "+" 1 }}</a>
+            <a href="#{{ id }}" data-toggle="tab" aria-expanded="true">Question {{ math @index "+" ../start_number }}</a>
         </li>
         {{/each}}
     </ul>

--- a/kalite/coachreports/hbtemplates/coach_nav/detailspanelbody.handlebars
+++ b/kalite/coachreports/hbtemplates/coach_nav/detailspanelbody.handlebars
@@ -8,7 +8,7 @@
     </ul>
     <div class="tab-content">
         {{#each collection}}
-        <div class="tab-pane {{#if @first}}active{{/if}}" id="{{ id }}">
+        <div class="tab-pane detail-panel-contents {{#if @first}}active{{/if}}" id="{{ id }}">
             <p class="detail-tab {{#if correct }}correct">{{_ "Correct" }}{{else}}incorrect">{{_ "Incorrect" }}{{/if}}</p>
             {{#if time_taken }}<p>{{_ "Time taken" }}: {{ math time_taken "/" 1000 }} {{_ "seconds" }}</p>{{/if}}
             {{#if points }}<p>{{_ "Points" }}: {{ points }}</p>{{/if}}
@@ -25,10 +25,10 @@
                 <tbody>
                 {{#each response_log }}
                 <tr>
-                    <td>{{ math @index "+" 1  }}</td>
-                    <td>{{ type }}{{#if answer}}: {{answer}}{{/if}}</td>
-                    <td>{{ datetime timestamp }}</td>
-                    <td>{{#ifcond correct "===" true}}{{_ "Correct" }}{{else}}{{#ifcond correct "===" false }}{{_ "Incorrect" }}{{/ifcond}}{{/ifcond}}</td>
+                    <td class="detail-table-cell">{{ math @index "+" 1  }}</td>
+                    <td class="detail-table-cell">{{ type }}{{#if answer}}: {{#ifObject answer}}{{#each answer.[0] }}{{#unless @first }}, {{/unless}}{{#each this }}{{this}}{{/each}}{{/each}}{{else}}{{answer}}{{/ifObject}}{{/if}}</td>
+                    <td class="detail-table-cell">{{ datetime timestamp }}</td>
+                    <td class="detail-table-cell">{{#ifcond correct "===" true}}{{_ "Correct" }}{{else}}{{#ifcond correct "===" false }}{{_ "Incorrect" }}{{/ifcond}}{{/ifcond}}</td>
                 </tr>
                 {{/each}}
                 </tbody>

--- a/kalite/coachreports/hbtemplates/coach_nav/landing.handlebars
+++ b/kalite/coachreports/hbtemplates/coach_nav/landing.handlebars
@@ -1,6 +1,6 @@
 <div id="coach_report_wrapper">
 	<div id="summary_mainview">
-		<h1 class="status_name">{{ status.facility_name }}{{#if status.group_name }}: {{ status.group_name }}{{/if}}<button id="show_tabular_report" class="btn btn-success pull-right">{{_ "Show Tabular Report" }}</button></h1>
+		<h1 class="status_name">{{ status.facility_name }}{{#if status.group_name }}: {{ status.group_name }}{{/if}}{{#if data.learner_events }}<button id="show_tabular_report" class="btn btn-success pull-right">{{_ "Show Tabular Report" }}</button>{{/if}}</h1>
 		<div id="radial_chartblock">
 			<div id="chartcontainer">
 				<h3>{{_ "This week" }}</h3>

--- a/kalite/coachreports/hbtemplates/coach_nav/landing.handlebars
+++ b/kalite/coachreports/hbtemplates/coach_nav/landing.handlebars
@@ -14,7 +14,7 @@
 				</div>
 				<div class="circlechart">
 					<div id="full_circle2">
-						<p>{{#if data.exercise_mastery }}{{data.exercise_mastery }}{{else}}{{_ "N/A" }}{{/if}}</p>
+						<p>{{#if data.exercise_mastery }}{{data.exercise_mastery }} %{{else}}{{_ "N/A" }}{{/if}}</p>
 					</div>
 					<div class="charttext">
 						{{_ "Average progress in exercises" }}
@@ -30,7 +30,7 @@
 				</div>
 				<div class="circlechart">
 					<div id="full_circle4">
-						<p>{{#if data.content_time_spent }}{{ data.content_time_spent }}{{else}}{{_ "N/A" }}{{/if}}</p>
+						<p>{{#if data.content_time_spent }}{{ data.content_time_spent }} {{_ "Hours" }}{{else}}{{_ "N/A" }}{{/if}}</p>
 					</div>
 					<div class="charttext">
 						{{_ "Total time spent on content" }}

--- a/kalite/coachreports/management/commands/generaterealdata.py
+++ b/kalite/coachreports/management/commands/generaterealdata.py
@@ -270,6 +270,7 @@ def generate_fake_exercise_logs(facility_user=None, topics=topics, start_date=da
                     alog.save()
 
                 elog.attempts = attempts
+                elog.latest_activity_timestamp = start_date + date_diff
                 elog.streak_progress = sum([log.correct for log in alogs][-10:])*10
                 elog.points = sum([log.points for log in alogs][-10:])
 
@@ -409,6 +410,7 @@ def generate_fake_video_logs(facility_user=None, topics=topics, start_date=datet
                         points=points,
                         complete=(pct_completed == 100.),
                         completion_timestamp=date_completed,
+                        latest_activity_timestamp=date_completed,
                     )
                     try:
                         vlog.save()  # avoid userlog issues

--- a/kalite/coachreports/static/css/coachreports/base.css
+++ b/kalite/coachreports/static/css/coachreports/base.css
@@ -6,12 +6,19 @@
     width: inherit;
 }
 
-.detail-tab.correct {
-    color: #669966;
+.detail-tab.correct,
+.detail-tab.correct a,
+.detail-tab.correct.active a {
+    color: #669966 !important;
 }
 
-.detail-tab.incorrect {
-    color: #FD795B; /*red*/
+.detail-tab.incorrect,
+.detail-tab.incorrect a,
+.detail-tab.incorrect.active a {
+    color: #FD795B !important; /*red*/
+}
+.detail-tab.incorrect a,
+.detail-tab.incorrect.active a {
     font-weight: bold;
 }
 

--- a/kalite/coachreports/static/css/coachreports/events_view.css
+++ b/kalite/coachreports/static/css/coachreports/events_view.css
@@ -1,46 +1,42 @@
 /* overriding the nav tabs of bootstrap-overrides.css for the detailed events panel */
-.tabs-left > .nav-tabs {
-	border-bottom: 0;
-	}
 .tab-content > .tab-pane,
 .pill-content > .pill-pane {
 	display: none;
-	}
+}
 .tab-content > .active,
 .pill-content > .active {
 	display: block;
-	}
+}
 .tabs-left > .nav-tabs > li {
 	float: none;
-	}
+}
 .tabs-left > .nav-tabs > li > a {
 	min-width: 74px;
 	margin-right: 0;
 	margin-bottom: 3px;
-	<!--add 5/12/2015-->
 	border-right: 1px solid #ddd;
-	}
+}
 .tabs-left > .nav-tabs {
 	float: left;
 	margin-right: 5px;
 	border-right: 1px solid #ddd;
-	}
+}
 .tabs-left > .nav-tabs > li > a {
 	margin-right: -1px;
 	-webkit-border-radius: 4px 0 0 4px;
 	-moz-border-radius: 4px 0 0 4px;
 	border-radius: 4px 0 0 4px;
-	}
+}
 .tabs-left > .nav-tabs > li > a:hover,
 .tabs-left > .nav-tabs > li > a:focus {
+	border:1px solid #ddd;
 	border-color: #eeeeee #dddddd #eeeeee #eeeeee;
-	}
+}
 .tabs-left > .nav-tabs .active > a,
 .tabs-left > .nav-tabs .active > a:hover,
 .tabs-left > .nav-tabs .active > a:focus {
 	border-color: #ddd transparent #ddd #ddd;
-	*border-right-color: #fff;
-	}	
+}
 
 .tabs-left > .nav-tabs > li > a,
 .tabs-left > .nav-tabs > li .active > a,

--- a/kalite/coachreports/static/css/coachreports/events_view.css
+++ b/kalite/coachreports/static/css/coachreports/events_view.css
@@ -46,3 +46,13 @@
 	background: #f9f9f9;
 	
 }
+
+/* Force panel to a min width and cells to a max-width to keep table inline */
+.detail-panel-contents {
+	min-width: 500px;
+}
+
+table.details-table td.detail-table-cell {
+	overflow: auto;
+	max-width: 120px;
+}

--- a/kalite/coachreports/static/css/coachreports/tabular_view.css
+++ b/kalite/coachreports/static/css/coachreports/tabular_view.css
@@ -80,6 +80,7 @@ th.headrowuser {
 	background-color: #eee;
 }
 
+/* Make this specific to .status to prevent it overriding cells in the details panel table. */
 #displaygrid td.status, #displaygrid th {
     min-width: 60px;
     /*max-width: 60px;*/

--- a/kalite/coachreports/static/css/coachreports/tabular_view.css
+++ b/kalite/coachreports/static/css/coachreports/tabular_view.css
@@ -17,6 +17,10 @@
     float: left;
 }
 
+.detailspanel{
+    overflow: auto;
+}
+
 .userstatus {
     overflow: auto;
     width: 88%;

--- a/kalite/coachreports/static/css/coachreports/tabular_view.css
+++ b/kalite/coachreports/static/css/coachreports/tabular_view.css
@@ -2,10 +2,6 @@
 	cursor: pointer;
 }
 
-#displaygrid td {
-	al
-}
-
 #displaygrid {
 	overflow: auto;
 	border-right: 1px solid #bbb;
@@ -84,7 +80,7 @@ th.headrowuser {
 	background-color: #eee;
 }
 
-#displaygrid td, #displaygrid th {
+#displaygrid td.status, #displaygrid th {
     min-width: 60px;
     /*max-width: 60px;*/
     overflow: hidden;

--- a/kalite/coachreports/static/js/coachreports/coach_reports/views.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/views.js
@@ -97,6 +97,7 @@ var DetailPanelInlineRowView = BaseView.extend({
     initialize: function(options) {
         this.contents_length = options.contents_length;
         this.content_item = options.content_item;
+        this.content_item_place = options.content_item_place;
         this.render();
     },
 
@@ -105,8 +106,17 @@ var DetailPanelInlineRowView = BaseView.extend({
             tagName: 'td',
             model: this.model,
             content_item: this.content_item,
-            attributes: {colspan: this.contents_length + 1}
+            attributes: {colspan: this.contents_length - this.content_item_place}
         });
+
+        this.spacer_view = new BaseView({
+            tagName: 'td',
+            attributes: {colspan: this.content_item_place + 1}
+        });
+
+        this.spacer_view.render();
+
+        this.$el.append(this.spacer_view.el);
         this.$el.append(this.detail_view.el);
     }
 });
@@ -225,10 +235,12 @@ var TabularReportRowView = BaseView.extend({
 
 
         var model_id = model.get("exercise_id") || model.get("video_id") || model.get("content_id");
+        var content_item = this.contents.find(function(item) {return item.get("id") === model_id;});
         this.detail_view = new DetailPanelInlineRowView({
             model: model,
             contents_length: this.contents.length,
-            content_item: this.contents.find(function(item) {return item.get("id") === model_id;})
+            content_item: content_item,
+            content_item_place: this.contents.indexOf(content_item)
         });
         this.$el.after(this.detail_view.el);
 

--- a/kalite/coachreports/static/js/coachreports/coach_reports/views.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/views.js
@@ -23,6 +23,7 @@ var DetailsPanelBodyView = BaseView.extend({
 
     initialize: function (options) {
         _.bindAll(this);
+        // Track the number of the first Question in this panel.
         this.start_number = options.start_number;
         this.render();
     },
@@ -63,6 +64,8 @@ var DetailsPanelView = BaseView.extend({
     },
 
     instantiate_collection: function() {
+        // Instantiate a collection, with the right attributes to fetch just the AttemptLogs needed
+        // for the currently requested page and no more.
         this.collection = new window.AttemptLogCollection([], {
             user: this.model.get("user"),
             limit: this.limit,
@@ -111,6 +114,7 @@ var DetailsPanelView = BaseView.extend({
         }));
         this.bodyView = new DetailsPanelBodyView ({
             collection: this.collection,
+            // Question number of first question on this page
             start_number: (this.page - 1)*this.limit + 1,
             el: this.$(".body")
         });
@@ -141,6 +145,7 @@ var DetailPanelInlineRowView = BaseView.extend({
             attributes: {colspan: this.contents_length - this.content_item_place}
         });
 
+        // Add in a view that spans the columns up to the selected cell.
         this.spacer_view = new BaseView({
             tagName: 'td',
             attributes: {colspan: this.content_item_place + 1}
@@ -205,6 +210,7 @@ var TabularReportRowCellView = BaseView.extend({
                 this.$el.html(this.model.get("streak_progress") + "%");
             }
         } else if (this.model.has("video_id") || this.model.has("content_id")) {
+            // Calculate progress from points if not an exercise.
             if (this.model.get("points") < ds.distributed.points_per_video) {
                 this.$el.html(Math.round(100*this.model.get("points")/ds.distributed.points_per_video) + "%");
             }
@@ -396,8 +402,6 @@ var CoachSummaryView = BaseView.extend({
     },
 
     render: function() {
-        delete this.fetching;
-
         this.$el.html(this.template({
             status:this.model.attributes,
             data: this.data_model.attributes

--- a/kalite/coachreports/static/js/coachreports/coach_reports/views.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/views.js
@@ -204,6 +204,10 @@ var TabularReportRowCellView = BaseView.extend({
             if (this.model.get("streak_progress") < 100) {
                 this.$el.html(this.model.get("streak_progress") + "%");
             }
+        } else if (this.model.has("video_id") || this.model.has("content_id")) {
+            if (this.model.get("points") < ds.distributed.points_per_video) {
+                this.$el.html(Math.round(100*this.model.get("points")/ds.distributed.points_per_video) + "%");
+            }
         }
     },
 

--- a/kalite/coachreports/static/js/coachreports/coach_reports/views.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/views.js
@@ -326,7 +326,6 @@ var CoachSummaryView = BaseView.extend({
         _.bindAll(this);
         this.listenTo(this.model, "change:facility", this.set_data_model);
         this.listenTo(this.model, "change:group", this.set_data_model);
-        this.set_data_model();
     },
 
     set_data_model: function (){
@@ -349,10 +348,14 @@ var CoachSummaryView = BaseView.extend({
     },
 
     render: function() {
+        delete this.fetching;
+
         this.$el.html(this.template({
             status:this.model.attributes,
             data: this.data_model.attributes
         }));
+
+        clear_messages();
 
         // If no user data at all, then show a warning to the user
         var ref, ref1;

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -189,7 +189,13 @@ a#user-name-a.dropdown-toggle {
     border-top: 2px solid #5AA685;
     border-right: 2px solid #5AA685;
 }
-.nav li a:focus {
+
+.nav li a:hover,
+.nav li a:focus,
+.nav li.active a,
+.nav li.active a:hover,
+.nav li.active span,
+.nav li.active span:hover {
     background: #5AA685;
 }
 .dropdown-menu li a {

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -196,7 +196,7 @@ a:hover {
 .teach-nav li a:hover {
     color: #5AA685;
 }
-.teach-nav span.icon {
+.teach-nav i.icon {
     font-size: 40pt;
 }
 .link-width {
@@ -283,7 +283,7 @@ a:hover {
     font-weight: bold;
     text-decoration: none;
 }
-.manage-nav span.icon {
+.manage-nav i.icon {
     font-size: 40pt;
 }
 

--- a/kalite/distributed/templates/distributed/base_manage.html
+++ b/kalite/distributed/templates/distributed/base_manage.html
@@ -14,13 +14,13 @@
         <ul class="nav nav-tabs">
             <div class="mobile-manage-nav">
             {% if request.session.facility_user.facility.id %}
-                <li class="teacher-only users {% block user_active %}{% endblock user_active %}"><a href="{% url 'facility_management' zone_id=None facility_id=request.session.facility_user.facility.id %}" title="{% trans 'Manage Users' %}"><div><span class="icon icon-uniE606"></span><br/>{% trans "Users" %}</div></a></li>
+                <li class="teacher-only users {% block user_active %}{% endblock user_active %}"><a href="{% url 'facility_management' zone_id=None facility_id=request.session.facility_user.facility.id %}" title="{% trans 'Manage Users' %}"><div><i class="icon icon-uniE606"></i><br/>{% trans "Users" %}</div></a></li>
             {% endif %}
-                <li class="facility {% block facility_active %}{% endblock facility_active %}"><a href="{% url 'zone_management' zone_id=None %}" title="{% trans 'Manage Facilities' %}"><div><span class="icon icon-uniE603"></span><br/>{% trans "Facilities" %}</div></a></li>         
+                <li class="facility {% block facility_active %}{% endblock facility_active %}"><a href="{% url 'zone_management' zone_id=None %}" title="{% trans 'Manage Facilities' %}"><div><i class="icon icon-uniE603"></i><br/>{% trans "Facilities" %}</div></a></li>         
             </div>
             <div class="mobile-manage-nav">
-                <li class="video {% block video_active %}{% endblock video_active %}"><a href="{% url 'update_videos' %}" title="{% trans 'Update this server with new videos and languages' %}"><div><span class="icon icon-uniE610"></span><br/>{% trans "Videos" %}</div></a></li>
-                <li class="languages {% block languages_active %}{% endblock languages_active %}"><a href="{% url 'update_languages' %}"><div><span class="icon icon-uniE600"></span><br/>{% trans "Language" %}</div></a></li>
+                <li class="video {% block video_active %}{% endblock video_active %}"><a href="{% url 'update_videos' %}" title="{% trans 'Update this server with new videos and languages' %}"><div><i class="icon icon-uniE610"></i><br/>{% trans "Videos" %}</div></a></li>
+                <li class="languages {% block languages_active %}{% endblock languages_active %}"><a href="{% url 'update_languages' %}"><div><i class="icon icon-uniE600"></i><br/>{% trans "Language" %}</div></a></li>
             </div>
 
         {% block inline-btn %}

--- a/python-packages/fle_utils/handlebars/static/js/handlebars/handlebars-helpers.js
+++ b/python-packages/fle_utils/handlebars/static/js/handlebars/handlebars-helpers.js
@@ -93,3 +93,11 @@ Handlebars.registerHelper("datetime", function(datetime_string, options) {
     var date = new Date(datetime_string);
     return date.toLocaleString();
 });
+
+Handlebars.registerHelper("ifObject", function(candidate, options){
+    if (_.isObject(candidate)) {
+        return options.fn(this);
+    } else {
+        return options.inverse(this);
+    }
+})

--- a/sphinx-docs/developer_docs/index.rst
+++ b/sphinx-docs/developer_docs/index.rst
@@ -8,3 +8,4 @@ Useful stuff our devs think that the rest of our devs ought to know about.
     Javascript Unit Tests <javascript_testing>
     Behavior-Driven Integration Tests <behave_testing>
     Profiling KA Lite <profiling>
+    Developer Utility Commands <utility>

--- a/sphinx-docs/developer_docs/utility.rst
+++ b/sphinx-docs/developer_docs/utility.rst
@@ -1,0 +1,19 @@
+Developer Utility Commands
+==========================
+
+Django Management Commands
+--------------------------
+
+All Django management commands can be run by typing:
+
+``bin/kalite manage <command_name>``
+
+in the root directory of the KA Lite project.
+
+generaterealdata
+--------------------------------------------
+
+This function is designed to produce example user data for testing various front end functionality, such as coach reports and content recommendation.
+It does take some shortcuts, and will not produce accurate answer data for exercises. This is a Django management command and can be run with the following command:
+
+``bin/kalite manage generaterealdata``


### PR DESCRIPTION
Fixes #3837, closes #3839, resolves #3845, fixes #3846, closes #3850, resolves #3853, fixes #3854, closes #3858, resolves #3880, and fixes #3882.

Summary of changes:
* Enhances latest activity timestamp logging in generaterealdata
* Stops two summary data API calls being made
* Fixes bug with summary data aggregation so that data is actually aggregated.
* Positions detail panel view under cell that was clicked.
* Prevents getattr calls without default values.
* Filters teachers out of coach reports.
* Pushes pagination outside of content in details panel.
* Properly implements pagination on the details panel view.
* Implements a first pass attempt at displaying Perseus answers in the details panel view.
* Hides the 'Show Tabular Report' button when no data is available.
* Shows progress text in tabular report for all log types.