### PR TITLE
Exercise import

### DIFF
--- a/kalite/contentload/management/commands/channels/CHANNELDATA.md
+++ b/kalite/contentload/management/commands/channels/CHANNELDATA.md
@@ -1,3 +1,5 @@
+This file describes module-level attributes which should be defined per-channel.
+
 slug_key is a mapping for different data kinds, showing which attribute to use to define the slug.
 This slug will be used to build the resource path in the URL.
 

--- a/kalite/contentload/management/commands/channels/import_channel.py
+++ b/kalite/contentload/management/commands/channels/import_channel.py
@@ -1,3 +1,6 @@
+"""
+Import topic tree from a filesystem source.
+"""
 import os
 import json
 import hashlib
@@ -9,6 +12,10 @@ from django.conf import settings; logging = settings.LOG
 from django.utils.text import slugify
 
 from functools import partial
+
+from hachoir_core.cmd_line import unicodeFilename
+from hachoir_parser import createParser
+from hachoir_metadata import extractMetadata
 
 import base
 
@@ -74,7 +81,7 @@ channel_data = {
 
 whitewash_node_data = partial(base.whitewash_node_data, channel_data=channel_data)
 
-def build_full_cache(items, id_key="id"):
+def build_full_cache(items):
     """
     Uses list of items retrieved from building the topic tree
     to create an item cache with look up keys.
@@ -122,41 +129,52 @@ def file_md5(namespace, file_path):
     return m.hexdigest()
 
 def construct_node(location, parent_path, node_cache, channel):
-    """Return list of dictionaries of subdirectories and/or files in the location"""
-    # Recursively add all subdirectories
-    children = []
-    location = location if not location or location[-1] != "/" else location[:-1]
+    """
+    Return list of dictionaries of subdirectories and/or files in the location.
+    If location is a directory, this will be called recursively on every file and subdirectory within, creating nodes
+        for each item and attaching them as children to the node corresponding to the containing directory.
+
+    :param location: A string. Path to node data to be imported. Depending on the extension, a different node
+        will be returned -- directories will create a Topic node, and different extensions will create nodes based on
+        the extension's value as a key in the module-defined dict `file_kind_map`. Files with the .json extension are
+        ignored as nodes -- but they can be used to add metadata to any arbitrary file. Extensions without an entry in
+        `file_kind_map` return None.
+    :param parent_path: A string. The directory corresponding to the parent Topic node.
+    :param node_cache: A mutable object, which will be updated with node data.
+    :param channel: A channel dictionary. Should at least have keys "name" and "id".
+    :return: None if location ends with `.json` or is not found in `file_kind_map`. Otherwise a dictionary.
+    """
+    location = location if not location else os.path.realpath(location)
     base_name = os.path.basename(location)
     if base_name.endswith(".json"):
         return None
     if not parent_path:
         base_name = channel["name"]
+
     slug = slugify(unicode(".".join(base_name.split(".")[:-1])))
     if not slug or slug in node_cache["Slugs"]:
         slug = slugify(unicode(base_name))
     # Note: It is assumed that any file with *exactly* the same file name is the same file.
     node_cache["Slugs"].add(slug)
+
+    meta_data = get_metadata_or_none(location)  # Could be updated depending on node type
+
     current_path = os.path.join(parent_path, slug)
-    try:
-        with open(location + ".json", "r") as f:
-            meta_data = json.load(f)
-    except IOError:
-        meta_data = {}
-        logging.warning("No metadata for file {base_name}".format(base_name=base_name))
     node = {
         "path": current_path,
         "slug": slug,
     }
+
+    # If location is a directory, add a topic node. If not, add a kind of node depending on the extension.
     if os.path.isdir(location):
         node.update({
             "kind": "Topic",
             "id": slug,
-            "children": sorted([construct_node(os.path.join(location, s), current_path, node_cache, channel) for s in os.listdir(location)], key=lambda x: (not x.get("topic_spotlight", False) if x else True, x.get("title", "") if x else "")),
+            "children": [construct_node(os.path.join(location, s), current_path, node_cache, channel) for s in
+                         os.listdir(location)],
         })
-
-        node["children"] = [child for child in node["children"] if child]
-
-        node.update(meta_data)
+        sort_key = lambda x: (not x.get("topic_spotlight", False) if x else True, x.get("title", "") if x else "")
+        node["children"] = sorted([child for child in node["children"] if child], key=sort_key)
 
         # Finally, can add contains
         contains = set([])
@@ -169,65 +187,110 @@ def construct_node(location, parent_path, node_cache, channel):
     else:
         extension = base_name.split(".")[-1]
         kind = file_kind_map.get(extension, None)
-
-        if not kind:
-            return None
-        elif kind in ["Video", "Audio", "Image"]:
-            from hachoir_core.cmd_line import unicodeFilename
-            from hachoir_parser import createParser
-            from hachoir_metadata import extractMetadata
-
-            filename = unicodeFilename(location)
-            parser = createParser(filename, location)
-
-            if parser:
-                info = extractMetadata(parser)
-                data_meta = {}
-                for meta_key, data_fn in file_meta_data_map.items():
-                    if data_fn(info):
-                        data_meta[meta_key] = data_fn(info)
-                if data_meta.get("codec", None):
-                    data_meta["{kind}_codec".format(kind=kind.lower())] = data_meta["codec"]
-                    del data_meta["codec"]
-                data_meta.update(meta_data)
-                meta_data = data_meta
-        elif kind == "Exercise":
-            zf = zipfile.ZipFile(open(location, "rb"), "r")
-            try:
-                data_meta = json.loads(zf.read("exercise.json"))
-            except KeyError:
-                data_meta = {}
-                logging.debug("No exercise metadata available in zipfile")
-            data_meta.update(meta_data)
-            try:
-                assessment_items = json.loads(zf.read("assessment_items.json"))
-            except KeyError:
-                assessment_items = []
-                logging.debug("No assessment items found in zipfile")
-            for filename in zf.namelist():
-                if os.path.splitext(filename)[0] != "json":
-                    zf.extract(filename, os.path.join(settings.ASSESSMENT_ITEM_ROOT, channel))
-
-
-        id = file_md5(channel["id"], location)
-
-        node.update({
-            "id": id,
-            "kind": kind,
-        })
-
-        if kind != "Exercise":
+        if kind:
             node.update({
-                "format": extension,
-                })
-            # Copy over content
-            shutil.copy(location, os.path.join(settings.CONTENT_ROOT, id + "." + extension))
-            logging.debug("%s file %s to local content directory." % ("Copied", slug))
+                "id": file_md5(channel["id"], location),
+                "kind": kind,
+            })
+        else:
+            return None
 
-        node.update(meta_data)
+        if kind in ["Video", "Audio", "Image"]:
+            node, extra_meta_data = construct_media_node_bundle(node, extension, location)
+            extra_meta_data.update(meta_data)
+            meta_data = extra_meta_data
+
+        elif kind == "Exercise":
+            extra_meta_data, assessment_items = construct_exercise_bundle(location, channel)
+            meta_data.update(extra_meta_data)
+
+    node.update(meta_data)
+    node = clean_up_node(node, location)
+
+    if node["kind"] != "Topic":
+        nodecopy = copy.deepcopy(node)
+        if node["kind"] == "Exercise":
+            node_cache["Exercise"].append(nodecopy)
+            node_cache["AssessmentItem"].extend(assessment_items)
+        else:
+            node_cache["Content"].append(nodecopy)
+
+    return node
 
 
-    # Verify some required fields:
+def construct_exercise_bundle(location, channel):
+    """
+    Construct a bundle for an exercise node, which should be a special zipfile.
+
+    :param location: A string. The node's location, a la construct_node. Should be a zipfile.
+    :param channel: The channel dictionary, a la construct_node. Requires the "name" item.
+    :return: A tuple (extra_meta_data, assessment_items).
+        extra_meta_data: A dict. Extracted meta data from "exercise.json" if it exists.
+        assessment_items: A list. Assessment items from "assessment_items.json" if they're included.
+    """
+    zf = zipfile.ZipFile(open(location, "rb"), "r")
+
+    try:
+        extra_meta_data = json.loads(zf.read("exercise.json"))
+    except KeyError:
+        extra_meta_data = {}
+        logging.debug("No exercise metadata available in zipfile")
+
+    try:
+        assessment_items = json.loads(zf.read("assessment_items.json"))
+    except KeyError:
+        assessment_items = []
+        logging.debug("No assessment items found in zipfile")
+    for filename in zf.namelist():
+        if os.path.splitext(filename)[0] != "json":
+            zf.extract(filename, os.path.join(settings.ASSESSMENT_ITEM_ROOT, channel["name"]))
+
+    return extra_meta_data, assessment_items
+
+
+def construct_media_node_bundle(node, extension, location):
+    """
+    Given a bunch of parameters, returns an updated node and meta data (extra_meta_data).
+    Copies files from "location" to settings.CONTENT_ROOT.
+
+    :param node: A dict. The node -- will be changed in place.
+    :param extension: A string. The file extension.
+    :param location: A string. The node's location, a la construct_node.
+    :return: A tuple, (node, extra_meta_data).
+        node: A dict. The updated node.
+        extra_meta_data: A dict. Extra meta data extracted from the file.
+    """
+    node.update({
+        "format": extension,
+    })
+
+    shutil.copy(location, os.path.join(settings.CONTENT_ROOT, node["id"] + "." + extension))
+    logging.debug("Copied file %s to local content directory." % node["slug"])
+
+    extra_meta_data = {}
+    filename = unicodeFilename(location)
+    parser = createParser(filename, location)
+    if parser:
+        info = extractMetadata(parser)
+        for meta_key, data_fn in file_meta_data_map.items():
+            if data_fn(info):
+                extra_meta_data[meta_key] = data_fn(info)
+        if extra_meta_data.get("codec", None):
+            extra_meta_data["{kind}_codec".format(kind=node["kind"].lower())] = extra_meta_data["codec"]
+            del extra_meta_data["codec"]
+
+    return node, extra_meta_data
+
+
+def clean_up_node(node, location):
+    """
+    Ensure node has a title and fold together certain attributes
+
+    :param node: A dict. The almost-finished node to be cleaned up.
+    :param location: A string. The location (a la construct_node) that the node is constructed from.
+    :return: The cleaned-up node.
+    """
+    base_name = os.path.basename(location)
     if "title" not in node:
         logging.warning("Title missing from file {base_name}, using file name instead".format(base_name=base_name))
         if os.path.isdir(location):
@@ -238,18 +301,26 @@ def construct_node(location, parent_path, node_cache, channel):
     # Clean up some fields:
     # allow tags and keywords to be a single item as a string, convert to list
     for key in ["tags", "keywords"]:
-        if isinstance(node.get(key, []), basestring):
+        if isinstance(node.get(key), basestring):
             node[key] = [node[key]]
-
-    if not os.path.isdir(location):
-        nodecopy = copy.deepcopy(node)
-        if kind == "Exercise":
-            node_cache["Exercise"].append(nodecopy)
-            node_cache["AssessmentItem"].extend(assessment_items)
-        else:
-            node_cache["Content"].append(nodecopy)
-
     return node
+
+
+def get_metadata_or_none(location):
+    """
+    Reads and returns json metadata if it exists at "location".
+
+    :param location: path to node data. Metadata should be in the file location+".json"
+    :return: The metadata if no IOError is raised, or else an empty dict.
+    """
+    try:
+        with open(location + ".json", "r") as f:
+            meta_data = json.load(f)
+    except IOError:
+        meta_data = {}
+        logging.warning("No metadata for file: {location}".format(location=location))
+    return meta_data
+
 
 path = ""
 
@@ -299,11 +370,8 @@ def retrieve_API_data(channel=None):
     }
 
     topic_tree = construct_node(path, "", node_cache, channel)
-
     exercises = node_cache["Exercise"]
-
     assessment_items = node_cache["AssessmentItem"]
-
     content = node_cache["Content"]
 
     del node_cache["Slugs"]

--- a/kalite/contentload/tests/import_tests.py
+++ b/kalite/contentload/tests/import_tests.py
@@ -96,7 +96,6 @@ class TestContentImportTopicTree(MainTestCase):
             for child in node["children"]:
                 self.recursively_find_nodes(child, key, value, cache)
 
-    @unittest.skip("Skipping until kaa package is replaced")
     def test_create_topic_tree(self):
         slug = os.path.basename(self.tempdir)
         topic_tree = {

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,4 +4,6 @@ selenium==2.45.0
 pysparklines==0.9
 unittest2==0.7.1
 mock==1.0.1
-
+hachoir-core==1.3.3
+hachoir-parser==1.3.4
+hachoir-metadata==1.3.3


### PR DESCRIPTION
Summary of changes:
* Accommodate exercise import
* Modify assessment item commands to allow for non-khan channel assessment items.

Requires ".exercise" file that is a zip file in the following format:
- exercise.json [Exercise metadata]
- assessment_items.json [Assessment items JSON]
- *.!json [Exercise asset files]

@aronasorman 