### PR TITLE
Calls remove on parent view first to remove from DOM to prevent multiple reflows.

### DIFF
--- a/python-packages/fle_utils/backbone/static/js/backbone/backbone-helpers.js
+++ b/python-packages/fle_utils/backbone/static/js/backbone/backbone-helpers.js
@@ -124,6 +124,9 @@ window.BaseView = Backbone.View.extend({
     },
 
     remove: function() {
+
+        Backbone.View.prototype.remove.call(this);
+
         if (this.subviews!==undefined) {
             for (i=0; i < this.subviews.length; i++) {
                 if (_.isFunction(this.subviews[i].close)) {
@@ -133,6 +136,5 @@ window.BaseView = Backbone.View.extend({
                 }
             }
         }
-        Backbone.View.prototype.remove.call(this);
     }
 });


### PR DESCRIPTION
General fix for a specific problem, witnessed when Hiding the Tabular Report View.

By removing the parent view first, we reflow only once.