### PR TITLE
Changed the VideoJS version number in the package.json to 4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "scriptjs": "^2.5.7",
     "soundmanager2": "^2.97.20150601",
     "underscore": "~1.8.3",
-    "video.js": "^4.12.10",
+    "video.js": "^4.11.4",
     "watchify": "^3.2.3"
   }
 }


### PR DESCRIPTION
`4.12` dropped the support for **srt** files, in favor of implementing **vtt**. `4.11` version is the most recent (Jan. 2015) that supports **srt**.