### PR TITLE
Coach login redirects to coach reports

### DIFF
--- a/kalite/facility/api_resources.py
+++ b/kalite/facility/api_resources.py
@@ -122,7 +122,12 @@ class FacilityUserResource(ModelResource):
             messages.success(request, _("You've been logged in! We hope you enjoy your time with KA Lite ")
                 + _("-- be sure to log out when you finish."))
 
-            return self.create_response(request, {'success': True})
+            extras = {'success': True}
+            if user.is_teacher:
+                extras.update({
+                    "redirect": reverse("coach_reports")
+                })
+            return self.create_response(request, extras)
 
 
     def logout(self, request, **kwargs):

--- a/kalite/facility/tests/__init__.py
+++ b/kalite/facility/tests/__init__.py
@@ -5,3 +5,4 @@ from crypto_tests import *
 from deletion_tests import *
 from form_tests import *
 from unicode_tests import *
+from api_resource_tests import *

--- a/kalite/facility/tests/api_resource_tests.py
+++ b/kalite/facility/tests/api_resource_tests.py
@@ -1,0 +1,28 @@
+import json
+
+from kalite.testing.base import KALiteClientTestCase
+from kalite.testing.mixins.facility_mixins import FacilityMixins
+
+class TestCoachRedirect(FacilityMixins, KALiteClientTestCase):
+    """
+    Regression test for https://github.com/learningequality/ka-lite/issues/3857
+    Ensures that the login api response for a coach redirects to the proper page.
+    """
+
+    def setUp(self):
+        super(TestCoachRedirect, self).setUp()
+        self.password = "abc123"
+        self.coach = self.create_teacher(password=self.password)
+
+    def test(self):
+        resp = self.client.post(
+            self.reverse("api_dispatch_list", kwargs={"resource_name": "user"}) + "login/",
+            json.dumps({
+                "username": self.coach.username,
+                "password": self.password,
+                "facility": self.coach.facility.id,
+            }),
+            content_type="application/json",
+        )
+        redirect = json.loads(resp.content).get("redirect")
+        self.assertEqual(redirect, self.reverse("coach_reports"), "Logging in as coach does not redirect!")


### PR DESCRIPTION
Fixes #3857 and adds a test for it. Supersedes #3879, since I rewrote history. Warning: looking at that PR now may cause headaches.