### PR TITLE
Windows root data path workaround

### DIFF
--- a/kalite/__init__.py
+++ b/kalite/__init__.py
@@ -4,9 +4,12 @@ import sys
 from version import *
 
 
-# Where all data is stored in a kalite installation, relative to sys.prefix
-# If running kalite from source dir, you can disregard it.
-ROOT_DATA_PATH = os.path.join(sys.prefix, 'share/kalite')
+# ROOT_DATA_PATH should point to the directory where the source files live, including the "docs" dir
+if os.name == "nt":
+    # TODO-BLOCKER(MCGallaspy): Use setuptools in the windows installer to avoid this nonsense.
+    ROOT_DATA_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+else:
+    ROOT_DATA_PATH = os.path.join(sys.prefix, 'share', 'kalite')
 
 
 # TODO: Burn down this function, the name is weird, it just checks if a

--- a/kalite/__init__.py
+++ b/kalite/__init__.py
@@ -5,11 +5,11 @@ from version import *
 
 
 # ROOT_DATA_PATH should point to the directory where the source files live, including the "docs" dir
-if os.name == "nt":
-    # TODO-BLOCKER(MCGallaspy): Use setuptools in the windows installer to avoid this nonsense.
-    ROOT_DATA_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-else:
-    ROOT_DATA_PATH = os.path.join(sys.prefix, 'share', 'kalite')
+# TODO-BLOCKER(MCGallaspy): Use setuptools in the windows installer to avoid this nonsense.
+ROOT_DATA_PATH = os.environ.get(
+    "KALITE_ROOT_DATA_PATH",
+    os.path.join(sys.prefix, 'share', 'kalite')
+)
 
 
 # TODO: Burn down this function, the name is weird, it just checks if a

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -400,7 +400,7 @@ TEMPLATE_CONTEXT_PROCESSORS = [
 
 TEMPLATE_DIRS = tuple()  # will be filled recursively via INSTALLED_APPS
 # libraries common to all apps
-built_docs_path = os.path.join(_data_path, "sphinx-docs", "_build")
+built_docs_path = os.path.join(_data_path, "docs", "_build")
 if os.path.exists(built_docs_path):
     STATICFILES_DIRS = (
         os.path.join(_data_path, 'static-libraries'),


### PR DESCRIPTION
On windows, since the windows installer does not use setup tools, we must make the setting `USER_DATA_ROOT` be configurable. Also, since the docs directory was renamed (sphinx-docs to docs) let that be reflected in the static docs serving code.