### PR TITLE
Deleting "← Back to Facilities" link on student Progress report page

### DIFF
--- a/kalite/coachreports/templates/coachreports/student_view.html
+++ b/kalite/coachreports/templates/coachreports/student_view.html
@@ -30,7 +30,8 @@
 
 {% block content %}
     {{ block.super }}
-    
+
+    <!-- Radina: Commenting out for now to make sure it doesn't break anything before deleting
     <div class="row">
         <div class="col-md-12">
             <p class="pull-left">
@@ -40,6 +41,7 @@
             </p>
         </div>
     </div>
+    -->
 
     {% block student_report %}
         <div class="container">

--- a/kalite/coachreports/templates/coachreports/student_view.html
+++ b/kalite/coachreports/templates/coachreports/student_view.html
@@ -31,18 +31,6 @@
 {% block content %}
     {{ block.super }}
 
-    <!-- Radina: Commenting out for now to make sure it doesn't break anything before deleting
-    <div class="row">
-        <div class="col-md-12">
-            <p class="pull-left">
-                <a href="{% url 'facility_management' zone_id=None facility_id=facility_id %}">
-                    &#x2190; {% trans "Back to Facilities" %}
-                </a>
-            </p>
-        </div>
-    </div>
-    -->
-
     {% block student_report %}
         <div class="container">
             <div id="student-progress-container"></div>


### PR DESCRIPTION
Should fix #3927. 

It doesn't seem to break anything on my end, but I'll test some more (and do a rebase :P ) before merging. 