### PR TITLE
Check if facility is missing metadata. If so, promp user (via icon/to…

### DIFF
--- a/kalite/control_panel/static/css/control_panel/base.css
+++ b/kalite/control_panel/static/css/control_panel/base.css
@@ -35,3 +35,6 @@ h2 {
 .add-new-table-item {
     margin-left: 8px;
 }
+.notice {
+    color:#dd8844;
+}

--- a/kalite/control_panel/templates/control_panel/partials/_facility_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_facility_table.html
@@ -10,13 +10,8 @@
             </small>
             {% if missing_meta %}
             <small>
-                <span class = "help‐tooltip glyphicon
-                               glyphicon‐exclamation‐sign text-warning" data‐toggle = "tooltip"
-                               data‐placement="right" title = '{% trans "The
-                               facilities highlighted below are missing
-                               metadata (e.g. location, contact
-                               information). Click the facility to edit or
-                               update this information" %}'></span>
+                <span class="help-tooltip glyphicon glyphicon-exclamation-sign
+                notice" data-toggle="tooltip" data-placement="right" title='{%trans "The facilities highlighted below are missing metadata (e.g. location, contact information). Click the pencil icon to edit or update this information." %}'></span>
             </small>
             {% endif %}
         </h2>
@@ -40,9 +35,10 @@
                         {% for id,facility in facilities.items %}
                             <tr {% if facility.meta_data_in_need %} class="warning" {% endif %}>
                                 <td>
-                                     <a class="facility-name" href="{% url 'facility_management' zone_id=zone_id facility_id=facility.id %}">
-                                        {{ facility.name }}
-                                    </a>
+                                     <a class="facility-name" href="{% url 'facility_management' zone_id=zone_id facility_id=facility.id %}">{{ facility.name }}</a>
+ 					{% if facility.meta_data_in_need %} 
+						<a href="facility/{{ facility.id }}/edit" class="help-tooltip glyphicon glyphicon-pencil notice" data-toggle="tooltip" data-placement="right" title="{% trans "Edit/update information for this facility." %}"></a>
+ 					{% endif %}
                                 </td>
                                 <td>
                                     {{ facility.num_users }}

--- a/kalite/control_panel/templates/control_panel/partials/_facility_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_facility_table.html
@@ -8,6 +8,18 @@
             <small>
                 <span class="help-tooltip glyphicon glyphicon-question-sign" data-toggle="tooltip" data-placement="right" title='{% trans "A facility is a physical location where learners learn." %}'></span>
             </small>
+            {% if missing_meta %}
+            <small>
+                <span class = "help‐tooltip glyphicon
+                               glyphicon‐exclamation‐sign" style
+                               ="color:orange;" data‐toggle = "tooltip"
+                               data‐placement="right" title = '{% trans "The
+                               facilities highlighted below are missing
+                               metadata (e.g. location, contact
+                               information). Click the facility to edit or
+                               update this information" %}'></span>
+            </small>
+            {% endif %}
         </h2>
         {% if not facilities %}
             <p id="no-facilities-message">
@@ -27,7 +39,7 @@
                     </thead>
                     <tbody>
                         {% for id,facility in facilities.items %}
-                            <tr>
+                            <tr {% if facility.meta_data_in_need %} class="warning" {% endif %}>
                                 <td>
                                      <a class="facility-name" href="{% url 'facility_management' zone_id=zone_id facility_id=facility.id %}">
                                         {{ facility.name }}

--- a/kalite/control_panel/templates/control_panel/partials/_facility_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_facility_table.html
@@ -37,7 +37,7 @@
                                 <td>
                                      <a class="facility-name" href="{% url 'facility_management' zone_id=zone_id facility_id=facility.id %}">{{ facility.name }}</a>
  					{% if facility.meta_data_in_need %} 
-						<a href="facility/{{ facility.id }}/edit" class="help-tooltip glyphicon glyphicon-pencil notice" data-toggle="tooltip" data-placement="right" title="{% trans "Edit/update information for this facility." %}"></a>
+						<a href="{% url 'facility_form' facility_id=facility.id %}" class="help-tooltip glyphicon glyphicon-pencil notice" data-toggle="tooltip" data-placement="right" title="{% trans "Edit/update information for this facility." %}"></a>
  					{% endif %}
                                 </td>
                                 <td>

--- a/kalite/control_panel/templates/control_panel/partials/_facility_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_facility_table.html
@@ -11,8 +11,7 @@
             {% if missing_meta %}
             <small>
                 <span class = "help‐tooltip glyphicon
-                               glyphicon‐exclamation‐sign" style
-                               ="color:orange;" data‐toggle = "tooltip"
+                               glyphicon‐exclamation‐sign text-warning" data‐toggle = "tooltip"
                                data‐placement="right" title = '{% trans "The
                                facilities highlighted below are missing
                                metadata (e.g. location, contact

--- a/kalite/control_panel/tests/control_panel.py
+++ b/kalite/control_panel/tests/control_panel.py
@@ -120,7 +120,7 @@ class FacilityControlTests(FacilityMixins,
                                            password=teacher_password)
         self.browser_login_teacher(username=teacher_username,
                                    password=teacher_password,
-                                   facility_name=self.teacher.facility.name)
+                                   facility_name=facility_name)
         self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
 
         with self.assertRaises(NoSuchElementException):
@@ -134,7 +134,7 @@ class FacilityControlTests(FacilityMixins,
                                            password=teacher_password)
         self.browser_login_teacher(username=teacher_username,
                                    password=teacher_password,
-                                   facility_name=self.teacher.facility.name)
+                                   facility_name=facility_name)
         self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
         #should raise NoSuchElementException if there is (incorrectly) no facility no with the warning class
         self.browser.find_element_by_xpath('//*[@id="facilities-table"]/table/tbody/tr[@class="warning"]')
@@ -153,7 +153,7 @@ class FacilityControlTests(FacilityMixins,
                                            password=teacher_password)
         self.browser_login_teacher(username=teacher_username,
                                    password=teacher_password,
-                                   facility_name=self.teacher.facility.name)
+                                   facility_name=facility_name)
         self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
         #should raise NoSuchElementException if there is (incorrectly) no facility no with the warning class
         self.browser.find_element_by_xpath('//*[@id="facilities-table"]/table/tbody/tr[@class="warning"]')

