### PR TITLE
Docs tweaks

### DIFF
--- a/docs/developer_docs/documentation.rst
+++ b/docs/developer_docs/documentation.rst
@@ -14,7 +14,7 @@ Documentation development
 -------------------------
 
 #. Work from the *develop* branch.
-#. From the base directory, the documenation can be found in the ``docs/``
+#. From the base directory, the documentation can be found in the ``docs/``
    subdirectory. Specific pages of the docs are each associated with a different
    .rst file, potentially in a subdirectory of ``docs/``.
 #. The documentation is written in

--- a/docs/developer_docs/documentation.rst
+++ b/docs/developer_docs/documentation.rst
@@ -1,19 +1,48 @@
 How to contribute to documentation
 ==================================
 
-You can propose changes to the docs directly on github (instructions below) or email your recommendations to info@learningequality.org.
+You can propose changes to the docs directly on Github (instructions below) or
+email your recommendations to info@learningequality.org.
 
-To propose changes directly, you'll need to create an account on github and open a pull request. This document assumes you are somewhat familiar with that process, and will not explain all the steps in detail. For full instructions on how to make a pull request, see `Github's help section <https://help.github.com/articles/creating-a-pull-request/>`_. Some guidelines:
+To propose changes directly, you'll need to create an account on github and open
+a pull request. This document assumes you are somewhat familiar with that
+process, and will not explain all the steps in detail. For full instructions on
+how to make a pull request, see
+`Github's help section <https://help.github.com/articles/creating-a-pull-request/>`_.
 
-* Work from the *develop* branch.
-* From the base directory, the documenation can be found in the *sphinx-docs* subdirectory. Specific pages of the docs are each associated with a different .rst file, potentially in a subdirectory of *sphinx-docs*.
-* The documentation is written in `ReStructured Text <http://sphinx-doc.org/rest.html>`_ format, so please see the primer!
-* After making your changes, try to build the docs to review them. This process can take some time, as an instance of the server and a browser may need to be started. To build the docs (see *README.md* in the *sphinx-docs* directory for requirements):
+Documentation development
+-------------------------
 
-    * In Linux, if you have the *pyvirtualdisplay* package installed you can build in headless mode by running the command *env SPHINX_SS_USE_PVD=true make html* in the *sphinx-docs* directory.
-    * In other OSes, or to build in non-headless (headed?) mode, just run the command *make html* in the *sphinx-docs* directory. This may launch a browser. Don't interfere with it!
+#. Work from the *develop* branch.
+#. From the base directory, the documenation can be found in the ``docs/``
+   subdirectory. Specific pages of the docs are each associated with a different
+   .rst file, potentially in a subdirectory of ``docs/``.
+#. The documentation is written in
+   `ReStructured Text <http://sphinx-doc.org/rest.html>`_ format, so please see
+   the primer!
+#. After making your changes, try to build the docs to review them. This process
+   can take some time, as an instance of the server and a browser may need to
+   be started. To build the docs::
+   
+       pip install -r requirements_sphinx.txt  # To install software for building docs
+       cd docs
+       make html
 
-* You can view the docs in a browser by opening *sphinx-docs/_build/html/index.html*.
-* After you are satisfied with your changes push them to your fork of the ka-lite project, and then open a PR.
+#. You can view the docs in a browser by opening *docs/_build/html/index.html*.
+#. After you are satisfied with your changes push them to your fork of the ka-lite project, and then open a PR.
 
-For this project we have created an rst directive to take screenshots of the site (in case of UI changes or to build internationalized versions of the docs). To read about the use of this directive, see the *SCREENSHOT_USAGE.md* file and check out usage in the docs (a good starting point is the ss_examples.rst file).
+
+Screenshots
+-----------
+
+Screenshots are made automatically following the screenshots directives. They
+are stored in a folder ``docs/_static/``, which is also sync'ed to Github
+(TODO: This is a temporary procedure).
+
+To grab new screenshots, you have to have Firefox installed and run::
+
+   cd docs/
+   SPHINX_SS_USE_PVD=true make SPHINXOPTS="-D screenshots_create=1" html
+
+You can also refer to ``docs/SCREENSHOT_USAGE.MD`` for more info about the
+screenshot RST directive.

