### PR TITLE
Updated gitmigrate command to a) work, b) be friendlier. Also, fixed docopt option parsing.

### DIFF
--- a/kalite/distributed/management/commands/gitmigrate.py
+++ b/kalite/distributed/management/commands/gitmigrate.py
@@ -1,17 +1,63 @@
+import glob
+import logging
 import os
 import shutil
+import time
 
 from distutils.dir_util import copy_tree
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
 from optparse import make_option
 
 
+def get_old_installation_path():
+
+    while True:
+
+        path = raw_input("Please enter the path of the previous installation of KA Lite (version 0.13 or below): ")
+
+        if os.path.exists(os.path.join(path, "kalite", "database")):
+            break
+        else:
+            logging.error("The specified path did not contain a valid KA Lite installation (version 0.13 or below). Please try again.")
+
+    return path
+
+
+def get_old_content_path(default):
+
+    while True:
+
+        path = raw_input("Please enter path you would like to import videos from (press Enter to choose '%s')? " % default) or default
+
+        if os.path.exists(path):
+            break
+        else:
+            logging.error("The specified path did not exist. Please try again.")
+
+    return path
+
+
+def raw_input_options(prompt, options, reminder="Please provide a valid response."):
+
+    while True:
+
+        ans = raw_input(prompt + " ").strip().lower()
+        if ans in options:
+            return ans
+        print reminder
+
+
+def get_glob_size_in_mb(pathglob):
+     return sum([os.path.getsize(f) for f in glob.glob(pathglob)]) / 1048576
+
+
 class Command(BaseCommand):
     """
-    This command takes an argument for the path to a git based installation of KA Lite.
-    It then copies the database file from there to the current location of KA Lite (if the two are different).
+    This command takes an argument for the path to a git based installation of KA Lite (version 0.13 or below).
+    It then copies the database file from the old location to the location needed for the current installation of KA Lite.
     """
     option_list = BaseCommand.option_list + (
         make_option(
@@ -19,34 +65,99 @@ class Command(BaseCommand):
             action='store',
             dest='path',
             default=None,
-            help="Git Install Path"
+            help="Path of previous KA Lite installation (version 0.13 or below) from which to import",
+        ),
+        make_option('-n', '--noinput',
+            action='store_false',
+            dest='interactive',
+            default=True,
+            help='Run in non-interactive mode',
         ),
     )
 
     def handle(self, *args, **options):
+
+        interactive = options.get("interactive")
+
         try:
             path = options.get("path") or args[0]
         except IndexError:
             path = None
 
         if not path:
-            # This is necessary, as simply specifying "" means you are trying to migrate something onto itself
-            raise CommandError("Must specify a path to migrate the Git installed version of KA Lite from")
 
-        if not os.path.exists(os.path.join(path, "kalite", "database", "data.sqlite")):
-            raise CommandError("No database file found to migrate")
-        else:
-            print("-------------------------------------------------------------------")
-            print("Attempting to copy Database file from previous installation")
-            print("-------------------------------------------------------------------\n")
-            shutil.copy2(os.path.join(path, "kalite", "database", "data.sqlite"), os.path.join(os.environ.get("KALITE_DIR"), "kalite", "database", "data.sqlite"))
-            print("***Database file successfully copied***\n")
+            if interactive:
+                path = get_old_installation_path()
+            else:
+                raise CommandError("Must specify a path for the old installation of KA Lite to import data from, using --path argument.")
 
-        if not os.path.exists(os.path.join(path, "content")):
-            raise CommandError("No content folder find to migrate")
+        print
+        print "-------------------------------------------------------------------"
+        print "Attempting to copy database file from previous installation"
+        print "-------------------------------------------------------------------\n"
+
+        old_database_path = os.path.join(path, "kalite", "database", "data.sqlite")
+
+        if not os.path.exists(os.path.split(old_database_path)[0]):
+            raise CommandError("No database folder found to import from")
+
+        if not os.path.exists(old_database_path):
+
+            print "No database file found. Continuing."
+
         else:
