### PR TITLE
Securesync fixes

### DIFF
--- a/kalite/testing/management/commands/readmodel.py
+++ b/kalite/testing/management/commands/readmodel.py
@@ -1,3 +1,4 @@
+import datetime
 import importlib
 import json
 import sys
@@ -8,6 +9,8 @@ from fle_utils.importing import resolve_model
 from django.conf import settings; logging = settings.LOG
 from django.core.management.base import BaseCommand, CommandError
 from django.core import serializers
+
+dthandler = lambda obj: obj.isoformat() if isinstance(obj, datetime.datetime) else None
 
 class Command(BaseCommand):
     args = "<model_path>"
@@ -40,7 +43,7 @@ class Command(BaseCommand):
                 serialized_data = serializers.serialize("python", [data])[0]["fields"]
                 serialized_data["id"] = model_id
                 logging.debug("Serialized data: '%s'" % serialized_data)
-                print json.dumps(serialized_data)
+                print json.dumps(serialized_data, default=dthandler)
 
             except Model.DoesNotExist:
                 logging.error("Could not find '%s' entry with primary key: '%s'" % (model_path, model_id))

--- a/python-packages/securesync/__init__.py
+++ b/python-packages/securesync/__init__.py
@@ -7,17 +7,7 @@ import os
 ID_MAX_LENGTH=32
 IP_MAX_LENGTH=50
 
-
-# TODO(benjaoming): So the version of securesync dynamic !? Not understanding
-# this.. plus it adds problems in dependency testing... but that should be
-# deleted anyways... for now just hard coding it at 1.0 and below will be
-# left commented out.
-# try:
-#     from kalite.version import VERSION
-# except:
-#     VERSION = "1.0"
-
-VERSION = "1.0"
+from kalite.version import VERSION
 
 # JsonResponseMessageError codes
 class ERROR_CODES:


### PR DESCRIPTION
- Use kalite.version.VERSION for securesync; needed for minversion checks
- Properly handle dates when serializing models to JSON in readmodels