### PR TITLE
Fix for #3990 issue - For Mac OS, Video Downloading.

### DIFF
--- a/kalite/updates/static/js/updates/update_videos.js
+++ b/kalite/updates/static/js/updates/update_videos.js
@@ -167,6 +167,7 @@ $(function() {
         numVideos = youtube_ids.length;
 
         // Do the request
+        show_message("warning", "Wait for the video download to start.");
         doRequest(window.Urls.start_video_download(), {youtube_ids: youtube_ids})
             .success(function() {
                 updatesStart("videodownload", 5000, video_callbacks);

--- a/kalite/updates/static/js/updates/update_videos.js
+++ b/kalite/updates/static/js/updates/update_videos.js
@@ -167,7 +167,7 @@ $(function() {
         numVideos = youtube_ids.length;
 
         // Do the request
-        show_message("warning", "Wait for the video download to start.");
+        show_message("warning", gettext("It takes a while for downloading a video, please wait."));
         doRequest(window.Urls.start_video_download(), {youtube_ids: youtube_ids})
             .success(function() {
                 updatesStart("videodownload", 5000, video_callbacks);


### PR DESCRIPTION
@aronasorman. This fixes #3990.

I create a warning message to be shown in download video, prompting the user to wait for the video download to start.