--- a/kalite/control_panel/tests/control_panel.py
+++ b/kalite/control_panel/tests/control_panel.py
@@ -111,6 +111,10 @@ class FacilityControlTests(FacilityMixins,
     def test_facility_with_no_missing_metadata(self):
         facility_name = 'no-missing-metadata'
         self.fac = self.create_facility(name=facility_name)
+        for field in ['user_count', 'latitude', 'longitude', 'contact_phone']:
+            setattr(self.fac, field, 100)
+        for field in ['address', 'contact_name', 'contact_email']:
+            setattr(self.fac, field, 'Not Empty')
         teacher_username, teacher_password = 'teacher1', 'password'
         self.teacher = self.create_teacher(username=teacher_username,
                                            password=teacher_password)
@@ -125,6 +129,25 @@ class FacilityControlTests(FacilityMixins,
     def test_facility_with_missing_metadata(self):
         facility_name = 'missing-metadata'
         self.fac = self.create_facility(name=facility_name)
+        teacher_username, teacher_password = 'teacher1', 'password'
+        self.teacher = self.create_teacher(username=teacher_username,
+                                           password=teacher_password)
+        self.browser_login_teacher(username=teacher_username,
+                                   password=teacher_password,
+                                   facility_name=self.teacher.facility.name)
+        self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
+        #should raise NoSuchElementException if there is (incorrectly) no facility no with the warning class
+        self.browser.find_element_by_xpath('//*[@id="facilities-table"]/table/tbody/tr[@class="warning"]')
+
+        
+    def test_facility_with_empty_string_metadata(self):
+        facility_name = 'empy-string-metadata'
+        self.fac = self.create_facility(name=facility_name)
+        for field in ['user_count', 'latitude', 'longitude', 'contact_phone']:
+            setattr(self.fac, field, 100)
+        for field in ['address', 'contact_name']:
+            setattr(self.fac, field, 'Not Empty')
+        self.fac.contact_email = ''
         teacher_username, teacher_password = 'teacher1', 'password'
         self.teacher = self.create_teacher(username=teacher_username,
                                            password=teacher_password)

--- a/kalite/control_panel/tests/control_panel.py
+++ b/kalite/control_panel/tests/control_panel.py
@@ -108,6 +108,34 @@ class FacilityControlTests(FacilityMixins,
         with self.assertRaises(NoSuchElementException):
             self.browser.find_element_by_xpath('//a[@class="facility-delete-link"]')
 
+    def test_facility_with_no_missing_metadata(self):
+        facility_name = 'no-missing-metadata'
+        self.fac = self.create_facility(name=facility_name)
+        teacher_username, teacher_password = 'teacher1', 'password'
+        self.teacher = self.create_teacher(username=teacher_username,
+                                           password=teacher_password)
+        self.browser_login_teacher(username=teacher_username,
+                                   password=teacher_password,
+                                   facility_name=self.teacher.facility.name)
+        self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
+
+        with self.assertRaises(NoSuchElementException):
+            self.browser.find_element_by_xpath('//*[@id="facilities-table"]/table/tbody/tr[@class="warning"]')
+
+    def test_facility_with_missing_metadata(self):
+        facility_name = 'missing-metadata'
+        self.fac = self.create_facility(name=facility_name)
+        teacher_username, teacher_password = 'teacher1', 'password'
+        self.teacher = self.create_teacher(username=teacher_username,
+                                           password=teacher_password)
+        self.browser_login_teacher(username=teacher_username,
+                                   password=teacher_password,
+                                   facility_name=self.teacher.facility.name)
+        self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
+
+        warning=self.browser.find_element_by_xpath('//*[@id="facilities-table"]/table/tbody/tr[@class="warning"]')
+        return self.assertTrue(len(warning) != 0)
+
 
 class GroupControlTests(FacilityMixins,
                         CreateAdminMixin,

--- a/kalite/control_panel/tests/control_panel.py
+++ b/kalite/control_panel/tests/control_panel.py
@@ -132,9 +132,8 @@ class FacilityControlTests(FacilityMixins,
                                    password=teacher_password,
                                    facility_name=self.teacher.facility.name)
         self.browse_to(self.reverse('zone_redirect'))  # zone_redirect so it will bring us to the right zone
-
-        warning=self.browser.find_element_by_xpath('//*[@id="facilities-table"]/table/tbody/tr[@class="warning"]')
-        return self.assertTrue(len(warning) != 0)
+        #should raise NoSuchElementException if there is (incorrectly) no facility no with the warning class
+        self.browser.find_element_by_xpath('//*[@id="facilities-table"]/table/tbody/tr[@class="warning"]')
 
 
 class GroupControlTests(FacilityMixins,

--- a/kalite/control_panel/views.py
+++ b/kalite/control_panel/views.py
@@ -131,15 +131,6 @@ def zone_management(request, zone_id="None"):
 
         user_activity = UserLogSummary.objects.filter(user__facility=facility)
         exercise_activity = ExerciseLog.objects.filter(user__facility=facility)
-        print ""
-        print ""
-        print ""
-        print ""
-        print check_meta_data(facility)
-        print ""
-        print ""
-        print ""
-        print ""
         facility_data[facility.id] = {
             "name": facility.name,
             "num_users":  FacilityUser.objects.filter(facility=facility).count(),
@@ -578,7 +569,7 @@ def check_meta_data(facility):
       bool: True if one or more metadata fields are missing'''
 
     check_fields = ['user_count', 'latitude', 'longitude', 'address', 'contact_name', 'contact_phone', 'contact_email']
-    return any([getattr(facility, field, None) is None for field in check_fields])
+    return any([ (getattr(facility, field, None) is None or getattr(facility, field)=='') for field in check_fields])
 
 
 # context functions

--- a/kalite/control_panel/views.py
+++ b/kalite/control_panel/views.py
@@ -137,7 +137,7 @@ def zone_management(request, zone_id="None"):
             "num_users":  FacilityUser.objects.filter(facility=facility).count(),
             "num_groups": FacilityGroup.objects.filter(facility=facility).count(),
             "id": facility.id,
-            "meta_data_in_need": check_meta_data(facility.id),
+            "meta_data_in_need": check_meta_data(facility),
             "last_time_used":   exercise_activity.order_by("-completion_timestamp")[0:1] if user_activity.count() == 0 else user_activity.order_by("-last_activity_datetime", "-end_datetime")[0],
         }
 
@@ -560,25 +560,17 @@ def _get_user_usage_data(users, groups=None, period_start=None, period_end=None,
     return (user_data, group_data)
 
 
-def check_meta_data(facility_id):
+def check_meta_data(facility):
     '''Checks whether any metadata is missing for the specified facility.
 
     Args: 
-      facility_id (str): id of facility to check
+      facility (Facility instance): facility to check for missing metadata
  
     Returns:
       bool: True if one or more metadata fields are missing'''
 
-    facility_data = {}
-    facility_entry = Facility.objects.filter(id=facility_id)[0]
-    facility_data['usercount'] = facility_entry.user_count
-    facility_data['latitude'] = facility_entry.latitude
-    facility_data['longitude'] = facility_entry.longitude
-    facility_data['address'] = facility_entry.address
-    facility_data['contact_name'] = facility_entry.contact_name
-    facility_data['contact_phone'] = facility_entry.contact_phone
-    facility_data['contact_email'] = facility_entry.contact_email
-    return any([value is None for value in facility_data.values()])
+    check_fields = ['usercount', 'latitude', 'longitude', 'address', 'contact_name', 'contact_phone', 'contact_email']
+    return any([getattr(facility, field, None) is None for field in check_fields])
 
 
 # context functions

--- a/kalite/control_panel/views.py
+++ b/kalite/control_panel/views.py
@@ -131,7 +131,15 @@ def zone_management(request, zone_id="None"):
 
         user_activity = UserLogSummary.objects.filter(user__facility=facility)
         exercise_activity = ExerciseLog.objects.filter(user__facility=facility)
-
+        print ""
+        print ""
+        print ""
+        print ""
+        print check_meta_data(facility)
+        print ""
+        print ""
+        print ""
+        print ""
         facility_data[facility.id] = {
             "name": facility.name,
             "num_users":  FacilityUser.objects.filter(facility=facility).count(),
@@ -569,7 +577,7 @@ def check_meta_data(facility):
     Returns:
       bool: True if one or more metadata fields are missing'''
 
-    check_fields = ['usercount', 'latitude', 'longitude', 'address', 'contact_name', 'contact_phone', 'contact_email']
+    check_fields = ['user_count', 'latitude', 'longitude', 'address', 'contact_name', 'contact_phone', 'contact_email']
     return any([getattr(facility, field, None) is None for field in check_fields])
 
 


### PR DESCRIPTION
…oltip + highlighting) to update facility information

Attempts to address issue [#1808](https://github.com/learningequality/ka-lite/issues/1808).

This PR checks each facility for complete metadata when presenting facilities on the control panel. If metadata is missing, an icon w/ tooltip notifies user that there are facilities with incomplete information. Each facility missing metadata is highlighted (using warning class).

BTW: This is my first commit to ka-lite (and, well, to anything other than my own little projects) so feedback on the code and/or process very welcome!

When all data is available:
![no-missing-metadata](https://cloud.githubusercontent.com/assets/7255416/8252142/ba4b9652-1650-11e5-808a-2c0b9e993507.png)

When missing data:
![missing-metadata](https://cloud.githubusercontent.com/assets/7255416/8252143/ba4c12ee-1650-11e5-957a-558569e6607d.png)

Tooltip hover:
![tooltip](https://cloud.githubusercontent.com/assets/7255416/8252144/ba4c3d96-1650-11e5-9024-a04c04cf35c4.png)

