### PR TITLE
Cannot connect to server for downloading video files from current development installs

### DIFF
--- a/python-packages/fle_utils/django_utils/command.py
+++ b/python-packages/fle_utils/django_utils/command.py
@@ -138,7 +138,7 @@ def call_command_async(cmd, *args, **kwargs):
     # and have everyone else spawn threads.
     is_osx = sys.platform == 'darwin'
     in_proc = kwargs.pop('in_proc', not is_osx)
-    in_proc = kwargs.pop('in_proc', True)
+    #in_proc = kwargs.pop('in_proc', True)S
     
     if in_proc:
         return call_command_threaded(cmd, *args, **kwargs)


### PR DESCRIPTION
Hi @aronasorman this fixes #3704 

Downloading videos on osx isntaller worked properly after I commented `line 141` at `ka-lite/python-packages/fle_utils/django_utils/command.py`.
Refer to the screenshots below.  
![screen shot 2015-06-24 at 5 44 06 pm](https://cloud.githubusercontent.com/assets/8663934/8329200/095101bc-1aaa-11e5-9ac6-34dbd8c9941b.png)

![screen shot 2015-06-24 at 5 47 05 pm](https://cloud.githubusercontent.com/assets/8663934/8329195/fd8af1c6-1aa9-11e5-96c1-7672e7a74353.png)

![screen shot 2015-06-24 at 6 10 20 pm](https://cloud.githubusercontent.com/assets/8663934/8329258/8807bac8-1aaa-11e5-972a-be7becd5d3a2.png)

I also observed that progress bar is not showing during downloading videos. I think this is another issue.


