### PR TITLE
Video download and topic tree fixes

### DIFF
--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -66,7 +66,7 @@ def get_topic_tree(force=False, annotate=False, channel=None, language=None, par
     if TOPICS.get(channel) is None:
         TOPICS[channel] = {}
     if annotate or TOPICS.get(channel, {}).get(language) is None:
-        TOPICS[channel][language] = softload_json(TOPICS_FILEPATHS.get(channel), logger=logging.debug, raises=False)
+        topics = softload_json(TOPICS_FILEPATHS.get(channel), logger=logging.debug, raises=False)
 
         # Just loaded from disk, so have to restamp.
         annotate = True
@@ -122,7 +122,7 @@ def get_topic_tree(force=False, annotate=False, channel=None, language=None, par
 
             flat_topic_tree.append(node)
 
-        recurse_nodes(TOPICS[channel][language])
+        recurse_nodes(topics)
 
         TOPICS[channel][language] = flat_topic_tree
 

--- a/kalite/updates/__init__.py
+++ b/kalite/updates/__init__.py
@@ -29,34 +29,6 @@ def my_handler(sender, **kwargs):
             .update(completed=True)
 
 
-@receiver(post_save, sender=VideoFile)
-def invalidate_on_video_update(sender, **kwargs):
-    """
-    Listen in to see when videos become available.
-    """
-    # Can only do full check in Django 1.5+, but shouldn't matter--we should only save with
-    # percent_complete == 100 once.
-    just_now_available = kwargs["instance"] and kwargs["instance"].percent_complete == 100  # and "percent_complete" in kwargs["updated_fields"]
-    if just_now_available:
-        # This event should only happen once, so don't bother checking if
-        #   this is the field that changed.
-        logging.debug("Invalidating cache on VideoFile save for %s" % kwargs["instance"])
-        from kalite import caching  # caching also imports updates; import here to prevent circular dependencies
-        caching.invalidate_all_caches()
-
-
-@receiver(pre_delete, sender=VideoFile)
-def invalidate_on_video_delete(sender, **kwargs):
-    """
-    Listen in to see when available videos become unavailable.
-    """
-    was_available = kwargs["instance"] and kwargs["instance"].percent_complete == 100
-    if was_available:
-        logging.debug("Invalidating cache on VideoFile delete for %s" % kwargs["instance"])
-        from kalite import caching  # caching also imports updates; import here to prevent circular dependencies
-        caching.invalidate_all_caches()
-
-
 def delete_language(lang_code):
 
     langpack_resource_paths = [get_localized_exercise_dirpath(lang_code), get_srt_path(lang_code), get_locale_path(lang_code)]

--- a/kalite/updates/management/commands/videoscan.py
+++ b/kalite/updates/management/commands/videoscan.py
@@ -93,7 +93,6 @@ class Command(CronCommand):
             videos_flagged_for_download = set([video.youtube_id for video in VideoFile.objects.filter(flagged_for_download=True)])
             videos_needing_model_deletion_chunked = break_into_chunks(videos_marked_at_all - youtube_ids_in_filesystem - videos_flagged_for_download)
             # Disconnect cache-invalidation listener to prevent it from being called multiple times
-            pre_delete.disconnect(receiver=updates.invalidate_on_video_delete, sender=VideoFile)
             for chunk in videos_needing_model_deletion_chunked:
                 video_files_needing_model_deletion = VideoFile.objects.filter(youtube_id__in=chunk)
                 deleted_video_ids += [video_file.youtube_id for video_file in video_files_needing_model_deletion]


### PR DESCRIPTION
Fixes #2976, and attempts to resolve #3835, and perhaps closes #3743 permanently.

Summary of changes:
* Only assign topic tree to global variable after the flat topic tree has been generated.
* Removes signals that trigger cache invalidation after modification of VideoFile model.