### PR TITLE
Update setup command with correct link and better version display, and add "--no-assessment-items" option

### DIFF
--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -208,25 +208,25 @@ class Command(BaseCommand):
             options["hostname"] = options["hostname"] or get_host_name()
 
         # blank allows ansible scripts to dump errors cleanly.
-        print("                                  ")
-        print("  _   __  ___    _     _ _        ")
-        print(" | | / / / _ \  | |   (_) |       ")
-        print(" | |/ / / /_\ \ | |    _| |_ ___  ")
-        print(" |    \ |  _  | | |   | | __/ _ \ ")
-        print(" | |\  \| | | | | |___| | ||  __/ ")
-        print(" \_| \_/\_| |_/ \_____/_|\__\___| ")
-        print("                                  ")
-        print("http://kalite.learningequality.org")
-        print("                                  ")
+        print("                                     ")
+        print("   _   __  ___    _     _ _          ")
+        print("  | | / / / _ \  | |   (_) |         ")
+        print("  | |/ / / /_\ \ | |    _| |_ ___    ")
+        print("  |    \ |  _  | | |   | | __/ _ \   ")
+        print("  | |\  \| | | | | |___| | ||  __/   ")
+        print("  \_| \_/\_| |_/ \_____/_|\__\___|   ")
+        print("                                     ")
+        print("https://learningequality.org/ka-lite/")
+        print("                                     ")
         print("         version %s" % VERSION)
-        print("                                  ")
+        print("                                     ")
 
         if sys.version_info >= (2, 8) or sys.version_info < (2, 6):
             raise CommandError(
-                "You must have Python version 2.6.x or 2.7.x installed. Your version is: %s\n" % str(sys.version_info))
+                "You must have Python version 2.6.x or 2.7.x installed. Your version is: %d.%d.%d\n" % sys.version_info[:3])
         if sys.version_info < (2, 7, 9):
             logging.warning(
-                "It's recommended that you install Python version 2.7.9. Your version is: %s\n" % str(sys.version_info))
+                "It's recommended that you install Python version 2.7.9. Your version is: %d.%d.%d\n" % sys.version_info[:3])
 
         if options["interactive"]:
             print(

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -196,6 +196,11 @@ class Command(BaseCommand):
                     dest='force-assessment-item-dl',
                     default=False,
                     help='Downloads assessment items from the url specified by settings.ASSESSMENT_ITEMS_ZIP_URL, without interaction'),
