### PR TITLE
Add a message telling the user to wait while downloading a video.

### DIFF
--- a/kalite/updates/views.py
+++ b/kalite/updates/views.py
@@ -28,8 +28,9 @@ def update_context(request):
 @render_to("updates/update_videos.html")
 def update_videos(request, max_to_show=4):
     context = update_context(request)
+    messages.warning(request, _('Downloading a video using Mac OS will take a while to start, please wait.'))
     messages.warning(request, _('For low-powered devices like the Raspberry Pi, please download less than 25 videos at a time.'))
-    if settings.DO_NOT_RELOAD_CONTENT_CACHE_AT_STARTUP:
+    if getattr(settings, "DO_NOT_RELOAD_CONTENT_CACHE_AT_STARTUP", False):
         messages.warning(request, _('After video download, the server must be restarted for them to be available to users.'))
     context.update({
         "video_count": VideoFile.objects.filter(percent_complete=100).count(),


### PR DESCRIPTION
@aronasorman. This fixes #3990.

Subprocess module will cause the video download not to start immediately for Mac OS users. So I created a message telling the user to wait during downloading a video.  