### PR TITLE
Replace the 'close' <a> element with an accessible button in user alert messages

### DIFF
--- a/kalite/distributed/static/js/distributed/utils/messages.js
+++ b/kalite/distributed/static/js/distributed/utils/messages.js
@@ -34,7 +34,7 @@ function show_message(msg_class, msg_text, msg_id) {
         return $("#message_container");
     }
 
-    var x_button = '<a class="close" data-dismiss="alert" href="#">&times;</a>';
+    var x_button = '<button type="button" class="close" data-dismiss="alert"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>';
 
     if (msg_class === "error") {
         msg_class = "danger"


### PR DESCRIPTION
Fixes #4117, instead of #4119 that suffered a bad rebase.


![button-close](https://cloud.githubusercontent.com/assets/1457929/8753634/9ac08986-2cbd-11e5-9f5e-c3688dca5cb6.png)