--- a/docs/developer_docs/environment.rst
+++ b/docs/developer_docs/environment.rst
@@ -1,0 +1,32 @@
+Setting up your development environment
+=======================================
+
+KA Lite is like a normal django project, if you have done Django before, you will recognize most of these steps.
+
+#. Check out the project from our _`github`
+#. Create a virtual environment "kalite" that you will work in::
+     
+     sudo pip install virtualenvwrapper
+     mkvirtualenv kalite
+     workon kalite
+
+#. Install kalite in your virtualenv in "editable" mode, meaning that the source is just linked::
+     
+     cd path/to/repo
+     pip install -e .
+
+#. Install additional development tools::
+     
+     pip install -r requirements_dev.txt
+
+#. Run a development server and use development settings like this::
+     
+     kalite manage runserver --settings=kalite.project.settings.dev
+  
+
+You can also change your ``~/.kalite/settings.py`` to point to ``kalite.project.settings.dev`` by default, then you do not have to specify `--settings=...` every time you run kalite.
+
+Now, every time you work on your development environment, just remember to switch on your virtual environment with ``workon kalite``.
+
+.. _github: https://github.com/learningequality/ka-lite
+

--- a/docs/developer_docs/index.rst
+++ b/docs/developer_docs/index.rst
@@ -1,39 +1,10 @@
-Setting up your development environment
-=======================================
-
-KA Lite is like a normal django project, if you have done Django before, you will recognize most of these steps.
-
-  1. Check out the project from our _`github`
-  1. Create a virtual environment "kalite" that you will work in:
-     .. ::
-       sudo pip install virtualenvwrapper
-       mkvirtualenv kalite
-       workon kalite
-  1. Install kalite in your virtualenv in "editable" mode, meaning that the source is just linked:
-     .. ::
-       cd path/to/repo
-       pip install -e .
-  1. Install additional development tools:
-     .. ::
-       pip install -r requirements_dev.txt
-  1. Run a development server and use development settings like this:
-     .. ::
-       kalite manage runserver --settings=kalite.project.settings.dev
-  
-
-You can also change your ``~/.kalite/settings.py`` to point to ``kalite.project.settings.dev`` by default, then you do not have to specify `--settings=...` every time you run kalite.
-
-Now, everytime you work on your development environment, just remember to switch on your virtual environment with `workon kalite`.
-
-.. _github: https://github.com/learningequality/ka-lite
-
-
 Developer Docs
 ==============
 
 Useful stuff our devs think that the rest of our devs ought to know about.
 
 .. toctree::
+    Setting up your development environment <environment>
     Developing Front End Code <front_end_code>
     Javascript Unit Tests <javascript_testing>
     Behavior-Driven Integration Tests <behave_testing>

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -193,13 +193,14 @@ We are also developing RCTs to start in June for a deployment in India.
 Backing up data: is there any easy way to do it locally?
 --------------------------------------------------------
 
-Yes! Just copy the file::
+Yes! Just copy the ``.kalite`` folder, typically located in ``/home/user/.kalite``.
+To restore, simply copy the backup data file to the same location. If you have
+changed versions, please run::
 
-    ka-lite/kalite/database/data.sqlite
+    kalite manage setup
 
-to a secure location. To restore, simply copy the backup data file to the same location. If you have changed versions, please run::
-
-    python kalite/manage.py migrate --merge
+If you only want to backup the database, locate the ``.kalite/database/`` folder
+and copy and restore that one.
 
 to guarantee your database is compatible with the current version of KA Lite you have installed!
 Note that online data back-ups occur if you "register" your KA Lite installation with an online account on our website.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,0 @@
