### PR TITLE
Fix for extant test failures on develop. Add options for skipping bdd to TestRunner.

### DIFF
--- a/kalite/distributed/features/login.feature
+++ b/kalite/distributed/features/login.feature
@@ -14,7 +14,8 @@ Feature: Logging into KA Lite
         then there should be a facility drop down
 
     Scenario: Logging in with the incorrect password
-        Given I have an account
+        Given there is one facility
+        and I have an account
         and I am on the homepage
         when I click log in
         and I enter my username correctly
@@ -24,7 +25,8 @@ Feature: Logging into KA Lite
         and a tooltip should appear on the password box only
 
     Scenario: Logging in with the wrong username
-        Given I have an account
+        Given there is one facility
+        and I have an account
         and I am on the homepage
         when I click log in
         and I enter my username incorrectly
@@ -34,7 +36,8 @@ Feature: Logging into KA Lite
         and a tooltip should appear on the username box only
 
     Scenario: Logging in with correct username and password
-        Given I have an account
+        Given there is one facility
+        and I have an account
         and I am on the homepage
         when I click log in
         and I enter my username correctly

--- a/kalite/distributed/features/steps/login.py
+++ b/kalite/distributed/features/steps/login.py
@@ -48,7 +48,7 @@ def step_impl(context):
 
 @given('I have an account')
 def impl(context):
-    context.user = CreateStudentMixin.create_student()
+    context.user = CreateStudentMixin.create_student(facility=getattr(context, "facility", None))
     context.password = CreateStudentMixin.DEFAULTS["password"]
 
 @when('I enter my password incorrectly')

--- a/kalite/testing/testrunner.py
+++ b/kalite/testing/testrunner.py
@@ -42,6 +42,18 @@ def get_options():
                     dest="browser",
                     help="Specify the browser to use for testing",
                     ),
+        make_option("--bdd_only",
+                    action="store_true",
+                    default=False,
+                    dest="bdd_only",
+                    help="Only run bdd tests",
+                    ),
+        make_option("--no_bdd",
+                    action="store_true",
+                    default=False,
+                    dest="no_bdd",
+                    help="Don't run bdd tests",
+                    ),
     )
 
     option_info = {"--behave_browser": True}


### PR DESCRIPTION
It is likely that the login test failure is as a result of the incorrect facility being selected during login (hence giving a 'bad username' rather than 'bad password' error).

In addition, the proposed --bdd-only flag does not actually function, and is meant to come from a bdd_only flag. This option has been added to allow only running the bdd tests.