### PR TITLE
Ditch the underscore for module attribute

### DIFF
--- a/kalite/facility/api_resources.py
+++ b/kalite/facility/api_resources.py
@@ -183,7 +183,7 @@ class FacilityUserResource(ModelResource):
             "version": version.VERSION,
             "facilities": request.session.get("facilities"),
             "simplified_login": settings.SIMPLIFIED_LOGIN,
-            "docs_exist": getattr(settings, "_DOCS_EXIST", False),
+            "docs_exist": getattr(settings, "DOCS_EXIST", False),
         }
 
         # Override properties using facility data

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -406,10 +406,10 @@ if os.path.exists(built_docs_path):
         os.path.join(_data_path, 'static-libraries'),
         built_docs_path,
     )
-    _DOCS_EXIST = True
+    DOCS_EXIST = True
 else:
     STATICFILES_DIRS = (os.path.join(_data_path, 'static-libraries'),)
-    _DOCS_EXIST = False
+    DOCS_EXIST = False
 
 DEFAULT_ENCODING = 'utf-8'
 


### PR DESCRIPTION
I just discovered the following situation:
```sh
> kalite manage shell
>>> from kalite import settings
>>> settings._DOCS_EXIST
AttributeError: 'module' object has no attribute '_DOCS_EXIST'
```

This seems to resolve it. Necessary to make sure statically served docs have an entry in the navbar.