-            print("-------------------------------------------------------------------")
-            print("Attempting to copy content files from previous installation")
-            print("-------------------------------------------------------------------\n")
-            output = copy_tree(os.path.join(path, "content"), os.path.join(os.environ.get("KALITE_DIR"), "content"), update=True)
-            print("***Copied {files} files from the previous content folder***\n".format(files=len(output)))
+
+            # Backup any existing database before overwriting it
+            if os.path.exists(settings.DEFAULT_DATABASE_PATH):
+                backup_db_path = settings.DEFAULT_DATABASE_PATH + ".%d.bak" % int(time.time())
+                print "Backing up existing database file in new KA Lite installation ('%s') to '%s'..." % (settings.DEFAULT_DATABASE_PATH, backup_db_path),
+                shutil.copy(settings.DEFAULT_DATABASE_PATH, backup_db_path)
+                print "done."
+
+            # Copy in the old database to the new location
+            print "Copying old database ('%s') into correct location for new version of KA Lite ('%s')..." % (old_database_path, settings.DEFAULT_DATABASE_PATH),
+            shutil.copy(old_database_path, settings.DEFAULT_DATABASE_PATH)
+            print "done."
+
+            # Copy in the old database to the new location
+            print "Renaming old database ('%s') to '%s' to prevent it from being used in the old version of KA Lite anymore..." % (old_database_path, os.path.split(old_database_path)[-1] + ".donotuse"),
+            shutil.move(old_database_path, old_database_path + ".donotuse")
+            print "done."
+
+        print
+        print "-------------------------------------------------------------------"
+        print "Attempting to move or copy content files from previous installation"
+        print "-------------------------------------------------------------------\n"
+
+        # Determine where to import content from, confirming with the user (if we're in interactive mode)
+        old_content_path = os.path.join(path, "content")
+        if interactive:
+            old_content_path = get_old_content_path(default=old_content_path)
+
+        # Get some file size stats about the old content path
+        video_size_mb = get_glob_size_in_mb(os.path.join(old_content_path, "*.mp4"))
+        image_size_mb = get_glob_size_in_mb(os.path.join(old_content_path, "*.png"))
+
+        # Determine whether to copy, or move, the content (default to "move")
+        if not interactive:
+            move_content = True
+        else:
+            move_content = raw_input_options(
+                "Would you like to move, or copy, the %dmb of videos and %dmb of thumbnails from '%s' to '%s'?" % (video_size_mb, image_size_mb, old_content_path, settings.CONTENT_ROOT),
+                ["move","copy","c","m"],
+                "Please enter either 'move' or 'copy'."
+            ).startswith("m")
+        clone_fn = shutil.move if move_content else shutil.copy
+        clone_name = "Moving" if move_content else "Copying"
+
+        if not os.path.exists(old_content_path):
+            raise CommandError("No content folder found to be imported")
+
+        for filepath in glob.glob(os.path.join(old_content_path, "*.mp4")) + glob.glob(os.path.join(old_content_path, "*.png")):
+            filename = os.path.split(filepath)[-1]
+            destination_path = os.path.join(settings.CONTENT_ROOT, filename)
+            print "%s %s to %s..." % (clone_name, filepath, destination_path),
+            clone_fn(filepath, destination_path)
+            print "done."
+
+        print "Finished %s content into new directory. Enjoy!" % clone_name.lower()

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -200,7 +200,7 @@ class Command(BaseCommand):
                     action='store',
                     dest='git_migrate_path',
                     default=None,
-                    help='Runs the git migrate management command to migrate from previous installations of KA Lite using Git'),
+                    help='Runs the gitmigrate management command to import data and content from previous installations of KA Lite'),
     )
 
     def handle(self, *args, **options):
@@ -257,13 +257,13 @@ class Command(BaseCommand):
         git_migrate_path = options["git_migrate_path"]
 
         if git_migrate_path:
-            call_command("gitmigrate", path=git_migrate_path)
-        
+            call_command("gitmigrate", path=git_migrate_path, interactive=options["interactive"])
+
         # TODO(benjaoming): This is used very loosely, what does it mean?
         # Does it mean that the installation path is clean or does it mean
         # that we should remove (clean) items from a previous installation?
         install_clean = not kalite.is_installed()
-        
+
         database_kind = settings.DATABASES["default"]["ENGINE"]
         database_file = (
             "sqlite" in database_kind and settings.DATABASES["default"]["NAME"]) or None
@@ -339,7 +339,7 @@ class Command(BaseCommand):
             # Try locating django
             for dir_to_clean in distributed_packages:
                 clean_pyc(dir_to_clean)
-            
+
         # Move database file (if exists)
         if install_clean and database_file and os.path.exists(database_file):
             # This is an overwrite install; destroy the old db

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -663,12 +663,17 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):  # @Re
     
     # if matched and left == []:  # better error message if left?
     if collected:  # better error message if left?
