### PR TITLE
Fix management command gitmigrate and setup --git-migrate=/old_install

### DIFF
--- a/kalitectl.py
+++ b/kalitectl.py
@@ -682,7 +682,9 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):  # @Re
         # count the number of arguments that were not Django options, and then properly read in Django
         # options from sys.argv (we can't get them from "DJANGO_OPTIONS", since that doesn't catch 
         # long-form options like "--git-migrate")
-        kalite_command_arg_count = len([x for x in collected if x.name!="DJANGO_OPTIONS"])
+        kalite_command_arg_count = len(collected)
+        if "DJANGO_OPTIONS" in result:
+            kalite_command_arg_count -= 1
         result['DJANGO_OPTIONS'] = sys.argv[kalite_command_arg_count+1:]
         
         # If any of the collected arguments are also in the DJANGO_OPTIONS,

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -676,17 +676,12 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):  # @Re
     
     # if matched and left == []:  # better error message if left?
     if collected:  # better error message if left?
-        
         result = Dict((a.name, a.value) for a in (pattern.flat() + collected))
-        
-        # count the number of arguments that were not Django options, and then properly read in Django
-        # options from sys.argv (we can't get them from "DJANGO_OPTIONS", since that doesn't catch 
-        # long-form options like "--git-migrate")
-        kalite_command_arg_count = len(collected)
-        if "DJANGO_OPTIONS" in result:
-            kalite_command_arg_count -= 1
-        result['DJANGO_OPTIONS'] = sys.argv[kalite_command_arg_count+1:]
-        
+        collected_django_options = len(result.get('DJANGO_OPTIONS', []))
+        result['DJANGO_OPTIONS'] = (
+            result.get('DJANGO_OPTIONS', []) +
+            sys.argv[len(collected) + (collected_django_options or 1):]
+        )
         # If any of the collected arguments are also in the DJANGO_OPTIONS,
         # then exit because we don't want users to have put options for kalite
         # at the end of the command


### PR DESCRIPTION
#4024
#4026

@jamalex I reverted the part with the docopt stuff, I don't know exactly what is ups and downs here, but I suspect that the old method was working, not saying that the change doesn't work just that I don't understand the implications atm!! Will open up a new issue addressing this.