### PR TITLE
Simplify logging and docs, and command line instructions

### DIFF
--- a/sphinx-docs/developer_docs/logging.rst
+++ b/sphinx-docs/developer_docs/logging.rst
@@ -3,11 +3,6 @@ Logging
 
 If you wish to view output from the server, you have a few options:
 
-*  Start the server using the command ``kalite manage kaserve --production``.
-   This will start the server using CherryPy and a single thread, with output going to stdout and stderr.
-*  If you wish to capture the output from ``kalite start``, then you need to do two thing:
-
-   *  Opt-in by setting the value of the environment variable NAIVE_LOGGING to "True".
-      It is opt-in because there is no rotation or control on log file size.
-   *  Ensure that you have write permissions in the directory pointed to by the environment variable KALITE_HOME.
-      The output will be logged to the file KALITE_HOME/kalite.log.
+*  Start the server using the command ``kalite manage runserver`` (this doesn't start the job scheduler).
+*  Start the server with ``kalite start --foreground``. This will start the server using CherryPy and a single thread, with output going to your terminal.
+*  Run the normal mode ``kalite start``, and check ``~/.kalite/server.log`` for output.


### PR DESCRIPTION
Final amendment to #3601

@MCGallaspy I replaced NAIVE_LOGGING with a default log file that's just truncated every time you run `kalite start`. I think it matches the needs better on a production system.

I don't mind that it's there by default, because you'd have to have an incredible uptime and usage to make a significant impact on file size. Everything else will memory leak and die before this is an issue, and restarting kalite always truncates the log file.

In case there's a failure, normal users can refer to the log. I could add more interesting features that kept latest lines from a previous log, but on the other hand, I feel like we need to get a proper logging mechanism and not spend more time on this :)