-sphinx==1.3
-sphinx-intl
-# Required for sphinx-intl in python 2.6
-ordereddict
-# Required by screenshots.py to take screenshots in headless manner
-pyvirtualdisplay

--- a/docs/usermanual/userman_admin.rst
+++ b/docs/usermanual/userman_admin.rst
@@ -467,32 +467,16 @@ After registering your device:
 Downloading Videos in Bulk
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you want to download videos in bulk, your best option is to download the KA Lite videos through the `BitTorrent Sync`_ client. This will be a much faster process than using the KA Lite app to download all of the videos.
+If want to download all the videos, you'll need ~33 GB free space. To fetch all
+the videos, `download and open the according torrent file <https://learningequality.org/downloads/ka-lite/0.14/content/>`_.
 
-We have made the full set of KA videos (in the format needed by KA Lite) available via `BitTorrent Sync`_ (btsync). Note that this is different from BitTorrent; btsync allows us to add new videos or fix problems without issuing a whole new torrent file, and then having seeders split between the old and new torrent files. Here are the steps to set this up:
+Save the videos on the ``CONTENT_ROOT`` of your installation. By default, this
+is the ``.kalite/content/`` folder in the *home directory* of the user running KA Lite.
 
-#. Download and install `BitTorrent Sync`_.
-#. Run btsync. On some platforms, this will bring up a graphical interface. On Linux, you will need to type http://127.0.0.1:8888/ into the address bar of your browser to get the interface.
-#. Click the "Enter a key or link" button, and enter **BT7AOITNAIP3X3CSLE2EPQJFXJXMXVGQI**
-#. Select the "content" folder inside your KA Lite installation as the "location" (unless you want the videos to be located elsewhere).
-#. Allow the videos to sync in there from your peers! It may take a while for now, as we don't yet have many seeders on it. On that note -- please help seed by keeping it running even after you've got all the videos, if you have bandwidth to spare! This will make it easier for others to download the content as well.
+On Windows, navigate to ``X:\Documents and Settings\<username>\.kalite\content``.
 
-These are resized videos. All in all, this will take around 23 GB of space.
-
-
-.. WARNING::
-    If you chose to download them to somewhere other than the content folder inside the ka-lite folder as recommended above, you need to tell KA Lite where to find them. If this is the case, follow the steps below:
-
-
-#. Make sure all video files are located in a single directory, with .mp4 extensions (KA Lite expects this!)
-#. In a text editor, open up ``~/.kalite/settings.py`` (on Windows, locate ``C:\Users\<username>\.kalite``).
-#. Add the line ``CONTENT_ROOT="[full path to your videos directory]"``, making SURE to include an OS-specific slash at the end (see examples) and encapsulate it in quotes.
-    **For example, on Windows:** ``CONTENT_ROOT="C:\\torrented_videos_location\\"``
-    **For example, on Linux:** ``CONTENT_ROOT="/home/me/torrented_videos_location/"``
-
-#. Restart your server. If you are unsure on how to do this, please see :ref:`restarting-your-server` .
-
-.. _BitTorrent Sync: http://www.getsync.com/
+.. note:: The ``.kalite`` folder is hidden on some systems, so if you are in a
+          file browser, you have to enable showing hidden files and folders.
 
 
 Adding assessment items (exercises)

--- a/docs/usermanual/userman_admin.rst
+++ b/docs/usermanual/userman_admin.rst
@@ -637,9 +637,15 @@ Once you have deployed KA Lite to a computer, there are a number of ways you can
 Running KA Lite with your own settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In a text editor, open up ``~/.kalite/settings.py`` (on Windows, locate ``C:\Users\<username>\.kalite``). That file is where you should put your custom settings, and KA Lite will load them automatically.
+In a text editor, open up ``~/.kalite/settings.py`` (on Windows, locate 
+``X:\Documents and Settings\<username>\.kalite``). That file is where you should
+put your custom settings, and KA Lite will load them automatically.
 
