### PR TITLE
Front end bug fixes

### DIFF
--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -167,7 +167,7 @@ def aggregate_learner_logs(request):
         "progress": getattr(log, "streak_progress", getattr(log, "progress", None)),
         "content": get_exercise_cache().get(getattr(log, "exercise_id", ""), get_content_cache().get(getattr(log, "video_id", getattr(log, "content_id", "")), {})),
         } for log in output_logs[:event_limit]]
-    output_dict["total_time_logged"] = UserLogSummary.objects\
-        .filter(user__in=learners, last_activity_datetime__gte=start_date, last_activity_datetime__lte=end_date)\
-        .aggregate(Sum("total_seconds")).get("total_seconds__sum") or 0
+    output_dict["total_time_logged"] = round((UserLogSummary.objects\
+        .filter(user__in=learners, start_datetime__gte=start_date, start_datetime__lte=end_date)\
+        .aggregate(Sum("total_seconds")).get("total_seconds__sum") or 0)/3600.0, 1)
     return JsonResponse(output_dict)

--- a/kalite/coachreports/hbtemplates/tabular_reports/tabular-view-row.handlebars
+++ b/kalite/coachreports/hbtemplates/tabular_reports/tabular-view-row.handlebars
@@ -1,7 +1,7 @@
 <th class="username">
     <span title="{{ first_name }} {{last_name}}({{ username }})">
         <div class="student-name">
