### PR TITLE
Tweaks needed in order to work with central server

### DIFF
--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -340,6 +340,7 @@ INSTALLED_APPS = [
     'fle_utils.config',
     'fle_utils.backbone',
     'fle_utils.chronograph',
+    'fle_utils.testing', # needed to get the "runcode" command, which we sometimes tell users to run
     'kalite.django_cherrypy_wsgiserver',
     'kalite.coachreports',
     'kalite.distributed',

--- a/python-packages/fle_utils/django_utils/command.py
+++ b/python-packages/fle_utils/django_utils/command.py
@@ -173,7 +173,14 @@ def call_outside_command_with_output(command, *args, **kwargs):
     cmd = (kalite_bin, "manage", command)
     for arg in args:
         cmd += (arg,)
-    for key, val in kwargs.items():
+
+    kwargs_keys = kwargs.keys()
+    
+    # Ensure --settings occurs first, as otherwise docopt parsing barfs
+    kwargs_keys = sorted(kwargs_keys, cmp=lambda x,y: -1 if x=="settings" else 0)
+    
+    for key in kwargs_keys:
+        val = kwargs[key]
         key = key.replace(u"_",u"-")
         prefix = u"--" if command != "runcherrypyserver" else u""  # hack, but ... whatever!
         if isinstance(val, bool):

--- a/python-packages/fle_utils/django_utils/command.py
+++ b/python-packages/fle_utils/django_utils/command.py
@@ -169,6 +169,7 @@ def call_outside_command_with_output(command, *args, **kwargs):
         kalite_bin = os.path.join(kalite_dir, "bin/kalite")
     else:
         kalite_bin = 'kalite'
+
     cmd = (kalite_bin, "manage", command)
     for arg in args:
         cmd += (arg,)
@@ -178,7 +179,10 @@ def call_outside_command_with_output(command, *args, **kwargs):
         if isinstance(val, bool):
             cmd += (u"%s%s" % (prefix, key),)
         else:
-            cmd += (u"%s%s=%s" % (prefix, key, unicode(val)),)
+            # TODO(jamalex): remove this replacement, after #4066 is fixed:
+            # https://github.com/learningequality/ka-lite/issues/4066
+            cleaned_val = unicode(val).replace(" ", "")
+            cmd += (u"%s%s=%s" % (prefix, key, cleaned_val),)
 
     p = subprocess.Popen(
         cmd,

--- a/python-packages/securesync/management/commands/register.py
+++ b/python-packages/securesync/management/commands/register.py
@@ -50,7 +50,7 @@ class Command(BaseCommand):
         assert client.test_connection() == "success", "Unable to connect to the central server!"
 
         # ensure a zone was specified
-        assert "zone" in options, "You must specify a zone."
+        assert options.get("zone", None), "You must specify a zone."
 
         # simulate browser-based reg process
         s = requests.session()


### PR DESCRIPTION
This doesn't really affect anything on the distributed server (other than adding `fle_utils.testing` to `INSTALLED_APPS` to support the `runcode` command), but is needed to get the submodule stuff on ka-lite-central working.