### PR TITLE
Optimizing content recommendations page for screen readers

### DIFF
--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.css
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.css
@@ -496,6 +496,11 @@ table td.title {
 .panel-heading h3 {
     margin: 10px 0;
 }
+.panel-heading h1.title {
+    color: white;
+    font-family: Helvetica, Arial, sans-serif ;
+    font-size: 24px;
+}
 .panel-heading span.title {
     color: white;
     font-family: Helvetica, Arial, sans-serif ;

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -934,7 +934,7 @@ to items you want to have the icon appear with.
     margin-top:30px
 }
 
-/* TODO Radina: styles to be revised upon browserify */
+/* Additional styles for content-rec */
 
 .gly-h1 {
     font-size: 36px;

--- a/kalite/distributed/static/css/distributed/khan-lite.css
+++ b/kalite/distributed/static/css/distributed/khan-lite.css
@@ -934,5 +934,14 @@ to items you want to have the icon appear with.
     margin-top:30px
 }
 
+/* TODO Radina: styles to be revised upon browserify */
 
+.gly-h1 {
+    font-size: 36px;
+    margin-bottom: 10px;
+    margin-top: 20px;
+}
 
+.up10 {
+    margin-top: 10px;
+}

--- a/kalite/distributed/static/js/distributed/content/hbtemplates/content-wrapper.handlebars
+++ b/kalite/distributed/static/js/distributed/content/hbtemplates/content-wrapper.handlebars
@@ -14,7 +14,7 @@
 
                     {{#if dubs_available }}
 
-                    <h3>
+                    <span class="h3">
                         <select class="content-language-selector">
                             {{#each availability }}
                             <option value="{{ @key }}" {{#ifcond @key "==" ../selected_language }}selected{{/ifcond}}>
@@ -22,10 +22,9 @@
                             </option>
                             {{/each}}
                         </select>
-                    </h3>
+                    </span>
                     {{/if}}
 
-                    {{!-- Title should go inside H1 element. TODO Radina - add proper CSS after browserify --}}
                     <h1 class="title">{{ title }}</h1>
                     {{#if organization}}
                         <span class="organization">{{_ "by:" }} {{ organization }}</span>

--- a/kalite/distributed/static/js/distributed/content/hbtemplates/content-wrapper.handlebars
+++ b/kalite/distributed/static/js/distributed/content/hbtemplates/content-wrapper.handlebars
@@ -13,6 +13,7 @@
                     </div>
 
                     {{#if dubs_available }}
+
                     <h3>
                         <select class="content-language-selector">
                             {{#each availability }}
@@ -24,7 +25,8 @@
                     </h3>
                     {{/if}}
 
-                    <span class="title">{{ title }}</span>
+                    {{!-- Title should go inside H1 element. TODO Radina - add proper CSS after browserify --}}
+                    <h1 class="title">{{ title }}</h1>
                     {{#if organization}}
                         <span class="organization">{{_ "by:" }} {{ organization }}</span>
                     {{/if}}

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-explore-topic.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-explore-topic.handlebars
@@ -3,17 +3,17 @@
   <div class="content-explore-topic">
     <div class="row">
       <div class="col-xs-12">
-          <h4><small>{{_ "Based on your interest in" }} {{ interest_topic.title }}:</small></h4>
+          <p class="up10">{{_ "Based on your interest in" }} <b>{{ interest_topic.title }}</b><span class="sr-only">{{_ ", we recommend you" }}</span>:</p>
       </div>
     </div>
     <div class="row">
       <div class="col-xs-5">
-          <h3>{{ suggested_topic.title }}:</h3>
+          <h2 class="h3">{{ suggested_topic.title }}:</h2>
       </div>
       {{#if suggested_topic.description }}
       <div class="col-xs-7">
-        <h4>{{_ "Description" }}:</h4>
-        <p>{{ truncate suggested_topic.description 70 }}</p>
+        <p class="h4">{{_ "Description" }}:</p>
+        <p>{{ truncate suggested_topic.description 100 }}</p>
       </div>
       {{/if}}
       <hr class="module_divider" />

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-explore.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-explore.handlebars
@@ -5,7 +5,7 @@
         <h1 class="card-title">{{_ "Explore" }}</h1>
       </div>
       <div class="col-xs-3">
-          <span class="glyphicon glyphicon-road gly-h1" aria-hidden="true" role="presentation"></span>
+          <span aria-hidden="true" role="presentation"><i class="glyphicon glyphicon-road gly-h1"></i></span>
       </div>
       <hr class="module_divider"/>
   </div>

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-explore.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-explore.handlebars
@@ -2,10 +2,10 @@
   <!--This is where the card title is-->
   <div class="row card-title">
       <div class="col-xs-9">
-        <h1 class="card-title">Explore</h1>
+        <h1 class="card-title">{{_ "Explore" }}</h1>
       </div>
       <div class="col-xs-3">
-      <h1 class="glyphicon glyphicon-road" aria-hidden="true"></h1>
+          <span class="glyphicon glyphicon-road gly-h1" aria-hidden="true" role="presentation"></span>
       </div>
       <hr class="module_divider"/>
   </div>

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-nextsteps-lesson.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-nextsteps-lesson.handlebars
@@ -3,28 +3,36 @@
 	<a href="/learn/{{ path }}">
       <div class="col-xs-3">
         <center>
+        <!--ALT for image gets read from 'description' so it doesn't need to be read twice-->
           {{#if content_urls.thumbnail }}
-          <img src="{{content_urls.thumbnail}}" class="img-responsive">
+          <img src="{{content_urls.thumbnail}}" class="img-responsive"
+              {{#if description }}
+                  aria-hidden="true" role="presentation"
+              {{else}}
+                  alt="{{ truncate description 150 }}"
+              {{/if}}>
           {{else}}
-          <h1 class="icon-{{kind}} glyphicon-expand"></h1>
+          <span class="icon-{{kind}} glyphicon glyphicon-expand gly-h1" aria-hidden="true" role="presentation"></span>
           {{/if}}
         </center>
       </div>
 
       <div class="col-xs-6">
-          <h4>
-            <small>{{ topic.title }}:</small>
+          <h2 class="h4">
+            <span class="small">{{ topic.title }}:</span>
             <br />
             {{ title }}
-        </h4>
+          </h2>
       </div>
     </a>
     <!--The URL without the specific video, so that we see the path
     along the nav and show them the entire series-->
     <a href="/learn/{{ topic.path }}">
       <div class="col-xs-3">
-          <h4>Topic</h4>
-          <span class="ns_series_arrow glyphicon glyphicon-arrow-right" aria-hidden="true"></span>
+          <p class="h4">{{_ "Topic" }}:</p>
+          <span class="ns_series_arrow glyphicon glyphicon-arrow-right" aria-hidden="true" role="presentation"></span>
+          <!--Radina: Since glyph is invisible, adding 'sr-only' topic title-->
+          <span class="sr-only">{{ topic.title }}</span>
       </div>
     </a>
 <hr class="module_divider">

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-nextsteps-lesson.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-nextsteps-lesson.handlebars
@@ -12,7 +12,7 @@
                   alt="{{ truncate description 150 }}"
               {{/if}}>
           {{else}}
-          <span class="icon-{{kind}} glyphicon glyphicon-expand gly-h1" aria-hidden="true" role="presentation"></span>
+          <span aria-hidden="true" role="presentation"><i class="icon-{{kind}} glyphicon glyphicon-expand gly-h1"></i></span>
           {{/if}}
         </center>
       </div>
@@ -30,7 +30,7 @@
     <a href="/learn/{{ topic.path }}">
       <div class="col-xs-3">
           <p class="h4">{{_ "Topic" }}:</p>
-          <span class="ns_series_arrow glyphicon glyphicon-arrow-right" aria-hidden="true" role="presentation"></span>
+          <span aria-hidden="true" role="presentation"><i class="ns_series_arrow glyphicon glyphicon-arrow-right"></i></span>
           <!--Radina: Since glyph is invisible, adding 'sr-only' topic title-->
           <span class="sr-only">{{ topic.title }}</span>
       </div>

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-nextsteps.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-nextsteps.handlebars
@@ -2,10 +2,10 @@
   <!--This is where the title to the card goes-->
   <div class="row card-title">
       <div class="col-xs-9">
-          <h1>Next Steps</h1>
+          <h1>{{_ "Next Steps" }}</h1>
       </div>
       <div class="col-xs-3">
-          <h1 class="glyphicon glyphicon-ok" aria-hidden="true"></h1>
+          <span class="glyphicon glyphicon-ok gly-h1" aria-hidden="true" role="presentation"></span>
       </div>
     <hr class="module_divider"/>
   </div>

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-nextsteps.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-nextsteps.handlebars
@@ -5,7 +5,7 @@
           <h1>{{_ "Next Steps" }}</h1>
       </div>
       <div class="col-xs-3">
-          <span class="glyphicon glyphicon-ok gly-h1" aria-hidden="true" role="presentation"></span>
+          <span aria-hidden="true" role="presentation"><i class="glyphicon glyphicon-ok gly-h1"></i></span>
       </div>
     <hr class="module_divider"/>
   </div>

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-resume.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-resume.handlebars
@@ -5,7 +5,7 @@
       <h1>{{_ "Resume" }}</h1>
     </div>
     <div class="col-xs-3">
-      <h1 class="glyphicon glyphicon-play-circle" aria-hidden="true"></h1>
+      <span class="glyphicon glyphicon-play-circle gly-h1" aria-hidden="true" role="presentation"></span>
     </div>
     <hr class="module_divider" />
   </div>
@@ -16,21 +16,27 @@
       <div class="row">
         <center>
           <div class="col-xs-12">
-            <h4>{{ title }}</h4>
+            <h2 class="h4">{{ title }}</h2>
           </div>
         </center>
       </div>
       <div class="row">
         <div class="col-xs-12">
           <center>
-            <img src="{{content_urls.thumbnail}}" class="img-responsive" alt="{{ truncate description 100 }}">
+          <!--ALT for image gets read from 'description' so it doesn't need to be read twice-->
+            <img src="{{content_urls.thumbnail}}" class="img-responsive"
+                 {{#if description }}
+                     aria-hidden="true" role="presentation"
+                 {{else}}
+                     alt="{{ truncate description 150 }}"
+                 {{/if}}>
           </center>
         </div>
       </div>
         {{#if description }}
         <div class="row">
           <div class="col-xs-12">
-            <h3>{{_ "Description" }}:</h3>
+            <p class="h3">{{_ "Description" }}:</p>
           </div>
         </div>
         <div class="row">
@@ -43,13 +49,13 @@
       <div class="row">
         <div class="col-xs-3">
           <center>
-            <h1 id="exercise-icon" class="icon-{{kind}} glyphicon-expand"></h1>
+            <span id="exercise-icon" class="icon-{{kind}} glyphicon glyphicon-pencil gly-h1" aria-hidden="true" role="presentation"></span>
           </center>
         </div> 
         
         <div class="col-xs-9">
-          <h4><small>{{_ "Exercise" }}:</small></h4>
-          <h4>{{ title }}</h4>
+          <h2 class="h4">{{_ "Exercise" }}:<br />
+          {{ title }}</h2>
         </div>
         
 <!-- NO descriptions for excercise? Is it necessary?

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-resume.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-resume.handlebars
@@ -5,7 +5,7 @@
       <h1>{{_ "Resume" }}</h1>
     </div>
     <div class="col-xs-3">
-      <span class="glyphicon glyphicon-play-circle gly-h1" aria-hidden="true" role="presentation"></span>
+      <span aria-hidden="true" role="presentation"><i class="glyphicon glyphicon-play-circle gly-h1"></i></span>
     </div>
     <hr class="module_divider" />
   </div>
@@ -49,7 +49,7 @@
       <div class="row">
         <div class="col-xs-3">
           <center>
-            <span id="exercise-icon" class="icon-{{kind}} glyphicon glyphicon-pencil gly-h1" aria-hidden="true" role="presentation"></span>
+            <span aria-hidden="true" role="presentation"><i id="exercise-icon" class="icon-{{kind}} glyphicon glyphicon-pencil gly-h1"></i></span>
           </center>
         </div> 
         

--- a/kalite/distributed/static/js/distributed/exercises/hbtemplates/exercise.handlebars
+++ b/kalite/distributed/static/js/distributed/exercises/hbtemplates/exercise.handlebars
@@ -1,5 +1,4 @@
- {{!-- Title should go inside H1 element. TODO Radina - add proper CSS after browserify --}}
-<h1 class="row">
+<h1 class="h3 row">
     <div class="col-xs-12">
         <span class="exercise-title-prefix">{{#if test_id }}{{_ "Test" }}{{ else }}{{_ "Practicing" }}{{/if }}</span>
         <span class="exercise-title">{{ title }}</span>

--- a/kalite/distributed/static/js/distributed/exercises/hbtemplates/exercise.handlebars
+++ b/kalite/distributed/static/js/distributed/exercises/hbtemplates/exercise.handlebars
@@ -1,10 +1,11 @@
-<h3 class="row">
+ {{!-- Title should go inside H1 element. TODO Radina - add proper CSS after browserify --}}
+<h1 class="row">
     <div class="col-xs-12">
         <span class="exercise-title-prefix">{{#if test_id }}{{_ "Test" }}{{ else }}{{_ "Practicing" }}{{/if }}</span>
         <span class="exercise-title">{{ title }}</span>
     {{#if description }}<br/><span class="practice-exercise-description">{{ description }}</span>{{/if }}
     </div>
-</h3>
+</h1>
 
 <div class="row">
     <div class="exercises-body col-sm-12">

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -153,7 +153,7 @@
                   <div class="row">
                       <div class="navbar-header">
                           {# collapse entire menu #}
-                          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse" aria-label="Open menu" id="navbar_toggle">
+                          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse" aria-hidden="true" id="navbar_toggle">
                               <span class="icon-bar"></span>
                               <span class="icon-bar"></span>
                               <span class="icon-bar"></span>

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -153,7 +153,7 @@
                   <div class="row">
                       <div class="navbar-header">
                           {# collapse entire menu #}
-                          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse" aria-hidden="true" id="navbar_toggle">
+                          <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse" aria-label="Open menu" id="navbar_toggle">
                               <span class="icon-bar"></span>
                               <span class="icon-bar"></span>
                               <span class="icon-bar"></span>


### PR DESCRIPTION
**Before:**  

![contentrec-before](https://cloud.githubusercontent.com/assets/1457929/8700197/ce862640-2b0a-11e5-8da3-75b6631862ed.png)  

**After:**

![contentrec-after](https://cloud.githubusercontent.com/assets/1457929/8700206/d9c2441c-2b0a-11e5-8d2f-30696b8bce98.png)

Mostly rearranging & styling headers, rendering icon fonts properly invisible, adding some `sr-only` spans and conditions so descriptions do not get read twice.   