### PR TITLE
New diagnose command diagnoses system (not so robust)

### DIFF
--- a/kalite/__init__.py
+++ b/kalite/__init__.py
@@ -4,6 +4,9 @@ import sys
 from version import *
 
 
+__version__ = VERSION
+
+
 # ROOT_DATA_PATH should point to the directory where the source files live, including the "docs" dir
 # TODO-BLOCKER(MCGallaspy): Use setuptools in the windows installer to avoid this nonsense.
 ROOT_DATA_PATH = os.environ.get(

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -197,7 +197,7 @@ def update_default_args(defaults, updates):
 
 
 def get_size(start_path):
-    """Utility function"""
+    """Utility function, returns the size (bytes) of a folder"""
     total_size = 0
     for dirpath, __, filenames in os.walk(start_path):
         for f in filenames:
@@ -607,11 +607,15 @@ status.codes = {
 
 def diagnose():
     """
-    This command diagnoses a running instance of KA Lite
+    This command diagnoses an installation of KA Lite
     
     It has to be able to work with instances of KA Lite that users do not
     actually own, however it's assumed that the path and the 'kalite' commands
     are configured and work.
+    
+    The function is currently non-robust, meaning that not all aspects of
+    diagnose data collection is guaranteed to succeed, thus the command could
+    potentially fail :(
     
     Example: KALITE_HOME=/home/otheruser/.kalite kalite diagnose --port=7007
     """
@@ -620,6 +624,8 @@ def diagnose():
     print("KA Lite diagnostics")
     print("")
     
+    # Tell users we are calculating, because checking the size of the
+    # content directory is slow. Flush immediately after.
     print("Calculating diagnostics...")
     sys.stdout.flush()
     print("")

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -62,6 +62,7 @@ from __future__ import print_function
 # Add distributed python-packages subfolder to current path
 # DO NOT IMPORT BEFORE THIS LIKE
 import os
+import platform
 import socket
 import sys
 import time
@@ -638,7 +639,7 @@ def diagnose():
     
     diag("KA Lite version", kalite.__version__)
     diag("python", sys.version)
-    diag("platform", "\n".join(os.uname()))
+    diag("platform", platform.platform())
     
     try:
         __, __, port = get_pid()

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -667,11 +667,14 @@ def diagnose():
         try:
             from securesync.models import Device
             device = Device.get_own_device()
+            sync_sessions = device.client_sessions.all()
+            zone = device.get_zone()
             diag("device name", str(device.name))
-            diag("device UUID", str(device.get_uuid()))
+            diag("device ID", str(device.id))
             diag("device registered", str(device.is_registered()))
-            diag("device synced", str(device.client_sessions.all().count()) + " times")
-            diag("zone", device.get_zone())
+            diag("synced", str(sync_sessions.latest('timestamp').timestamp if sync_sessions.exists() else "Never"))
+            diag("sync result", ("OK" if sync_sessions.latest('timestamp').errors == 0 else "Error") if sync_sessions.exists() else "-")
+            diag("zone ID", str(zone.id) if zone else "Unset")
         except:
             diag("Device failure", traceback.format_exc())
     

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -13,6 +13,7 @@ Usage:
   kalite shell [options] [DJANGO_OPTIONS ...]
   kalite test [options] [DJANGO_OPTIONS ...]
   kalite manage [options] COMMAND [DJANGO_OPTIONS ...]
+  kalite diagnose [options]
   kalite -h | --help
   kalite --version
 
@@ -42,6 +43,7 @@ Examples:
   kalite stop           Stop KA Lite
   kalite shell          Display a Django shell
   kalite manage help    Show the Django management usage dialogue
+  kalite diagnose       Show system information for debugging
 
   kalite start --foreground   Run kalite in the foreground and do not go to
                               daemon mode.
@@ -63,6 +65,7 @@ import os
 import socket
 import sys
 import time
+import traceback
 
 # KALITE_DIR set, so probably called from bin/kalite
 if 'KALITE_DIR' in os.environ:
@@ -97,8 +100,8 @@ from socket import timeout
 
 from django.core.management import ManagementUtility, get_commands
 
+import kalite
 from kalite.django_cherrypy_wsgiserver.cherrypyserver import DjangoAppPlugin
-from kalite.version import VERSION
 from kalite.shared.compat import OrderedDict
 from fle_utils.internet.functions import get_ip_addresses
 
@@ -191,6 +194,16 @@ def update_default_args(defaults, updates):
         defined_updates[elm[0]] = elm[1]
     defined_defaults.update(defined_updates)
     return defined_defaults.values()
+
+
+def get_size(start_path):
+    """Utility function"""
+    total_size = 0
+    for dirpath, __, filenames in os.walk(start_path):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            total_size += os.path.getsize(fp)
+    return total_size
 
 
 # Utility functions for pinging or killing PIDs
@@ -570,7 +583,7 @@ def status():
         sys.stderr.write("KA Lite running on:\n\n")
         for addr in get_ip_addresses():
             sys.stderr.write("\thttp://%s:%s/\n" % (addr, port))
-        return 0
+        return STATUS_RUNNING
     except NotRunning as e:
         status_code = e.status_code
         verbose_status = status.codes[status_code]
@@ -591,6 +604,79 @@ status.codes = {
     STATUS_UNKNOW: 'Could not determine status',
 }
 
+
+def diagnose():
+    """
+    This command diagnoses a running instance of KA Lite
+    
+    It has to be able to work with instances of KA Lite that users do not
+    actually own, however it's assumed that the path and the 'kalite' commands
+    are configured and work.
+    
+    Example: KALITE_HOME=/home/otheruser/.kalite kalite diagnose --port=7007
+    """
+    
+    print("")
+    print("KA Lite diagnostics")
+    print("")
+    
+    print("Calculating diagnostics...")
+    sys.stdout.flush()
+    print("")
+    
+    # Key, value store for diagnostics
+    # Not using OrderedDict because of python 2.6
+    diagnostics = []
+    
+    diag = lambda x, y: diagnostics.append((x, y))
+    
+    diag("KA Lite version", kalite.__version__)
+    diag("python", sys.version)
+    diag("platform", "\n".join(os.uname()))
+    
+    try:
+        __, __, port = get_pid()
+        for addr in get_ip_addresses():
+            diag("server address", "http://%s:%s/" % (addr, port))
+        status_code = STATUS_RUNNING
+    except NotRunning as e:
+        status_code = e.status_code
+    
+    diag("server status", status.codes[status_code])
+    
+    settings_imported = True  # Diagnostics from settings
+    try:
+        from django.conf import settings
+        from django.template.defaultfilters import filesizeformat
+    except:
+        settings_imported = False
+        diag("Settings failure", traceback.format_exc())
+    
+    if settings_imported:
+        diag("installed in", os.path.dirname(kalite.__file__))
+        diag("content root", settings.CONTENT_ROOT)
+        diag("content size", filesizeformat(get_size(settings.CONTENT_ROOT)))
+        diag("user database", settings.DATABASES['default']['NAME'])
+        diag("assessment database", settings.DATABASES['assessment_items']['NAME'])
+        try:
+            from securesync.models import Device
+            device = Device.get_own_device()
+            diag("device name", str(device.name))
+            diag("device UUID", str(device.get_uuid()))
+            diag("device registered", str(device.is_registered()))
+            diag("device synced", str(device.client_sessions.all().count()) + " times")
+            diag("zone", device.get_zone())
+        except:
+            diag("Device failure", traceback.format_exc())
+    
+    for k, v in diagnostics:
+        
+        # Pad all the values to match the key column
+        values = str(v).split("\n")
+        values = "\n".join([values[0]] + map(lambda x: (" " * 22) + x, values[1:]))
+        
+        print((k.upper() + ": ").ljust(21), values)
+    
 
 def url():
     """
@@ -709,7 +795,7 @@ def docopt(doc, argv=None, help=True, version=None, options_first=False):  # @Re
 if __name__ == "__main__":
     # Since positional arguments should always come first, we can safely
     # replace " " with "=" to make options "--xy z" same as "--xy=z".
-    arguments = docopt(__doc__, version=str(VERSION), options_first=False)
+    arguments = docopt(__doc__, version=str(kalite.__version__), options_first=False)
 
     settings_module = arguments.pop('--settings', None)
     if settings_module:
@@ -741,6 +827,9 @@ if __name__ == "__main__":
         status_code = status()
         sys.exit(status_code)
 
+    elif arguments['diagnose']:
+        diagnose()
+    
     elif arguments['shell']:
         manage('shell', args=arguments['DJANGO_OPTIONS'])
 


### PR DESCRIPTION
Example:

```
✗ bin/kalite diagnose

KA Lite diagnostics

Calculating diagnostics...

KA LITE VERSION:      0.14.0
PYTHON:               2.7.6 (default, Mar 22 2014, 22:59:56) 
                      [GCC 4.8.2]
PLATFORM:             Linux
                      hostname
                      3.16.0-38-generic
                      #52~14.04.1-Ubuntu SMP Fri May 8 09:43:57 UTC 2015
                      x86_64
SERVER ADDRESS:       http://192.168.40.148:8008/
SERVER ADDRESS:       http://127.0.0.1:8008/
SERVER STATUS:        OK, running
INSTALLED IN:         code/ka-lite/kalite
CONTENT ROOT:         code/ka-lite/content
CONTENT SIZE:         3.0 MB
USER DATABASE:        code/ka-lite/kalite/database/data.sqlite
ASSESSMENT DATABASE:  code/ka-lite/content/assessmentitems.sqlite
DEVICE NAME:          hostname
DEVICE UUID:          60d28ba6c1d9593b8f9c6b61d1ae7935
DEVICE REGISTERED:    True
DEVICE SYNCED:        10 times
ZONE:                 Zone for public key MIIBCgKCAQEA1o91D7UGvm8wfovNq92h6Uzxm9C5QDXRl43268
```