### PR TITLE
Safely wait for page load in tests

### DIFF
--- a/kalite/coachreports/features/steps/coachreports.py
+++ b/kalite/coachreports/features/steps/coachreports.py
@@ -25,8 +25,7 @@ colour_legend = {
 
 @given("I am on the coach report")
 def step_impl(context):
-    url = reverse("coach_reports")
-    context.browser.get(build_url(context, url))
+    go_to_coachreports(context)
 
 @given("there is no data")
 def step_impl(context):


### PR DESCRIPTION
Just waits for a page to load before continuing. Should address the test failures in #3809.