-            <a href="{{ url "student_view" }}?user={{ pk }}">{{#ifcond first_name "||" last_name }}{{ first_name }} {{last_name}}{{else}}{{username}}{{/ifcond}}</a>
+            <a href="{{ url "student_view" }}?user={{ pk }}">{{#ifcond first_name "||" last_name }}{{ first_name }}<br>{{last_name}}{{else}}{{username}}{{/ifcond}}</a>
         </div>
     </span>
 </th>

--- a/kalite/coachreports/management/commands/generaterealdata.py
+++ b/kalite/coachreports/management/commands/generaterealdata.py
@@ -278,6 +278,16 @@ def generate_fake_exercise_logs(facility_user=None, topics=topics, start_date=da
 
                 exercise_logs.append(elog)
 
+                ulog = UserLog(
+                    user=facility_user,
+                    activity_type=1,
+                    start_datetime = start_date,
+                    end_datetime = start_date + date_diff,
+                    last_active_datetime = start_date + date_diff,
+                )
+                ulog.save()
+                user_logs.append(ulog)
+
     return (exercise_logs, user_logs)
 
 

--- a/kalite/coachreports/static/css/coachreports/tabular_view.css
+++ b/kalite/coachreports/static/css/coachreports/tabular_view.css
@@ -108,9 +108,9 @@ th.headrowuser {
     float:left; 
     display:none;
     overflow:hidden;
-    white-space:nowrap;
+    white-space:pre-line;
     width:100%;
-    margin:0px 5px 0px 0px;
+    margin:0px 5px 0px 3px;
     padding:0px;
     text-align:right;
     vertical-align:middle;

--- a/kalite/coachreports/static/css/coachreports/tabular_view.css
+++ b/kalite/coachreports/static/css/coachreports/tabular_view.css
@@ -178,3 +178,7 @@ th.headrowuser {
     select#topic { margin-left: 0 !important; }
     /* Moves "Select Topic" dropdown slightly to the right so that it lines up with "Select Topic" and "Select Report" */
 }
+
+.detail-panel-contents {
+    padding-top: 0.5em;
+}

--- a/kalite/coachreports/static/css/coachreports/tabular_view.css
+++ b/kalite/coachreports/static/css/coachreports/tabular_view.css
@@ -80,7 +80,7 @@ th.headrowuser {
     background-color: #C0E7F3;
 }
 
-.partial.selected {
+.partial.selected, .partial:hover{
     background-color: #749BA7;
 }
 
@@ -88,7 +88,7 @@ th.headrowuser {
     background-color: #5AA685;
 }
 
-.complete.selected {
+.complete.selected, .complete:hover{
     background-color: #0E5A39;
 }
 
@@ -96,7 +96,7 @@ th.headrowuser {
     background-color: #FD795B;
 }
 
-.struggling.selected {
+.struggling.selected, .struggling:hover{
     background-color: #CA4628;
 }
 

--- a/kalite/coachreports/static/css/coachreports/tabular_view.css
+++ b/kalite/coachreports/static/css/coachreports/tabular_view.css
@@ -80,12 +80,24 @@ th.headrowuser {
     background-color: #C0E7F3;
 }
 
+.partial.selected {
+    background-color: #749BA7;
+}
+
 .complete {
     background-color: #5AA685;
 }
 
+.complete.selected {
+    background-color: #0E5A39;
+}
+
 .struggling {
     background-color: #FD795B;
+}
+
+.struggling.selected {
+    background-color: #CA4628;
 }
 
 .not-attempted {

--- a/kalite/coachreports/static/js/coachreports/coach_reports/models.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/models.js
@@ -1,8 +1,4 @@
 var StateModel = Backbone.Model.extend({
-    defaults: {
-        group: window.GROUP_ID || "",
-        facility: window.FACILITY_ID || ""
-    },
 
     initialize: function() {
         _.bindAll(this);

--- a/kalite/coachreports/static/js/coachreports/coach_reports/router.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/router.js
@@ -3,6 +3,9 @@ CoachReportRouter = Backbone.Router.extend({
         _.bindAll(this);
         this.state_model = new StateModel();
         this.listenTo(this.state_model, "change", this.set_url);
+        if (options.facility) {
+            this.facility = options.facility;
+        }
     },
 
     routes: {
@@ -10,6 +13,9 @@ CoachReportRouter = Backbone.Router.extend({
     },
 
     report: function(facility, group, report) {
+        if (!facility) {
+            facility = this.facility;
+        }
         this.state_model.set({
             facility: facility,
             group: group,

--- a/kalite/coachreports/static/js/coachreports/coach_reports/views.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/views.js
@@ -478,7 +478,7 @@ var FacilitySelectView = Backbone.View.extend({
     },
 
     events: {
-        "#facility-select click": "facility_changed"
+        "change": "facility_changed"
     },
 
     facility_changed: function() {
@@ -522,7 +522,7 @@ var GroupSelectView = Backbone.View.extend({
     },
 
     events: {
-        "click": "group_changed"
+        "change": "group_changed"
     },
 
     group_changed: function() {

--- a/kalite/coachreports/static/js/coachreports/coach_reports/views.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/views.js
@@ -221,6 +221,12 @@ var TabularReportRowCellView = BaseView.extend({
         if (_.isEmpty(this.model.attributes)) {
             return false;
         } else {
+            this.listenToOnce(this.model, "selected", function() {
+                this.$el.addClass("selected");
+            });
+            this.listenToOnce(this.model, "deselected", function() {
+                this.$el.removeClass("selected");
+            });
             this.trigger("detail_view", this.model);
         }
     }
@@ -275,7 +281,6 @@ var TabularReportRowView = BaseView.extend({
             this.detail_view.remove();
         }
 
-
         var model_id = model.get("exercise_id") || model.get("video_id") || model.get("content_id");
         var content_item = this.contents.find(function(item) {return item.get("id") === model_id;});
         this.detail_view = new DetailPanelInlineRowView({
@@ -286,7 +291,7 @@ var TabularReportRowView = BaseView.extend({
         });
         this.$el.after(this.detail_view.el);
 
-        this.trigger("detail_view", this.detail_view);
+        this.trigger("detail_view", this.detail_view, model);
 
     }
 
@@ -362,11 +367,13 @@ var TabularReportView = BaseView.extend({
         }
     },
 
-    set_detail_view: function(detail_view) {
+    set_detail_view: function(detail_view, model) {
         if (this.detail_view) {
+            this.detail_view.model.trigger("deselected");
             this.detail_view.remove();
         }
         if (detail_view) {
+            model.trigger("selected");
             this.detail_view = detail_view;
         }
     }

--- a/kalite/coachreports/static/js/coachreports/coach_reports/views.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/views.js
@@ -478,7 +478,7 @@ var FacilitySelectView = Backbone.View.extend({
     },
 
     events: {
-        "change": "facility_changed"
+        "#facility-select click": "facility_changed"
     },
 
     facility_changed: function() {
@@ -522,7 +522,7 @@ var GroupSelectView = Backbone.View.extend({
     },
 
     events: {
-        "change": "group_changed"
+        "click": "group_changed"
     },
 
     group_changed: function() {

--- a/kalite/coachreports/static/js/coachreports/coach_reports/views.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/views.js
@@ -299,8 +299,9 @@ var TabularReportView = BaseView.extend({
 
     template: HB.template("tabular_reports/tabular-view"),
 
-    initialize: function() {
+    initialize: function(options) {
         _.bindAll(this);
+        this.complete_callback = options.complete;
         this.set_data_model();
         this.listenTo(this.model, "change", this.set_data_model);
     },
@@ -323,6 +324,10 @@ var TabularReportView = BaseView.extend({
         this.append_views(row_views, ".student-data");
         
         this.$('.headrowuser').css("min-width", this.$('.headrow.data').outerWidth());
+
+        if(this.complete_callback) {
+            this.complete_callback();
+        }
 
     },
 
@@ -424,9 +429,14 @@ var CoachSummaryView = BaseView.extend({
     },
 
     toggle_tabular_view: _.debounce(function() {
+        var self = this;
         if (!this.tabular_report_view) {
-            this.$("#show_tabular_report").text("Hide Tabular Report");
-            this.tabular_report_view = new TabularReportView({model: this.model});
+            this.$("#show_tabular_report").text("Loading");
+            this.$("#show_tabular_report").attr("disabled", "disabled");
+            this.tabular_report_view = new TabularReportView({model: this.model, complete: function() {
+                self.$("#show_tabular_report").text("Hide Tabular Report");
+                self.$("#show_tabular_report").removeAttr("disabled");
+            }});
             this.$("#detailed_report_view").append(this.tabular_report_view.el);
         } else {
             this.$("#show_tabular_report").text("Show Tabular Report");

--- a/kalite/coachreports/templates/coachreports/coach.html
+++ b/kalite/coachreports/templates/coachreports/coach.html
@@ -16,6 +16,7 @@
     <script type="text/javascript">
         var FACILITY_RESOURCE_URL = "{% url 'api_dispatch_list' resource_name='facility' %}";
         var GROUP_RESOURCE_URL = "{% url 'api_dispatch_list' resource_name='group' %}";
+        var FACILITY_ID = {% if facility_id %}"{{ facility_id }}"{% else %}undefined{% endif %};
     </script>
     <script src="{% url 'handlebars_templates' module_name='coach_nav' %}"></script>
     <script src="{% url 'handlebars_templates' module_name='tabular_reports' %}"></script>
@@ -25,7 +26,7 @@
     <script type="text/javascript" src="{% static 'js/coachreports/coach_reports/views.js' %}"></script>
     <script>
         $(function() {
-            window.coach_router = new CoachReportRouter();
+            window.coach_router = new CoachReportRouter({facility: FACILITY_ID});
             Backbone.history.start({pushState: true, root: "{% url 'coach_reports' %}"});
         });
     </script>

--- a/kalite/coachreports/views.py
+++ b/kalite/coachreports/views.py
@@ -6,6 +6,7 @@ from django.http import Http404
 
 from kalite.main.models import UserLog
 from kalite.shared.decorators.auth import require_authorized_access_to_student_data, require_authorized_admin, get_user_from_request
+from kalite.facility.decorators import facility_from_request
 
 @require_authorized_access_to_student_data
 @render_to("coachreports/student_view.html")
@@ -33,12 +34,18 @@ def student_view_context(request):
     }
     return context
 
-
 @require_authorized_admin
+@facility_from_request
 @render_to("coachreports/coach.html")
-def coach_reports(request):
+def coach_reports(request, facility=None):
     """Landing page needs plotting context in order to generate the navbar"""
-    return {}
+    if facility:
+        facility_id = facility.id
+    else:
+        facility_id = None
+    return {
+        "facility_id": facility_id
+        }
 
 
 

--- a/kalite/distributed/static/js/distributed/content/views.js
+++ b/kalite/distributed/static/js/distributed/content/views.js
@@ -12,34 +12,40 @@ window.ContentWrapperView = BaseView.extend({
 
         var self = this;
 
-        window.statusModel.loaded.then(function() {
-            // load the info about the content itself
-            self.data_model = new ContentDataModel({id: options.id});
-            if (self.data_model.get("id")) {
-                self.data_model.fetch().then(function() {
+        // load the info about the content itself
+        this.data_model = new ContentDataModel({id: options.id});
+        if (this.data_model.get("id")) {
+            this.data_model.fetch().then(function() {
+                window.statusModel.loaded.then(self.setup_content_environment);
+            })
+        }
 
-                    // This is a hack to support the legacy VideoLog, separate from other ContentLog
-                    // TODO-BLOCKER (rtibbles) 0.14: Remove this
+        
+    },
 
-                    if (self.data_model.get("kind") == "Video") {
-                        LogCollection = VideoLogCollection;
-                    } else {
-                        LogCollection = ContentLogCollection;
-                    }
+    setup_content_environment: function() {
 
-                    self.log_collection = new LogCollection([], {content_model: self.data_model});
+        // This is a hack to support the legacy VideoLog, separate from other ContentLog
+        // TODO-BLOCKER (rtibbles) 0.14: Remove this
 
-                    if (window.statusModel.get("is_logged_in")) {
+        if (this.data_model.get("kind") == "Video") {
+            LogCollection = VideoLogCollection;
+        } else {
+            LogCollection = ContentLogCollection;
+        }
 
-                        self.log_collection.fetch().then(self.user_data_loaded);
+        this.log_collection = new LogCollection([], {content_model: this.data_model});
 
-                    } else {
-                        self.user_data_loaded();
-                    }
-                });
-            }
+        if (window.statusModel.get("is_logged_in")) {
 
-        });
+            this.log_collection.fetch().then(this.user_data_loaded);
+
+        } else {
+            this.user_data_loaded();
+        }
+
+        this.listenToOnce(window.statusModel, "change:is_logged_in", this.setup_content_environment);
+
     },
 
     user_data_loaded: function() {

--- a/kalite/distributed/static/js/distributed/contentrec/views.js
+++ b/kalite/distributed/static/js/distributed/contentrec/views.js
@@ -22,18 +22,20 @@ window.HomepageWrapper = BaseView.extend({
     },
 
     render: function() {
-        this.$el.html(this.template());
+        if (this.collection.length > 0) {
+            this.$el.html(this.template());
 
-        if (this.content_resume) {
-            this.$("#resume").append(this.content_resume.el);
-        }
+            if (this.content_resume) {
+                this.$("#resume").append(this.content_resume.el);
+            }
 
-        if (this.content_nextsteps) {
-            this.$("#nextsteps").append(this.content_nextsteps.el);
-        }
+            if (this.content_nextsteps) {
+                this.$("#nextsteps").append(this.content_nextsteps.el);
+            }
 
-        if (this.content_explore) {
-            this.$("#explore").append(this.content_explore.el);
+            if (this.content_explore) {
+                this.$("#explore").append(this.content_explore.el);
+            }
         }
     },
 

--- a/kalite/distributed/static/js/distributed/distributed-server.js
+++ b/kalite/distributed/static/js/distributed/distributed-server.js
@@ -85,8 +85,9 @@ var StatusModel = Backbone.Model.extend({
     },
 
     get_server_time: function () {
+        var regex = /(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s[0-9]{2}\s[0-9]{4}\s[0-9]{2}:[0-9]{2}:[0-9]{2}/;
         // Function to return time corrected to server clock based on status update.
-        return (new Date(new Date() - this.get("client_server_time_diff"))).toISOString().slice(0, -1);
+        return (new Date(new Date().getTime() - this.get("client_server_time_diff"))).toString().match(regex)[0];
     },
 
     login: function(username, password, facility, callback) {
@@ -181,7 +182,8 @@ var StatusModel = Backbone.Model.extend({
         // As the server sends its timestamp without a timezone (and we can't rely on timezones
         // being set correctly, we need to do some finagling with the offset to get it to work out.
         var time_stamp = new Date(this.get("status_timestamp"));
-        this.set("client_server_time_diff", new Date() - time_stamp.getTime());
+
+        this.set("client_server_time_diff", (new Date()).getTime() - time_stamp.getTime());
 
         $(function() {
             toggle_state("logged-in", self.get("is_logged_in"));

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -483,22 +483,24 @@ window.ExerciseWrapperBaseView = BaseView.extend({
 
     initialize: function() {
 
-        var self = this;
-
         _.bindAll(this);
 
-        window.statusModel.loaded.then(function() {
+        window.statusModel.loaded.then(this.setup_exercise_environment);
+    },
 
-            if (self.initialize_subviews) {
-                self.initialize_subviews();
-            }
+    setup_exercise_environment: function() {
 
-            if (window.statusModel.get("is_logged_in")) {
+        if (this.initialize_subviews) {
+            this.initialize_subviews();
+        }
 
-                self.load_user_data();
+        if (window.statusModel.get("is_logged_in")) {
 
-            }
-        });
+            this.load_user_data();
+
+        }
+
+        this.listenToOnce(window.statusModel, "change:is_logged_in", this.setup_exercise_environment);
     },
 
     initialize_new_attempt_log: function(data) {
@@ -792,20 +794,21 @@ window.ExercisePracticeView = ExerciseWrapperBaseView.extend({
             numerator: ExerciseParams.STREAK_CORRECT_NEEDED,
             denominator: ExerciseParams.STREAK_WINDOW
         };
-
-        if (!this.log_model.get("complete")) {
-            if (this.log_model.get("attempts") > 0) { // don't display a message if the user is already partway into the streak
-                msg = "";
-            } else {
-                if (window.statusModel.is_student()) {
-                    msg = gettext("Answer %(numerator)d out of the last %(denominator)d questions correctly to complete your streak.");
-                } else {
-                    // TODO (rtibbles): Display a meaningful message to admins and coaches here.
+        if (this.log_model) {
+            if (!this.log_model.get("complete")) {
+                if (this.log_model.get("attempts") > 0) { // don't display a message if the user is already partway into the streak
                     msg = "";
+                } else {
+                    if (window.statusModel.is_student()) {
+                        msg = gettext("Answer %(numerator)d out of the last %(denominator)d questions correctly to complete your streak.");
+                    } else {
+                        // TODO (rtibbles): Display a meaningful message to admins and coaches here.
+                        msg = "";
+                    }
                 }
+            } else {
+                msg = gettext("You have finished this exercise!");
             }
-        } else {
-            msg = gettext("You have finished this exercise!");
         }
         clear_messages();
         show_message("info", sprintf(msg, context));

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -791,7 +791,12 @@ window.ExercisePracticeView = ExerciseWrapperBaseView.extend({
             if (this.log_model.get("attempts") > 0) { // don't display a message if the user is already partway into the streak
                 msg = "";
             } else {
-                msg = gettext("Answer %(numerator)d out of the last %(denominator)d questions correctly to complete your streak.");
+                if (window.statusModel.is_student()) {
+                    msg = gettext("Answer %(numerator)d out of the last %(denominator)d questions correctly to complete your streak.");
+                } else {
+                    // TODO (rtibbles): Display a meaningful message to admins and coaches here.
+                    msg = "";
+                }
             }
         } else {
             msg = gettext("You have finished this exercise!");

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -568,6 +568,10 @@ window.ExerciseWrapperBaseView = BaseView.extend({
                         context_type: self.options.context_type
                     });
 
+                    if (self.display_message) {
+                        self.display_message();
+                    }
+
                 } else { // use the seed already established for this attempt
                     self.exercise_view.load_question({
                         seed: self.current_attempt_log.get("seed"),
@@ -582,6 +586,10 @@ window.ExerciseWrapperBaseView = BaseView.extend({
         } else { // not logged in, but just load the next question, for kicks
 
             self.exercise_view.load_question();
+
+            if (self.display_message) {
+                self.display_message();
+            }
 
         }
 
@@ -741,8 +749,6 @@ window.ExercisePracticeView = ExerciseWrapperBaseView.extend({
             });
         }
 
-        this.display_message();
-
     },
 
 
@@ -801,6 +807,7 @@ window.ExercisePracticeView = ExerciseWrapperBaseView.extend({
         } else {
             msg = gettext("You have finished this exercise!");
         }
+        clear_messages();
         show_message("info", sprintf(msg, context));
     }
 

--- a/kalite/facility/api_resources.py
+++ b/kalite/facility/api_resources.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+from dateutil.tz import tzlocal
 
 from tastypie import fields
 from tastypie.http import HttpUnauthorized
@@ -179,7 +180,7 @@ class FacilityUserResource(ModelResource):
             "points": 0,
             "current_language": request.session.get(settings.LANGUAGE_COOKIE_NAME),
             "messages": message_dicts,
-            "status_timestamp": datetime.datetime.now(),
+            "status_timestamp": datetime.datetime.now(tzlocal()),
             "version": version.VERSION,
             "facilities": request.session.get("facilities"),
             "simplified_login": settings.SIMPLIFIED_LOGIN,


### PR DESCRIPTION
Fixes #3977, #3978, #3980, #3981, #3982, #3983, #3985, #3986, #3987, #3988, #3989, #4017, #4019.

Summary of changes:
* Make both client and server insensitive to timezones in datetime calculations.
* Adds loading indicator to tabular report button.
* Fixes display of student name cells in tabular report.
* Show currently clicked cell for detail view on tabular report as selected.
* Prevents detail panel contents from overflowing tab pane.
* Adds css hover to tabular report cells to indicate clickability.
* Automatically redirect coaches to their own facility.
* Don't display streak messages to admins and coaches.
* Adds UserLogs back into generaterealdata.
* Corrects total time logged to report hours, not seconds.
* Reinstate appropriate change functionality for facility and group selectors.
* If there are literally no recommendations, don't overwrite the 'learn' button on the homepage.
* Clear messages on exercises and show new ones as progress updates.
* Reinitializes exercises when statusModel changes.
* Makes content wrapper view responsive to changes in login status.