### PR TITLE
Adding support for Raspberry PI2 

### DIFF
--- a/kalite/settings.py
+++ b/kalite/settings.py
@@ -183,7 +183,7 @@ TEST_RUNNER = KALITE_TEST_RUNNER
 #  to override the auto-detection, set CONFIG_PACKAGE=None in the local_settings
 ########################
 
-CONFIG_PACKAGE = getattr(local_settings, "CONFIG_PACKAGE", "RPi" if (platform.uname()[0] == "Linux" and platform.uname()[4] == "armv6l") else [])
+CONFIG_PACKAGE = getattr(local_settings, "CONFIG_PACKAGE", "RPi" if (platform.uname()[0] == "Linux" and (platform.uname()[4] == "armv6l" or platform.uname()[4] == "armv7l")) else [])
 
 if isinstance(CONFIG_PACKAGE, basestring):
     CONFIG_PACKAGE = [CONFIG_PACKAGE]


### PR DESCRIPTION
RPI2 uses the armv7l, so today it doesn't benefit from the optimizations for RPI of ka-lite.  Adding support for this chip.