-You can also run the ``kalite`` with a completely different Python settings module by specifying ``kalite <command> --settings=my_settings_module``.
+You can also run the ``kalite`` with a completely different Python settings
+module by specifying ``kalite <command> --settings=my_settings_module``.
+
+.. note:: The ``.kalite`` folder is hidden on some systems, so if you are in a
+          file browser, you have to enable showing hidden files and folders.
 
 
 Changing base settings
@@ -650,17 +656,6 @@ By default, ``~/.kalite/settings.py`` will load ``kalite.project.settings.base``
   from kalite.project.settings.raspberry_pi import *
   # Put your settings here, e.g.
   # MY_SETTING_VAR = 123
-
-
-.. NOTE::
-    When changing ``CONTENT_ROOT``, you should also change your ``DATABASES`` **if you
-    have downloaded your own assessment items** and you want to keep the
-    read-only assessment_items database (~50 MB) together
-    with your other media contents (for portability). Example::
-      
-      from kalite.project.settings.base import *
-      CONTENT_ROOT = '/example'
-      DATABASES['assessment_items']['NAME'] = os.path.join(CONTENT_ROOT, 'assessmentitems.sqlite')
 
 
 Available settings
@@ -676,6 +671,17 @@ Most common settings
   This is the path that KA Lite will use to look for KA Lite video files to play.
   Change the path to another local directory to get video files from that directory.
   NB! Directory has to be writable for the user running the server in order to download videos.
