### PR TITLE
Central coach reports

### DIFF
--- a/kalite/coachreports/api_resources.py
+++ b/kalite/coachreports/api_resources.py
@@ -13,25 +13,8 @@ class CoachReportBaseResource(Resource):
     in the API
     """
 
-    @classmethod
-    def permission_check(self, request):
-        """
-        Require that the users are logged in, and that the user is the same student 
-        whose data is being requested, an admin, or a teacher in that facility
-        """
-        if getattr(request, "is_logged_in", False):  
-            pass
-        else:
-            raise Unauthorized(_("You must be logged in to access this page."))
-
-        if getattr(request, "is_admin", False):
-            pass
-        else:
-            user = get_user_from_request(request=request)
-            if request.GET.get("user_id") == user.id:
-                pass
-            else:
-                raise Unauthorized(_("You requested information for a user that you are not authorized to view."))
+    class Meta:
+        authorization = UserObjectsOnlyAuthorization()
 
     def detail_uri_kwargs(self, bundle_or_obj):
         kwargs = {}

--- a/kalite/coachreports/api_resources.py
+++ b/kalite/coachreports/api_resources.py
@@ -4,7 +4,7 @@ from tastypie.resources import Resource
 
 from django.utils.translation import ugettext as _
 
-from kalite.shared.decorators.auth import get_user_from_request
+from kalite.shared.api_auth.auth import UserObjectsOnlyAuthorization
 from .models import PlaylistProgress, PlaylistProgressDetail
 
 class CoachReportBaseResource(Resource):

--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -23,7 +23,10 @@ def get_learners_from_GET(request):
     if learner_ids:
         learner_filter = Q(pk__in=learner_ids)
     elif group_ids:
-        learner_filter = Q(group__pk__in=group_ids)
+        if "Ungrouped" in group_ids:
+            learner_filter = Q(group__pk__in=group_ids) | Q(group__isnull=True)
+        else:
+            learner_filter = Q(group__pk__in=group_ids)
     else:
         # Do this to ensure that we never return more than one facility's worth of anything.
         learner_filter = Q(facility__pk__in=facility_ids)

--- a/kalite/coachreports/features/steps/coachreports.py
+++ b/kalite/coachreports/features/steps/coachreports.py
@@ -169,7 +169,7 @@ def impl(context):
 @then(u"I should see the list of two groups that I teach")
 def impl(context):
     dropdown = Select(find_id_with_wait(context, "group-select"))
-    assert len(dropdown.options) == 3, "Only {n} displayed".format(n=len(dropdown.options))
+    assert len(dropdown.options) == 4, "Only {n} displayed".format(n=len(dropdown.options))
 
 @then(u"there should be ten exercise columns displayed")
 def impl(context):

--- a/kalite/coachreports/static/js/coachreports/coach_reports/views.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/views.js
@@ -475,6 +475,7 @@ var FacilitySelectView = Backbone.View.extend({
             selected: this.model.get("facility")
         }));
         var id = this.model.get("facility");
+        // This nonsense of 'id' not being the Backbone 'id' is because of tastypie Resource URLs being used as model ids
         this.model.set({
             "facility_name": this.facility_list.find(function(model){ return model.get("id") === id;}).get("name")
         });
@@ -487,6 +488,7 @@ var FacilitySelectView = Backbone.View.extend({
 
     facility_changed: function() {
         var id = this.$(":selected").val();
+        // This nonsense of 'id' not being the Backbone 'id' is because of tastypie Resource URLs being used as model ids
         this.model.set({
             "facility": id,
             "facility_name": this.facility_list.find(function(model){ return model.get("id") === id;}).get("name")
@@ -512,6 +514,7 @@ var GroupSelectView = Backbone.View.extend({
         var self = this;
 
         // Add in 'All' and 'Ungrouped' groups if appropriate
+        // Might be better to add in to the parse method of the collection
         if (this.group_list.length > 0) {
             this.group_list.add({
                 id: "",
@@ -524,6 +527,7 @@ var GroupSelectView = Backbone.View.extend({
         }
 
         // Remove reference to groups from another facility
+        // This nonsense of 'id' not being the Backbone 'id' is because of tastypie Resource URLs being used as model ids
         if (!this.group_list.some(function(model){ return model.get("id") === self.model.get("group");})) {
             this.model.set({
                 "group": undefined,
@@ -537,6 +541,7 @@ var GroupSelectView = Backbone.View.extend({
         }));
 
         var id = this.model.get("group");
+        // This nonsense of 'id' not being the Backbone 'id' is because of tastypie Resource URLs being used as model ids
         this.model.set({
             "group_name": this.group_list.find(function(model){ return model.get("id") === id;}).get("name")
         });
@@ -550,6 +555,7 @@ var GroupSelectView = Backbone.View.extend({
 
     group_changed: function() {
         var id = this.$(":selected").val();
+        // This nonsense of 'id' not being the Backbone 'id' is because of tastypie Resource URLs being used as model ids
         this.model.set({
             "group": id,
             "group_name": this.group_list.find(function(model){ return model.get("id") === id;}).get("name")

--- a/kalite/control_panel/api_resources.py
+++ b/kalite/control_panel/api_resources.py
@@ -87,23 +87,7 @@ class FacilityGroupResource(ModelResource):
             else:
                 qs = FacilityGroup.objects.filter(facility__id__in=facility_ids)
 
-        # Flag to return only the FacilityGroup objects and not including the "All" and "Ungrouped" options.
-        # TODO(cpauya): how to convert this into a kwargs above instead of a request.GET?
-        groups_only = bundle.request.GET.get("groups_only", True)
-        if groups_only:
-            group_list = list(qs)
-        else:
-            default_list = []
-            if qs or ungrouped_available:
-                # add the "All" option
-                default_list = [FacilityGroup(id=ALL_KEY, name=_("All"))]
-
-                # add the "Ungrouped" option
-                if ungrouped_available:
-                    fg = FacilityGroup(id=UNGROUPED_KEY, name=_("Ungrouped"))
-                    default_list.append(fg)
-            # add all the facility group options for the user
-            group_list = default_list + list(qs)
+        group_list = list(qs)
 
         # call super to trigger auth
         return super(FacilityGroupResource, self).authorized_read_list(group_list, bundle)

--- a/kalite/distributed/static/js/distributed/content/views.js
+++ b/kalite/distributed/static/js/distributed/content/views.js
@@ -17,7 +17,7 @@ window.ContentWrapperView = BaseView.extend({
         if (this.data_model.get("id")) {
             this.data_model.fetch().then(function() {
                 window.statusModel.loaded.then(self.setup_content_environment);
-            })
+            });
         }
 
         

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -35,8 +35,7 @@ window.SuperUserCreateModalView = BaseView.extend({
                 }
             },
             error : function(e){
-                $('#superusercreate-container').html("<div class='alert alert-danger'>Cannot correctly load the admin creation form. " 
-                    + e.status + " (" + e.statusText + ")</div>");
+                $('#superusercreate-container').html("<div class='alert alert-danger'>Cannot correctly load the admin creation form. " + e.status + " (" + e.statusText + ")</div>");
                 console.log(e);
             }
         });

--- a/kalite/shared/api_auth/auth.py
+++ b/kalite/shared/api_auth/auth.py
@@ -3,6 +3,31 @@ from django.conf import settings
 from tastypie.exceptions import NotFound, Unauthorized
 from tastypie.authorization import Authorization, ReadOnlyAuthorization
 
+def _is_central_object_admin(object_list, bundle):
+    """Return true if the central server user is allowed to access the objects"""
+    user = bundle.request.user
+    if not user.is_authenticated():
+        return False
+    else:
+        # check that user can access each object we are returning 
+        for obj in object_list:
+            # note that this authorization only works for syncable objects
+            if not user.get_profile().has_permission_for_object(obj):
+                return False
+        return True
+
+
+def _user_is_admin(object_list, bundle):
+    """Returns True if and only if the currently logged in user is an admin/teacher."""
+
+    # allow central server superusers to do whatever they want
+    if settings.CENTRAL_SERVER and _is_central_object_admin(object_list, bundle):
+        return True
+
+    # allow local admins (teachers or administrators) to do anything too
+    if getattr(bundle.request, "is_admin", False):
+        return True
+
 
 class UserObjectsOnlyAuthorization(Authorization):
 
@@ -10,17 +35,6 @@ class UserObjectsOnlyAuthorization(Authorization):
         """Convenience method to extract current user from bundle."""
 
         return bundle.request.session.get("facility_user", None)
-
-    def _user_is_admin(self, bundle):
-        """Returns True if and only if the currently logged in user is an admin/teacher."""
-
-        # allow central server superusers to do whatever they want
-        if settings.CENTRAL_SERVER and bundle.request.user.is_superuser:
-            return True
-
-        # allow local admins (teachers or administrators) to do anything too
-        if getattr(bundle.request, "is_admin", False):
-            return True
 
     def _user_matches_query(self, bundle):
         """Returns True if and only if the user id in the query is the id of the currently logged in user."""
@@ -51,7 +65,7 @@ class UserObjectsOnlyAuthorization(Authorization):
 
     def read_list(self, object_list, bundle):
 
-        if self._user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return object_list
 
         if not self._user_matches_query(bundle):
@@ -61,14 +75,14 @@ class UserObjectsOnlyAuthorization(Authorization):
 
     def read_detail(self, object_list, bundle):
 
-        if self._user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return True
 
         return bundle.obj.user == self._get_user(bundle)
 
     def create_list(self, object_list, bundle):
 
-        if self._user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return object_list
 
         if not self._all_objects_belong_to_user(object_list, bundle):
@@ -78,14 +92,14 @@ class UserObjectsOnlyAuthorization(Authorization):
 
     def create_detail(self, object_list, bundle):
 
-        if self._user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return True
 
         return bundle.obj.user == self._get_user(bundle)
 
     def update_list(self, object_list, bundle):
 
-        if self._user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return object_list
 
         if not self._all_objects_belong_to_user(object_list, bundle):
@@ -95,7 +109,7 @@ class UserObjectsOnlyAuthorization(Authorization):
 
     def update_detail(self, object_list, bundle):
 
-        if self._user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return True
 
         if bundle.obj.user == self._get_user(bundle):
@@ -110,18 +124,6 @@ class UserObjectsOnlyAuthorization(Authorization):
 
     def delete_detail(self, object_list, bundle):
         raise Unauthorized("Sorry, that operation is restricted.")
-
-
-def _user_is_admin(bundle):
-    """Returns True if and only if the currently logged in user is an admin/teacher."""
-
-    # allow central server superusers to do whatever they want
-    if settings.CENTRAL_SERVER and bundle.request.user.is_superuser:
-        return True
-
-    # allow local admins (teachers or administrators) to do anything too
-    if getattr(bundle.request, "is_admin", False):
-        return True
 
 
 class AdminReadWriteAndStudentReadOnlyAuthorization(Authorization):
@@ -139,42 +141,42 @@ class AdminReadWriteAndStudentReadOnlyAuthorization(Authorization):
 
     def create_list(self, object_list, bundle):
 
-        if _user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return object_list
 
         return []
 
     def create_detail(self, object_list, bundle):
 
-        if _user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return True
 
         raise Unauthorized("You are not allowed to access that resource.")
 
     def update_list(self, object_list, bundle):
 
-        if _user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return object_list
 
         return []
 
     def update_detail(self, object_list, bundle):
 
-        if _user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return True
 
         raise Unauthorized("You are not allowed to access that resource.")
 
     def delete_list(self, object_list, bundle):
 
-        if _user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return object_list
 
         return []
 
     def delete_detail(self, object_list, bundle):
 
-        if _user_is_admin(bundle):
+        if _user_is_admin(object_list, bundle):
             return True
 
         raise Unauthorized(_("You are not allowed to access that resource."))


### PR DESCRIPTION
This PR makes changes to the coach reports that leave their functionality unchanged on the distributed server, but make them compatible with the Central Server code.

Summary of changes:
* Do not create dummy Django models for Groups 'All' and 'Ungrouped', instead dynamically generate those options on the client side.
* Use CENTRAL_SERVER aware permissions (borrowing from existing CENTRAL_SERVER compatible permissions code) for student progress reports.