+        make_option('-i', '--no-assessment-items',
+                    action='store_true',
+                    dest='no-assessment-items',
+                    default=False,
+                    help='Skip all steps associating with assessment item downloading or the assessment item database'),
         make_option('-g', '--git-migrate',
                     action='store',
                     dest='git_migrate_path',
@@ -360,73 +365,79 @@ class Command(BaseCommand):
         call_command(
             "syncdb", interactive=False, verbosity=options.get("verbosity"))
         call_command("migrate", merge=True, verbosity=options.get("verbosity"))
-        # Create *.json and friends database
-        call_command("syncdb", interactive=False, verbosity=options.get(
-            "verbosity"), database="assessment_items")
 
         # download assessment items
         # This can take a long time and lead to Travis stalling. None of this
-        # is required for tests.
+        # is required for tests, and does not apply to the central server.
+        if options.get("no-assessment-items", False):
 
-        # Outdated location of assessment items
-        # TODO(benjaoming) for 0.15, remove this
-        writable_assessment_items = os.access(
-            settings.KHAN_ASSESSMENT_ITEM_ROOT, os.W_OK)
+            logging.warning("Skipping assessment item downloading and configuration.")
 
-        def _move_to_new_location(old, new):
-            if not writable_assessment_items:
-                return
-            if os.path.exists(old):
-                if os.access(settings.KHAN_CONTENT_PATH, os.W_OK):
-                    os.rename(old, new)
-        _move_to_new_location(
-            os.path.join(settings.KHAN_CONTENT_PATH, 'assessmentitems.sqlite'),
-            settings.KHAN_ASSESSMENT_ITEM_DATABASE_PATH
-        )
-        _move_to_new_location(
-            os.path.join(
-                settings.KHAN_CONTENT_PATH, 'assessmentitems.version'),
-            settings.KHAN_ASSESSMENT_ITEM_VERSION_PATH
-        )
-        _move_to_new_location(
-            os.path.join(
-                settings.USER_DATA_ROOT, "data", "khan", "assessmentitems.json"),
-            settings.KHAN_ASSESSMENT_ITEM_JSON_PATH
-        )
-        if writable_assessment_items and options['force-assessment-item-dl']:
-            call_command(
-                "unpack_assessment_zip", settings.ASSESSMENT_ITEMS_ZIP_URL)
-        elif options['force-assessment-item-dl']:
-            raise RuntimeError(
-                "Got force-assessment-item-dl but directory not writable")
-        elif writable_assessment_items and not settings.RUNNING_IN_TRAVIS and options['interactive']:
-            print(
-                "\nStarting in version 0.13, you will need an assessment items package in order to access many of the available exercises.")
-            print(
-                "If you have an internet connection, you can download the needed package. Warning: this may take a long time!")
-            print(
-                "If you have already downloaded the assessment items package, you can specify the file in the next step.")
-            print("Otherwise, we will download it from {url}.".format(
-                url=settings.ASSESSMENT_ITEMS_ZIP_URL))
+        else:
 
-            if raw_input_yn("Do you wish to download the assessment items package now?"):
-                ass_item_filename = settings.ASSESSMENT_ITEMS_ZIP_URL
-            elif raw_input_yn("Have you already downloaded the assessment items package?"):
-                ass_item_filename = get_assessment_items_filename()
+            # Create *.json and friends database
+            call_command("syncdb", interactive=False, verbosity=options.get(
+                "verbosity"), database="assessment_items")
+
+            # Outdated location of assessment items
+            # TODO(benjaoming) for 0.15, remove this
+            writable_assessment_items = os.access(
+                settings.KHAN_ASSESSMENT_ITEM_ROOT, os.W_OK)
+
+            def _move_to_new_location(old, new):
+                if not writable_assessment_items:
+                    return
+                if os.path.exists(old):
+                    if os.access(settings.KHAN_CONTENT_PATH, os.W_OK):
+                        os.rename(old, new)
+            _move_to_new_location(
+                os.path.join(settings.KHAN_CONTENT_PATH, 'assessmentitems.sqlite'),
+                settings.KHAN_ASSESSMENT_ITEM_DATABASE_PATH
+            )
+            _move_to_new_location(
+                os.path.join(
+                    settings.KHAN_CONTENT_PATH, 'assessmentitems.version'),
+                settings.KHAN_ASSESSMENT_ITEM_VERSION_PATH
+            )
+            _move_to_new_location(
+                os.path.join(
+                    settings.USER_DATA_ROOT, "data", "khan", "assessmentitems.json"),
+                settings.KHAN_ASSESSMENT_ITEM_JSON_PATH
+            )
+            if writable_assessment_items and options['force-assessment-item-dl']:
+                call_command(
+                    "unpack_assessment_zip", settings.ASSESSMENT_ITEMS_ZIP_URL)
+            elif options['force-assessment-item-dl']:
+                raise RuntimeError(
+                    "Got force-assessment-item-dl but directory not writable")
+            elif writable_assessment_items and not settings.RUNNING_IN_TRAVIS and options['interactive']:
+                print(
+                    "\nStarting in version 0.13, you need an assessment items package in order to access many of the available exercises.")
+                print(
+                    "If you have an internet connection, you can download the needed package. Warning: this may take a long time!")
+                print(
+                    "If you have already downloaded the assessment items package, you can specify the file in the next step.")
+                print("Otherwise, we will download it from {url}.".format(
+                    url=settings.ASSESSMENT_ITEMS_ZIP_URL))
+
+                if raw_input_yn("Do you wish to download the assessment items package now?"):
+                    ass_item_filename = settings.ASSESSMENT_ITEMS_ZIP_URL
+                elif raw_input_yn("Have you already downloaded the assessment items package?"):
+                    ass_item_filename = get_assessment_items_filename()
+                else:
+                    ass_item_filename = None
+
+                if not ass_item_filename:
+                    logging.warning(
+                        "No assessment items package file given. You will need to download and unpack it later.")
+                else:
+                    call_command("unpack_assessment_zip", ass_item_filename)
+            elif options['interactive']:
+                logging.warning(
+                    "Assessment item directory not writable, skipping download.")
             else:
-                ass_item_filename = None
-
-            if not ass_item_filename:
                 logging.warning(
                     "No assessment items package file given. You will need to download and unpack it later.")
-            else:
-                call_command("unpack_assessment_zip", ass_item_filename)
-        elif options['interactive']:
-            logging.warning(
-                "Assessment item directory not writable, skipping download.")
-        else:
-            logging.warning(
-                "No assessment items package file given. You will need to download and unpack it later.")
 
         # Individually generate any prerequisite models/state that is missing
         if not Settings.get("private_key"):


### PR DESCRIPTION
Fixes:
- Link to KA Lite website was out of date
- Python version was being display in non-human-readable form
- There was no way to skip assessment item stuff (e.g. database migrations) on central server