### PR TITLE
Fixes #3885. Don't reference object directly in Backbone Model defaults, as object will be shared across instances.

### DIFF
--- a/kalite/distributed/static/js/distributed/exercises/models.js
+++ b/kalite/distributed/static/js/distributed/exercises/models.js
@@ -191,8 +191,7 @@ window.AttemptLogModel = Backbone.Model.extend({
         points: 0,
         context_type: "",
         context_id: "",
-        response_count: 0,
-        response_log: []
+        response_count: 0
     },
 
     to_object: function() {


### PR DESCRIPTION
Not sure how long this has been extant, but it's going to give us some awfully crappy data.

Fixes #3885