### PR TITLE
Fix no module named yaml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ South==0.8.4
 django-js-reverse==0.5.0
 # used by django-js-reverse
 ply==3.4
+pyyaml==3.11
 # used by django-js-reverse
 slimit==0.8.1
 six==1.9.0


### PR DESCRIPTION
Hi @aronasorman and @djallado this fixed #4174 

I add the PyYAML 3.11 in production requirements to fix the no module named yaml.
After I installed the PyYAML 3.11 in my virtualenv. The problem was fixed see the image below.
![screenshot 2015-07-28 14 43 25](https://cloud.githubusercontent.com/assets/4099119/8925053/0b02a04a-3537-11e5-8c21-c33d2042aa89.png)