### PR TITLE
@echo off to make output redirection nicer

### DIFF
--- a/bin/windows/kalite.bat
+++ b/bin/windows/kalite.bat
@@ -1,2 +1,3 @@
+@echo off
 set "BIN_DIR=%~dp0"
 start /b python.exe "%BIN_DIR%..\kalite" %*


### PR DESCRIPTION
In the future, in windows, we may wish to e.g. get the version number of a previous install with the command "kalite.bat --version 1> version.txt". Without `@echo off`, this will also print the contents of kalite.bat.