+        
         result = Dict((a.name, a.value) for a in (pattern.flat() + collected))
-        collected_django_options = len(result.get('DJANGO_OPTIONS', []))
-        result['DJANGO_OPTIONS'] = (
-            result.get('DJANGO_OPTIONS', []) +
-            sys.argv[len(collected) + (collected_django_options or 1):]
-        )
+        
+        # count the number of arguments that were not Django options, and then properly read in Django
+        # options from sys.argv (we can't get them from "DJANGO_OPTIONS", since that doesn't catch 
+        # long-form options like "--git-migrate")
+        kalite_command_arg_count = len(collected)
+        if "DJANGO_OPTIONS" in result:
+            kalite_command_arg_count -= 1
+        result['DJANGO_OPTIONS'] = sys.argv[kalite_command_arg_count+1:]
+        
         # If any of the collected arguments are also in the DJANGO_OPTIONS,
         # then exit because we don't want users to have put options for kalite
         # at the end of the command

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -669,9 +669,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):  # @Re
         # count the number of arguments that were not Django options, and then properly read in Django
         # options from sys.argv (we can't get them from "DJANGO_OPTIONS", since that doesn't catch 
         # long-form options like "--git-migrate")
-        kalite_command_arg_count = len(collected)
-        if "DJANGO_OPTIONS" in result:
-            kalite_command_arg_count -= 1
+        kalite_command_arg_count = len([x for x in collected if x.name!="DJANGO_OPTIONS"])
         result['DJANGO_OPTIONS'] = sys.argv[kalite_command_arg_count+1:]
         
         # If any of the collected arguments are also in the DJANGO_OPTIONS,

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -663,15 +663,12 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):  # @Re
     
     # if matched and left == []:  # better error message if left?
     if collected:  # better error message if left?
-        
         result = Dict((a.name, a.value) for a in (pattern.flat() + collected))
-        
-        # count the number of arguments that were not Django options, and then properly read in Django
-        # options from sys.argv (we can't get them from "DJANGO_OPTIONS", since that doesn't catch 
-        # long-form options like "--git-migrate")
-        kalite_command_arg_count = len([x for x in collected if x.name!="DJANGO_OPTIONS"])
-        result['DJANGO_OPTIONS'] = sys.argv[kalite_command_arg_count+1:]
-        
+        collected_django_options = len(result.get('DJANGO_OPTIONS', []))
+        result['DJANGO_OPTIONS'] = (
+            result.get('DJANGO_OPTIONS', []) +
+            sys.argv[len(collected) + (collected_django_options or 1):]
+        )
         # If any of the collected arguments are also in the DJANGO_OPTIONS,
         # then exit because we don't want users to have put options for kalite
         # at the end of the command

--- a/sphinx-docs/installguide/release_notes.rst
+++ b/sphinx-docs/installguide/release_notes.rst
@@ -6,15 +6,15 @@ Release Notes
 
 General
 ^^^^^^^
-Installation from source (using ``git``) is no longer supported for end-users.
-If you have previously installed from source, in order to upgrade you must first install KA Lite again in a separate location using one of the supported installers.
-Then you can migrate your data from your old installation to your new one using the command::
+Installation from source (using ``git``) is no longer supported.
+If you have previously installed from source, in order to upgrade you must first install KA Lite again in a new location using one of the supported installers.
+Then you can migrate your database and content from your old installation to your new one using the command::
 
-    kalite manage setup --git-migrate [/path/to/your/old/installation/]
+    kalite manage setup --git-migrate=/path/to/your/old/installation/ka-lite
 
 You *must* use the ``kalite`` command that comes with your new installation.
 The path you should specify is the base project directory -- it should contain the ``kalite`` directory, which should in turn contain the ``database`` directory.
-Follow the on-screen prompts to complete the migration.
+Follow the on-screen prompts to complete the migration. You should then no longer use the old installation, and should consider deleting it.
 
 0.13.0
 ------


### PR DESCRIPTION
The command was trying to put stuff in `KALITE_DIR` instead of `DEFAULT_DATABASE_PATH` and `CONTENT_ROOT`, which prevented it from working at all.

The improvements here also present more options to the user, allowing them to select an alternate location to load videos from, see how big the files there are, and choose whether to copy or move. More granular progress is then displayed during the transfer.