### PR TITLE
Do not attempt to load assessment items on the central server.

### DIFF
--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -194,7 +194,10 @@ def get_exercise_cache(force=False, language=None):
             exercise_template = exercise_file
             exercise_lang = "en"
 
-            if exercise.get("uses_assessment_items", False):
+            # The central server doesn't have an assessment item database
+            if settings.CENTRAL_SERVER:
+                available = False
+            elif exercise.get("uses_assessment_items", False):
                 available = False
                 items = []
                 for item in exercise.get("all_assessment_items","[]"):


### PR DESCRIPTION
This blew up the facility management page on the central server, since it tried to load the assessment item DB in order to stamp availability when retrieving the topic tree (not sure why the facility management page needs the topic tree, but I didn't dig too deep for now).