### PR TITLE
No failure on "--long-option value" when dash in long option

### DIFF
--- a/kalitectl.py
+++ b/kalitectl.py
@@ -79,7 +79,7 @@ import cherrypy
 
 # We do not understand --option value, only --option=value.
 # Match all patterns of "--option value" and fail if they exist
-__validate_cmd_options = re.compile(r"--[^\s-]+\s+[^-\s][^-\s]+")
+__validate_cmd_options = re.compile(r"--[^\s]+\s+(?:(?!--|-[\w]))")
 if __validate_cmd_options.search(" ".join(sys.argv[1:])):
     sys.stderr.write("Please only use --option=value patterns. The option parser gets confused if you do otherwise.\n")
     sys.exit(1)


### PR DESCRIPTION
command line failure on --option=value pairs **without** = (e.g. "--long-option value") should understand --long-option containing a dash

#4026