### PR TITLE
Optimizing Student Progress Report page for screen readers

### DIFF
--- a/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
+++ b/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
@@ -1,27 +1,32 @@
 <div class="well">
     <div class="row">
         <div class="col-xs-12">
-            <h3 class="playlist-title center-block">
+            <span class="sr-only">{{_ "In topic " }}</span>
+            <h2 class="h3 playlist-title center-block">
                 <a href="{{this.url}}">{{title}}</a>
-            </h3>
+            </h2>
         </div>
     </div>
     {{!-- Videos --}}
     <div class="row progress-block">
         <div class="col-xs-2">
             <div class="progress-indicator progress-indicator-lg center-block {{vid_status}}">
+                <span class="sr-only">{{_ "There are " }}</span>
                 <div class="sidebar-icon icon-Video icon-label icon-label-lg"><span class="progress-indicator content-counter label label-primary">{{#if n_pl_videos}}{{n_pl_videos}}{{/if}}</span></div>
+                <span class="sr-only">{{_ " videos." }}</span>
             </div>
         </div>
         <div class="col-xs-10">
             <div class="progress playlist-progress-bar">
                 {{#if vid_pct_complete}}
                     <div class="progress-bar progress-bar-success" title="% Completed" style="width: {{vid_pct_complete}}%">
+                        <span class="sr-only">{{_ "Of those you have completed " }}</span>
                         <span>{{vid_pct_complete}}%</span>
                     </div>
                 {{/if}}
                 {{#if vid_pct_started}}
                     <div class="progress-bar inprogress" title="% In-Progress" style="width: {{vid_pct_started}}%">
+                        <span class="sr-only">{{_ "And you are still working on " }}</span>
                         <span>{{vid_pct_started}}%</span>
                     </div>
                 {{/if}}
@@ -32,23 +37,28 @@
     <div class="row progress-block">
         <div class="col-xs-2">
             <div class="progress-indicator progress-indicator-lg center-block {{ex_status}}">
+                <span class="sr-only">{{_ "There are " }}</span>
                 <div class="sidebar-icon icon-Exercise icon-label icon-label-lg"><span class="progress-indicator content-counter label label-primary">{{#if n_pl_exercises}}{{n_pl_exercises}}{{/if}}</span></div>
+                <span class="sr-only">{{_ " exercises." }}</span>
             </div>
         </div>
         <div class="col-xs-10">
             <div class="progress playlist-progress-bar">
                 {{#if ex_pct_mastered}}
                     <div class="progress-bar progress-bar-success" title="% Mastered" style="width: {{ex_pct_mastered}}%">
+                        <span class="sr-only">{{_ "Of those you have mastered " }}</span>
                         <span>{{ex_pct_mastered}}%</span>
                     </div>
                 {{/if}}
                 {{#if ex_pct_incomplete}}
                     <div class="progress-bar inprogress" title="% In-Progress" style="width: {{ex_pct_incomplete}}%">
+                        <span class="sr-only">{{_ "You are still working on " }}</span>
                         <span>{{ex_pct_incomplete}}%</span>
                     </div>
                 {{/if}}
                 {{#if ex_pct_struggling}}
                     <div class="progress-bar struggling" title="% Struggling" style="width: {{ex_pct_struggling}}%">
+                        <span class="sr-only">{{_ "And seem to be struggling with " }}</span>
                         <span>{{ex_pct_struggling}}%</span>
                     </div>
                 {{/if}}
@@ -76,7 +86,7 @@
     {{/if}}
     <div class="row">
         <div class="col-xs-12">
-            <button class="btn btn-sm btn-primary center-block toggle-details"><span class="expand-collapse glyphicon glyphicon-chevron-down"></span></button>
+            <button class="btn btn-sm btn-primary center-block toggle-details" aria-label="Press to open detailed view"><span class="expand-collapse glyphicon glyphicon-chevron-down"></span></button>
         </div>
     </div>
     <div class="row playlist-progress-details">

--- a/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
+++ b/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
@@ -1,26 +1,28 @@
 <div class="well">
     <div class="row">
         <div class="col-xs-12">
-            <span class="sr-only">{{_ "In topic " }}</span>
             <h2 class="h3 playlist-title center-block">
                 <a href="{{this.url}}">{{title}}</a>
             </h2>
+            <div class="sr-only">{{_ "In this topic " }}</div>
         </div>
     </div>
     {{!-- Videos --}}
     <div class="row progress-block">
         <div class="col-xs-2">
             <div class="progress-indicator progress-indicator-lg center-block {{vid_status}}">
-                <span class="sr-only">{{_ "There are " }}</span>
-                <div class="sidebar-icon icon-Video icon-label icon-label-lg"><span class="progress-indicator content-counter label label-primary">{{#if n_pl_videos}}{{n_pl_videos}}{{/if}}</span></div>
+                <span class="sr-only">{{_ "there are " }}</span>
+                <div class="sidebar-icon icon-Video icon-label icon-label-lg"><span class="progress-indicator content-counter label label-primary"><div class="sr-only">{{#unless n_pl_videos}}no{{/unless}}</div>{{#if n_pl_videos}}{{n_pl_videos}}{{/if}}</span></div>
                 <span class="sr-only">{{_ " videos." }}</span>
             </div>
         </div>
         <div class="col-xs-10">
             <div class="progress playlist-progress-bar">
-                {{#unless vid_pct_started}}
-                    <span class="sr-only">{{_ "You haven't started to watch videos! " }}</span>
-                {{/unless}}
+                {{#if n_pl_videos}}
+                    {{#unless vid_pct_started}}
+                        <span class="sr-only">{{_ "You haven't started to watch videos! " }}</span>
+                    {{/unless}}
+                {{/if}}
                 {{#if vid_pct_complete}}
                     <div class="progress-bar progress-bar-success" title="% Completed" style="width: {{vid_pct_complete}}%">
                         <span class="sr-only">{{_ "Of those you have completed " }}</span>
@@ -41,14 +43,16 @@
         <div class="col-xs-2">
             <div class="progress-indicator progress-indicator-lg center-block {{ex_status}}">
                 <span class="sr-only">{{_ "There are " }}</span>
-                <div class="sidebar-icon icon-Exercise icon-label icon-label-lg"><span class="progress-indicator content-counter label label-primary">{{#if n_pl_exercises}}{{n_pl_exercises}}{{/if}}</span></div>
+                <div class="sidebar-icon icon-Exercise icon-label icon-label-lg"><span class="progress-indicator content-counter label label-primary"><div class="sr-only">{{#unless n_pl_exercises}}no{{/unless}}</div>{{#if n_pl_exercises}}{{n_pl_exercises}}{{/if}}</span></div>
                 <span class="sr-only">{{_ " exercises." }}</span>
             </div>
         </div>
         <div class="col-xs-10">
             <div class="progress playlist-progress-bar">
-                {{#if ex_status.notstarted}}
-                    <span class="sr-only">{{_ "You haven't started to work on exercises! " }}</span>
+                {{#if n_pl_exercises}}
+                    {{#if ex_status.notstarted}}
+                        <span class="sr-only">{{_ "You haven't started to work on exercises! " }}</span>
+                    {{/if}}
                 {{/if}}
                 {{#if ex_pct_mastered}}
                     <div class="progress-bar progress-bar-success" title="% Mastered" style="width: {{ex_pct_mastered}}%">

--- a/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
+++ b/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
@@ -31,8 +31,14 @@
                 {{/if}}
                 {{#if vid_pct_started}}
                     <div class="progress-bar inprogress" title="% In-Progress" style="width: {{vid_pct_started}}%">
-                        <span class="sr-only">{{_ "And you are still working on " }}</span>
+                    {{#ifcond vid_pct_started "<" 100}}
+                        <span class="sr-only">{{_ "You are still working on " }}</span>
                         <span>{{vid_pct_started}}%</span>
+                    {{/ifcond}}
+                    {{#ifcond vid_pct_started "===" 100}}
+                        <span class="sr-only">{{_ "You are still working on all of them." }}</span>
+                        <span aria-hidden="true" role="presentation">{{vid_pct_started}}%</span>
+                    {{/ifcond}}
                     </div>
                 {{/if}}
             </div>
@@ -62,8 +68,14 @@
                 {{/if}}
                 {{#if ex_pct_incomplete}}
                     <div class="progress-bar inprogress" title="% In-Progress" style="width: {{ex_pct_incomplete}}%">
+                    {{#ifcond ex_pct_incomplete "<" 100}}
                         <span class="sr-only">{{_ "You are still working on " }}</span>
                         <span>{{ex_pct_incomplete}}%</span>
+                    {{/ifcond}}
+                    {{#ifcond ex_pct_incomplete "===" 100}}
+                        <span class="sr-only">{{_ "You are still working on all of them." }}</span>
+                        <span aria-hidden="true" role="presentation">{{ex_pct_incomplete}}%</span>
+                    {{/ifcond}}
                     </div>
                 {{/if}}
                 {{#if ex_pct_struggling}}
@@ -82,7 +94,7 @@
             <div class="progress-indicator progress-indicator-lg center-block {{quiz_status}}">
                 <span class="sr-only">{{_ "There are " }}</span>
                 <span class="sidebar-icon icon-Quiz icon-label icon-label-lg"></span>
-                <span class="sr-only">{{_ " quizes." }}</span>
+                <span class="sr-only">{{_ " quizzes." }}</span>
             </div>
         </div>
         <div class="col-xs-10">

--- a/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
+++ b/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
@@ -18,6 +18,9 @@
         </div>
         <div class="col-xs-10">
             <div class="progress playlist-progress-bar">
+                {{#unless vid_pct_started}}
+                    <span class="sr-only">{{_ "You haven't started to watch videos! " }}</span>
+                {{/unless}}
                 {{#if vid_pct_complete}}
                     <div class="progress-bar progress-bar-success" title="% Completed" style="width: {{vid_pct_complete}}%">
                         <span class="sr-only">{{_ "Of those you have completed " }}</span>
@@ -44,6 +47,9 @@
         </div>
         <div class="col-xs-10">
             <div class="progress playlist-progress-bar">
+                {{#if ex_status.notstarted}}
+                    <span class="sr-only">{{_ "You haven't started to work on exercises! " }}</span>
+                {{/if}}
                 {{#if ex_pct_mastered}}
                     <div class="progress-bar progress-bar-success" title="% Mastered" style="width: {{ex_pct_mastered}}%">
                         <span class="sr-only">{{_ "Of those you have mastered " }}</span>
@@ -70,13 +76,17 @@
     <div class="row progress-block">
         <div class="col-xs-2">
             <div class="progress-indicator progress-indicator-lg center-block {{quiz_status}}">
+                <span class="sr-only">{{_ "There are " }}</span>
                 <span class="sidebar-icon icon-Quiz icon-label icon-label-lg"></span>
+                <span class="sr-only">{{_ " quizes." }}</span>
             </div>
         </div>
         <div class="col-xs-10">
             <div class="progress playlist-progress-bar">
                 {{#if quiz_pct_score}}
                 <div class="progress-bar {{quiz_status}}" title="% Score" style="width: {{quiz_pct_score}}%">
+                    {{!-- Radina: TODO - revise once quizzes are operational --}}
+                    <span class="sr-only">{{_ "And your score is " }}</span>
                     <span>{{quiz_pct_score}}%</span>
                 </div>
                 {{/if}}
@@ -91,7 +101,7 @@
     </div>
     <div class="row playlist-progress-details">
         <div class="col-xs-12">
-            <img class="center-block" src="/static/images/loading.gif"/>    
+            <img class="center-block" src="/static/images/loading.gif" aria-hidden="true" role="presentation"/>
         </div>
     </div>
 </div>

--- a/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-details.handlebars
+++ b/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-details.handlebars
@@ -2,26 +2,25 @@
     {{!-- Whole section is only for screen readers --}}
 <div class="sr-only">
         <a href="/learn/{{attributes.path}}"><h3>{{attributes.title}}</h3></a>
-        <div> 
-            <span>{{_ " Status: " }}
-            {{!-- Status info for sr-user. --}}
+        <div>{{!-- Status info for sr-user. --}}
+            {{_ " Status: " }}
             {{#ifcond attributes.status "===" "complete"}}
-                {{_ " Completed " }}
+                {{_ " Completed. " }}
             {{/ifcond}}
 
             {{#ifcond attributes.status "===" "inprogress"}}
-                {{_ " In progress " }}
+                {{_ " In progress. " }}
             {{/ifcond}}
 
             {{#ifcond attributes.status "===" "struggling"}}
-                {{_ " Struggling " }}
+                {{_ " Struggling. " }}
             {{/ifcond}}
             
             {{#ifcond attributes.status "===" "notstarted"}}
-                {{_ " Not started " }}
+                {{_ " Not started. " }}
             {{/ifcond}}                
-               
-            </span>
+        </div>
+        <div>
             {{!-- Score info for sr-user. --}}
             {{!-- Video --}}
             {{#ifcond attributes.kind "===" "Video"}}
@@ -37,7 +36,6 @@
             {{#ifcond attributes.kind "===" "Quiz"}}
                 <span>{{_ " For this quiz your score is " }}{{attributes.score}}%.</span>
             {{/ifcond}}
-            
         </div>
 </div>
 {{!-- Whole section is rendered invisible to screen readers --}}

--- a/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-details.handlebars
+++ b/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-details.handlebars
@@ -1,5 +1,47 @@
 {{#each data}}
-<div class="col-xs-1 progress-block">
+    {{!-- Whole section is only for screen readers --}}
+<div class="sr-only">
+        <a href="/learn/{{attributes.path}}"><h3>{{attributes.title}}</h3></a>
+        <div> 
+            <span>{{_ " Status: " }}
+            {{!-- Status info for sr-user. --}}
+            {{#ifcond attributes.status "===" "complete"}}
+                {{_ " Completed " }}
+            {{/ifcond}}
+
+            {{#ifcond attributes.status "===" "inprogress"}}
+                {{_ " In progress " }}
+            {{/ifcond}}
+
+            {{#ifcond attributes.status "===" "struggling"}}
+                {{_ " Struggling " }}
+            {{/ifcond}}
+            
+            {{#ifcond attributes.status "===" "notstarted"}}
+                {{_ " Not started " }}
+            {{/ifcond}}                
+               
+            </span>
+            {{!-- Score info for sr-user. --}}
+            {{!-- Video --}}
+            {{#ifcond attributes.kind "===" "Video"}}
+                <span>{{_ " For this video you completed " }}{{attributes.score}}%.</span>
+            {{/ifcond}}
+
+            {{!-- Exercise --}}
+            {{#ifcond attributes.kind "===" "Exercise"}}
+                <span>{{_ " For this exercise your streak is " }}{{attributes.score}}%.</span>
+            {{/ifcond}}
+
+            {{!-- Quiz --}}
+            {{#ifcond attributes.kind "===" "Quiz"}}
+                <span>{{_ " For this quiz your score is " }}{{attributes.score}}%.</span>
+            {{/ifcond}}
+            
+        </div>
+</div>
+{{!-- Whole section is rendered invisible to screen readers --}}
+<div class="col-xs-1 progress-block" aria-hidden="true" role="presentation">
     <a href="/learn/{{attributes.path}}">
     <div 
         class="progress-indicator progress-indicator-sm {{attributes.status}}"

--- a/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/student-progress-container.handlebars
+++ b/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/student-progress-container.handlebars
@@ -1,2 +1,2 @@
-<h2>{{_ "Progress report" }}</h2>
+<h1 class="h2">{{_ "Progress report" }}</h1>
 <div id="playlists-container"></div>


### PR DESCRIPTION
#### UPDATE August 5 

This is technically finished, and I used `generaterealdata` function to test it with the learners from Wilson Elementary... :)
I can say I feel satisified, so, **review and merge away**! :)


##### UPDATE August 4
This is technically finished, but I'd like to test it more thoroughly with more content (waiting for the #4135 & #4157 ). So, **don't merge yet**! :)
  
  


Still **WIP**, but it's a lot of fun though, like trying to fit puzzle pieces... :)

##### playlist-progress-container.handlebars  
- [x] Videos
- [x] Exercises
- [x] Quizzes (We don't have those yet, right?)  -  *Oh Quizzes, we hardly knew ye!* by @rtibbles 
- [x] `sr-only` field for 0% progress bar for videos 
- [x] `sr-only` field for 0% progress bar for exercises 
- [x] Conditional logic for screen reader output in case of topics with only videos (& no exercises) or only exercises (& no videos).

- [x] I felt that the output `You are still working on 100%` was not sufficiently clear, so I added another condition to transform those cases in `You are still working on all of them` for both videos and exercises.

##### playlist-progress-details.handlebars
- [x] To avoid headaches about the support for `popover` class being flaky among different screen readers, I opted for rendering that whole section invisible with `aria-hidden="true"`, and then adding a new `sr-only` section with the same info for non-sighted users.