+
+.. NOTE::
+    When changing ``CONTENT_ROOT``, you should also change your ``DATABASES`` **if you
+    have downloaded your own assessment items** and you want to keep the
+    read-only assessment_items database (~50 MB) together
+    with your other media contents (for portability). Example::
+      
+      from kalite.project.settings.base import *
+      CONTENT_ROOT = '/example'
+      DATABASES['assessment_items']['NAME'] = os.path.join(CONTENT_ROOT, 'assessmentitems.sqlite')
+
 * ``ASSESSMENT_ITEMS_ZIP_URL = "scheme://path/to/assessmentitems.zip"``
   ``(default=https://learningequality.org/downloads/ka-lite/0.14/content/assessment.zip)``
   This is useful if you need an auto-deployment to fetch assessment items (exercises) from a local source. You can use
@@ -712,27 +718,3 @@ Online Synchronization
   Every time your installation syncs data, we record the time of the sync, the # of successful logs that were uploaded and downloaded, and any failures.
   This setting is how many such records we keep on your local server, for display.
   When you log in to our online server, you will see a *full* history of these records.
-
-
-Optimization of storage and system load
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* ``CRONSERVER_FREQUENCY = <desired frequency of cronserver to run in seconds> (default = 10 minutes)``
-  This is how frequently KA Lite tries to synchronize user data with other Devices on your Zone.  This can be changed to sync data more often (use a smaller #), or if you're never online (can be set to a large number)
-* ``CACHE_TIME = <desired length of cache time, in seconds> (default = 5*365*24*60*60) (that's 5 years!)``
-  Our basic topic pages, video pages, and exercise pages rarely change--only when you download new videos (changes made by user logins are made in a different way).  Therefore, we can "cache" copies of these pages, to avoid constantly regenerating them, and speed up KA Lite.  We have logic to delete the cached copies, and therefore generate new copies, if you download new videos or delete old videos through our interface.
-  If you would like to disable caching, set CACHE_TIME = 0 .
-  Read a little more about caching on Wikipedia.
-* ``CACHE_LOCATION = '<path to cache directory>' (default= dir named kalite_web_cache in the OS temporary dir)``
-  Some operating systems will clear the temporary directories when the system is rebooted.  To retain the cache between reboots, an alternative location can be specified.  (for example on Linix, "/var/tmp/kalite_web_cache")
-* ``CHERRYPY_THREAD_COUNT = <number of threads> (default=50)``
-  The CherryPy Webserver can handle multiple page requests simultaneously.  The default is 50, but for slow or single CPU servers, performance will be improved if the number of threads is reduced.  Minimum number of threads is 10, optimum setting for Raspberry Pi is 18.
-
-
-Raspberry Pi
-^^^^^^^^^^^^
-
-* ``USE_MPLAYER = <True or False> (default = False)``
-  With this setting, if the browser is run from the same computer as the KA Lite server, then instead of playing the video in the browser, the video will be launched outside of the browser and played in mplayer - a light-weight video player that is included with the KA Lite software.
-  This is intended for use only on the Raspberry Pi, where no other video player is available.
-

--- a/docs/usermanual/userman_admin.rst
+++ b/docs/usermanual/userman_admin.rst
@@ -466,6 +466,11 @@ is the ``.kalite/content/`` folder in the *home directory* of the user running K
 
 On Windows, navigate to ``X:\Documents and Settings\<username>\.kalite\content``.
 
+.. note:: If the drive where your ``.kalite/`` folder does not have enough free disk space,
+          you can change your `Configuration Settings`_, the one named ``CONTENT_ROOT`` and
+          define a folder where your videos are downloaded to. Remember that you may want
+          to move the contents of your old ``content/`` folder.
+
 .. note:: The ``.kalite`` folder is hidden on some systems, so if you are in a
           file browser, you have to enable showing hidden files and folders.
 

--- a/docs/usermanual/userman_admin.rst
+++ b/docs/usermanual/userman_admin.rst
@@ -610,22 +610,6 @@ Restarting Your Server: Mac
 
 #. Once you see the script that begins with ``To access KA Lite from another connected computer, try the following address(es):`` .... you will know that your KA Lite server has been successfully restarted.
 
-Updating KA Lite
-----------------
-
-If a new version of KA Lite comes out, you can update to the latest version by following the instructions below.
-
-Updating on Mac OS and Linux
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-At this time, the only supported way to update is to grab the source and run the setup management command.
-Follow the instructions in the :doc:`installation guide </installguide/install_main>` to ensure you're using the latest version.
-
-Updating on Windows
-^^^^^^^^^^^^^^^^^^^
-
-To update on Windows, simply use our Windows installer. You will have the option to update from a prior version.
-See the :doc:`Windows installation guide </installguide/install_windows>`.
 
 Configuration Settings
 ----------------------

--- a/docs/usermanual/userman_admin.rst
+++ b/docs/usermanual/userman_admin.rst
@@ -13,7 +13,7 @@ Administrator Glossary
 For users that choose to register online, there are some important terms to familiarize yourself with so that you understand how the flow of data works between installations and the online data hub.
 
 **Sharing Network**
-	A sharing network is a group of devices that share data between one another. Data can mean video content, access software applications, and certain files.
+	A Sharing Network is a group of devices that share user data. This data is synced to the central server when an Internet connection is available, and then synced down onto other devices in the same Sharing Network.
 
 **Organization**
 	An organization is a group of people responsible for administering a set of Sharing Networks. An organization can have multiple administrators and manage multiple sharing networks.
@@ -26,15 +26,6 @@ For users that choose to register online, there are some important terms to fami
 
 **Web Browser**
     A program that retrieves and presents information resources on the World Wide Web. Popular web browsers include Internet Explorer, Google Chrome, Mozilla Firefox, and Safari.
-
-**Torrent**
-    A file or files sent using the BitTorrent protocol. It can be any type of file, such as a movie, song, game, or application. During the transmission, the file is incomplete and therefore referred to as a torrent. Torrent downloads that are incomplete cannot be opened as regular files, because they do not have all the necessary data.
-
-**Seeder**
-    Seeders are users who have a complete version of the file you wish to download. If there are no seeders for a particular file, you will not be able to download the file. Seeders are extremely important, for they help distribute the file.
-
-**Bandwidth**
-    The amount of data that an Internet connection can handle in a given time. An Internet connection with larger bandwidth can move a certain amount of data much faster than an Internet connection with a lower bandwidth.
 
 Running the KA Lite Server
 ---------------------------

--- a/docs/usermanual/userman_admin.rst
+++ b/docs/usermanual/userman_admin.rst
@@ -596,7 +596,7 @@ Once you have deployed KA Lite to a computer, there are a number of ways you can
 Running KA Lite with your own settings
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In a text editor, open up ``~/.kalite/settings.py`` (on Windows, locate 
+In a text editor, open up ``/home/user/.kalite/settings.py`` (on Windows, locate 
 ``X:\Documents and Settings\<username>\.kalite``). That file is where you should
 put your custom settings, and KA Lite will load them automatically.
 
@@ -610,7 +610,7 @@ module by specifying ``kalite <command> --settings=my_settings_module``.
 Changing base settings
 ^^^^^^^^^^^^^^^^^^^^^^
 
-By default, ``~/.kalite/settings.py`` will load ``kalite.project.settings.base`` which are the basic settings. But you can also load Raspberry Pi settings by changing the file to read something like::
+By default, ``/home/user/.kalite/settings.py`` will load ``kalite.project.settings.base`` which are the basic settings. But you can also load Raspberry Pi settings by changing the file to read something like::
 
   from kalite.project.settings.raspberry_pi import *
   # Put your settings here, e.g.
@@ -626,12 +626,12 @@ Most common settings
 
 * ``DEBUG = <True or False> (default = False)``
   Enables debug mode. In case you run into technical issues, enable this setting before troubleshooting / reporting.
-* ``CONTENT_ROOT = "<path to desired content folder>" (default=~/.kalite/content)``
+* ``CONTENT_ROOT = "<path to desired content folder>" (default=/home/user/.kalite/content)``
   This is the path that KA Lite will use to look for KA Lite video files to play.
   Change the path to another local directory to get video files from that directory.
   NB! Directory has to be writable for the user running the server in order to download videos.
 
-.. NOTE::
+.. warning::
     When changing ``CONTENT_ROOT``, you should also change your ``DATABASES`` **if you
     have downloaded your own assessment items** and you want to keep the
     read-only assessment_items database (~50 MB) together
@@ -669,7 +669,8 @@ Online Synchronization
 
 * ``USER_LOG_MAX_RECORDS = <desired maxium for user log records> (default = 0)``
   When this is set to any non-zero number, we will record (and sync for online tracking) user login activity, summarized for every month (which is configurable, see below).  Default is set to 0, for efficiency purposes--but if you want to record this, setting to 1 is enough!  The # of records kept are not "summary" records, but raw records of every login.  These "raw" data are not synced, but are kept on your local machine only--there's too many of them.  Currently, we have no specific report to view these data (though we may have for v0.10.1)
-* ``USER_LOG_SUMMARY_FREQUENCY = <desired frequency in the following format (number, amount of time)> (default = (1, "months")``
+* ``USER_LOG_SUMMARY_FREQUENCY = <desired frequency (number, amount of time)>``
+  ``(default = (1, "months")``
   This determines the granularity of how we summarize and store user log data.  One database row is kept for each student, on each KA Lite installation, for the defined time period.  Acceptable values are:
   (1, "months"), (2, "months"), (3, "months"), (6, "months") - separate logged data for every month, 2 months, 3 months, or 6 months, respectively
   (1, "weeks") - separate logged data for every week ** NOTE THIS MAY PRODUCE A LOT OF DATA **


### PR DESCRIPTION
**Work in progress**

* Updates for #4106 and move CONTENT_ROOT note to correct location
* Removed outdated, mis-placed upgrade instructions, we're better off with release notes for people who pay attention to updates than instructing someone about how to upgrade in our offline docs.
* Development environment instructions no longer mis-placed
* Info about building the documentation updated