### PR TITLE
Log data migration

### DIFF
--- a/kalite/main/migrations/0039_log_timestamps.py
+++ b/kalite/main/migrations/0039_log_timestamps.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        """
+        Create latest_activity_timestamp data when possible by inspecting the model.
+        For ExerciseLog inspect relevant AttemptLogs to infer most recent activity.
+        If not available, and for other Logs, fallback to completion_timestamp if available.
+        """
+        for e in orm.ExerciseLog.objects.filter(latest_activity_timestamp=None):
+
+            alogs = orm.AttemptLog.objects.filter(user=e.user, exercise_id=e.exercise_id, context_type__in=["playlist", "exercise"])
+
+            if alogs:
+                e.latest_activity_timestamp = sorted([a.timestamp for a in alogs])[-1]
+                e.zone_fallback = e.get_zone()
+                e.save()
+            else:
+                e.latest_activity_timestamp = e.completion_timestamp
+                e.save()
+
+        for v in orm.VideoLog.objects.filter(latest_activity_timestamp=None):
+            v.latest_activity_timestamp = v.completion_timestamp
+            v.save()
+
+        for c in orm.ContentLog.objects.filter(latest_activity_timestamp=None):
+            c.latest_activity_timestamp = c.completion_timestamp
+            c.save()
+
+
+    def backwards(self, orm):
+        raise RuntimeError("Cannot reverse this migration.")
+
+    models = {
+        u'main.attemptlog': {
+            'Meta': {'object_name': 'AttemptLog', 'index_together': "[['user', 'exercise_id', 'context_type']]"},
+            'answer_given': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'assessment_item_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100', 'blank': 'True'}),
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'context_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'context_type': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'correct': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'exercise_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'response_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'response_log': ('django.db.models.fields.TextField', [], {'default': "'[]'"}),
+            'seed': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'time_taken': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.contentlog': {
+            'Meta': {'object_name': 'ContentLog'},
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'content_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'content_kind': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'content_source': ('django.db.models.fields.CharField', [], {'default': "'khan'", 'max_length': '100', 'db_index': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'extra_fields': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'latest_activity_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'progress': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'progress_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'start_timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'time_spent': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'views': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.exerciselog': {
+            'Meta': {'object_name': 'ExerciseLog'},
+            'attempts': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'attempts_before_completion': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'exercise_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'latest_activity_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'streak_progress': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'struggling': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.userlog': {
+            'Meta': {'object_name': 'UserLog'},
+            'activity_type': ('django.db.models.fields.IntegerField', [], {}),
+            'end_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'last_active_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'start_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'total_seconds': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"})
+        },
+        u'main.userlogsummary': {
+            'Meta': {'object_name': 'UserLogSummary'},
+            'activity_type': ('django.db.models.fields.IntegerField', [], {}),
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'device': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Device']"}),
+            'end_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'last_activity_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'start_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'total_seconds': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.videolog': {
+            'Meta': {'object_name': 'VideoLog'},
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'latest_activity_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'total_seconds_watched': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'video_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'youtube_id': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.device': {
+            'Meta': {'object_name': 'Device'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'public_key': ('django.db.models.fields.CharField', [], {'max_length': '500', 'db_index': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'version': ('django.db.models.fields.CharField', [], {'default': "'0.9.2'", 'max_length': '9', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.facility': {
+            'Meta': {'object_name': 'Facility'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'address_normalized': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'contact_email': ('django.db.models.fields.EmailField', [], {'max_length': '60', 'blank': 'True'}),
+            'contact_name': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'contact_phone': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'longitude': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_count': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"}),
+            'zoom': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'securesync.facilitygroup': {
+            'Meta': {'object_name': 'FacilityGroup'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'facility': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Facility']"}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.facilityuser': {
+            'Meta': {'object_name': 'FacilityUser'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'default_language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'facility': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Facility']"}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityGroup']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'is_teacher': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.zone': {
+            'Meta': {'object_name': 'Zone'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        }
+    }
+
+    complete_apps = ['main']
+    symmetrical = True

--- a/kalite/main/migrations/0039_log_timestamps.py
+++ b/kalite/main/migrations/0039_log_timestamps.py
@@ -22,7 +22,6 @@ class Migration(DataMigration):
 
                 if alogs:
                     e.latest_activity_timestamp = sorted([a.timestamp for a in alogs])[-1]
-                    e.zone_fallback = e.get_zone()
                     e.save()
                 elif e.completion_timestamp:
                     e.latest_activity_timestamp = e.completion_timestamp

--- a/kalite/main/migrations/0039_log_timestamps.py
+++ b/kalite/main/migrations/0039_log_timestamps.py
@@ -11,26 +11,39 @@ class Migration(DataMigration):
         Create latest_activity_timestamp data when possible by inspecting the model.
         For ExerciseLog inspect relevant AttemptLogs to infer most recent activity.
         If not available, and for other Logs, fallback to completion_timestamp if available.
+        All attempted migrations are wrapped in try-except blocks so that this migration
+        does not render an installation unusable simply because this fails for any data.
         """
         for e in orm.ExerciseLog.objects.filter(latest_activity_timestamp=None):
 
-            alogs = orm.AttemptLog.objects.filter(user=e.user, exercise_id=e.exercise_id, context_type__in=["playlist", "exercise"])
+            try:
 
-            if alogs:
-                e.latest_activity_timestamp = sorted([a.timestamp for a in alogs])[-1]
-                e.zone_fallback = e.get_zone()
-                e.save()
-            else:
-                e.latest_activity_timestamp = e.completion_timestamp
-                e.save()
+                alogs = orm.AttemptLog.objects.filter(user=e.user, exercise_id=e.exercise_id, context_type__in=["playlist", "exercise"])
+
+                if alogs:
+                    e.latest_activity_timestamp = sorted([a.timestamp for a in alogs])[-1]
+                    e.zone_fallback = e.get_zone()
+                    e.save()
+                else:
+                    e.latest_activity_timestamp = e.completion_timestamp
+                    e.save()
+
+            except:
+                pass
 
         for v in orm.VideoLog.objects.filter(latest_activity_timestamp=None):
-            v.latest_activity_timestamp = v.completion_timestamp
-            v.save()
+            try:
+                v.latest_activity_timestamp = v.completion_timestamp
+                v.save()
+            except:
+                pass
 
         for c in orm.ContentLog.objects.filter(latest_activity_timestamp=None):
-            c.latest_activity_timestamp = c.completion_timestamp
-            c.save()
+            try:
+                c.latest_activity_timestamp = c.completion_timestamp
+                c.save()
+            except:
+                pass
 
 
     def backwards(self, orm):

--- a/kalite/main/migrations/0039_log_timestamps.py
+++ b/kalite/main/migrations/0039_log_timestamps.py
@@ -24,21 +24,21 @@ class Migration(DataMigration):
                     e.latest_activity_timestamp = sorted([a.timestamp for a in alogs])[-1]
                     e.zone_fallback = e.get_zone()
                     e.save()
-                else:
+                elif e.completion_timestamp:
                     e.latest_activity_timestamp = e.completion_timestamp
                     e.save()
 
             except:
                 pass
 
-        for v in orm.VideoLog.objects.filter(latest_activity_timestamp=None):
+        for v in orm.VideoLog.objects.filter(latest_activity_timestamp=None).exclude(completion_timestamp=None):
             try:
                 v.latest_activity_timestamp = v.completion_timestamp
                 v.save()
             except:
                 pass
 
-        for c in orm.ContentLog.objects.filter(latest_activity_timestamp=None):
+        for c in orm.ContentLog.objects.filter(latest_activity_timestamp=None).exclude(completion_timestamp=None):
             try:
                 c.latest_activity_timestamp = c.completion_timestamp
                 c.save()
@@ -47,7 +47,7 @@ class Migration(DataMigration):
 
 
     def backwards(self, orm):
-        raise RuntimeError("Cannot reverse this migration.")
+        pass
 
     models = {
         u'main.attemptlog': {

--- a/kalite/main/migrations/0040_auto__chg_field_videolog_video_id__chg_field_attemptlog_exercise_id__c.py
+++ b/kalite/main/migrations/0040_auto__chg_field_videolog_video_id__chg_field_attemptlog_exercise_id__c.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Changing field 'VideoLog.video_id'
+        db.alter_column(u'main_videolog', 'video_id', self.gf('django.db.models.fields.CharField')(max_length=200))
+
+        # Changing field 'AttemptLog.exercise_id'
+        db.alter_column(u'main_attemptlog', 'exercise_id', self.gf('django.db.models.fields.CharField')(max_length=200))
+
+        # Changing field 'ContentLog.content_id'
+        db.alter_column(u'main_contentlog', 'content_id', self.gf('django.db.models.fields.CharField')(max_length=200))
+
+        # Changing field 'ExerciseLog.exercise_id'
+        db.alter_column(u'main_exerciselog', 'exercise_id', self.gf('django.db.models.fields.CharField')(max_length=200))
+
+    def backwards(self, orm):
+
+        # Changing field 'VideoLog.video_id'
+        db.alter_column(u'main_videolog', 'video_id', self.gf('django.db.models.fields.CharField')(max_length=100))
+
+        # Changing field 'AttemptLog.exercise_id'
+        db.alter_column(u'main_attemptlog', 'exercise_id', self.gf('django.db.models.fields.CharField')(max_length=100))
+
+        # Changing field 'ContentLog.content_id'
+        db.alter_column(u'main_contentlog', 'content_id', self.gf('django.db.models.fields.CharField')(max_length=100))
+
+        # Changing field 'ExerciseLog.exercise_id'
+        db.alter_column(u'main_exerciselog', 'exercise_id', self.gf('django.db.models.fields.CharField')(max_length=100))
+
+    models = {
+        u'main.attemptlog': {
+            'Meta': {'object_name': 'AttemptLog', 'index_together': "[['user', 'exercise_id', 'context_type']]"},
+            'answer_given': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'assessment_item_id': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '100', 'blank': 'True'}),
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'context_id': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'context_type': ('django.db.models.fields.CharField', [], {'max_length': '20', 'blank': 'True'}),
+            'correct': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'exercise_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'response_count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'response_log': ('django.db.models.fields.TextField', [], {'default': "'[]'"}),
+            'seed': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'time_taken': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.contentlog': {
+            'Meta': {'object_name': 'ContentLog'},
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'content_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'content_kind': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'content_source': ('django.db.models.fields.CharField', [], {'default': "'khan'", 'max_length': '100', 'db_index': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'extra_fields': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'latest_activity_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'progress': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'progress_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'start_timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'time_spent': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'views': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.exerciselog': {
+            'Meta': {'object_name': 'ExerciseLog'},
+            'attempts': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'attempts_before_completion': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'exercise_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'latest_activity_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'streak_progress': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'struggling': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.userlog': {
+            'Meta': {'object_name': 'UserLog'},
+            'activity_type': ('django.db.models.fields.IntegerField', [], {}),
+            'end_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'last_active_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'start_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'total_seconds': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"})
+        },
+        u'main.userlogsummary': {
+            'Meta': {'object_name': 'UserLogSummary'},
+            'activity_type': ('django.db.models.fields.IntegerField', [], {}),
+            'count': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'device': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Device']"}),
+            'end_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'last_activity_datetime': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'start_datetime': ('django.db.models.fields.DateTimeField', [], {}),
+            'total_seconds': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']"}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        u'main.videolog': {
+            'Meta': {'object_name': 'VideoLog'},
+            'complete': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'completion_counter': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'completion_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'latest_activity_timestamp': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'points': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'total_seconds_watched': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityUser']", 'null': 'True', 'blank': 'True'}),
+            'video_id': ('django.db.models.fields.CharField', [], {'max_length': '200', 'db_index': 'True'}),
+            'youtube_id': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.device': {
+            'Meta': {'object_name': 'Device'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'public_key': ('django.db.models.fields.CharField', [], {'max_length': '500', 'db_index': 'True'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'version': ('django.db.models.fields.CharField', [], {'default': "'0.9.2'", 'max_length': '9', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.facility': {
+            'Meta': {'object_name': 'Facility'},
+            'address': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'address_normalized': ('django.db.models.fields.CharField', [], {'max_length': '400', 'blank': 'True'}),
+            'contact_email': ('django.db.models.fields.EmailField', [], {'max_length': '60', 'blank': 'True'}),
+            'contact_name': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'contact_phone': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'latitude': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'longitude': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'user_count': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"}),
+            'zoom': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'securesync.facilitygroup': {
+            'Meta': {'object_name': 'FacilityGroup'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'facility': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Facility']"}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.facilityuser': {
+            'Meta': {'object_name': 'FacilityUser'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'default_language': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'facility': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.Facility']"}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['securesync.FacilityGroup']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'is_teacher': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '60', 'blank': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'username': ('django.db.models.fields.CharField', [], {'max_length': '30'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        },
+        'securesync.zone': {
+            'Meta': {'object_name': 'Zone'},
+            'counter': ('django.db.models.fields.IntegerField', [], {'default': 'None', 'null': 'True', 'blank': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.CharField', [], {'max_length': '32', 'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'signature': ('django.db.models.fields.CharField', [], {'max_length': '360', 'null': 'True', 'blank': 'True'}),
+            'signed_by': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Device']"}),
+            'signed_version': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'zone_fallback': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'+'", 'null': 'True', 'to': "orm['securesync.Zone']"})
+        }
+    }
+
+    complete_apps = ['main']

--- a/kalite/main/models.py
+++ b/kalite/main/models.py
@@ -28,7 +28,7 @@ from securesync.models import DeferredCountSyncedModel, Device
 class VideoLog(DeferredCountSyncedModel):
 
     user = models.ForeignKey(FacilityUser, blank=True, null=True, db_index=True)
-    video_id = models.CharField(max_length=100, db_index=True); video_id.minversion="0.10.3"  # unique key (per-user)
+    video_id = models.CharField(max_length=200, db_index=True); video_id.minversion="0.10.3"  # unique key (per-user)
     youtube_id = models.CharField(max_length=20) # metadata only
     total_seconds_watched = models.IntegerField(default=0)
     points = models.IntegerField(default=0)
@@ -123,7 +123,7 @@ class VideoLog(DeferredCountSyncedModel):
 
 class ExerciseLog(DeferredCountSyncedModel):
     user = models.ForeignKey(FacilityUser, blank=True, null=True, db_index=True)
-    exercise_id = models.CharField(max_length=100, db_index=True)
+    exercise_id = models.CharField(max_length=200, db_index=True)
     streak_progress = models.IntegerField(default=0)
     attempts = models.IntegerField(default=0)
     points = models.IntegerField(default=0)
@@ -489,7 +489,7 @@ class AttemptLog(DeferredCountSyncedModel):
     minversion = "0.13.0"
 
     user = models.ForeignKey(FacilityUser, db_index=True)
-    exercise_id = models.CharField(max_length=100, db_index=True)
+    exercise_id = models.CharField(max_length=200, db_index=True)
     seed = models.IntegerField(default=0)
     answer_given = models.TextField(blank=True) # first answer given to the question
     points = models.IntegerField(default=0)
@@ -516,7 +516,7 @@ class ContentLog(DeferredCountSyncedModel):
     minversion = "0.13.0"
 
     user = models.ForeignKey(FacilityUser, blank=True, null=True, db_index=True)
-    content_id = models.CharField(max_length=100, db_index=True)
+    content_id = models.CharField(max_length=200, db_index=True)
     points = models.IntegerField(default=0)
     language = models.CharField(max_length=8, blank=True, null=True); language.minversion="0.10.3"
     complete = models.BooleanField(default=False)


### PR DESCRIPTION
Summary of changes:
* Data migration for latest_activity_timestamp to put in values where available
* Increases size of 'id' fields on log models to 200.