### PR TITLE
Fix container-inside-container overflow issue.

### DIFF
--- a/kalite/control_panel/templates/control_panel/facility_management.html
+++ b/kalite/control_panel/templates/control_panel/facility_management.html
@@ -112,14 +112,12 @@
 {% endblock buttons %}
 
 {% block control_panel_content %}
-    <div class="container">
-        {# Coaches table #}
-        {% include "control_panel/partials/_coaches_table.html" %}
+    {# Coaches table #}
+    {% include "control_panel/partials/_coaches_table.html" %}
 
-        {# Groups table #}
-        {% include "control_panel/partials/_groups_table.html" %}
+    {# Groups table #}
+    {% include "control_panel/partials/_groups_table.html" %}
 
-        {# Students table #}
-        {% include "control_panel/partials/_students_table.html" %}
-    </div> <!-- End Container -->
+    {# Students table #}
+    {% include "control_panel/partials/_students_table.html" %}
 {% endblock control_panel_content %}

--- a/kalite/control_panel/templates/control_panel/zone_management.html
+++ b/kalite/control_panel/templates/control_panel/zone_management.html
@@ -43,13 +43,9 @@
 {% endblock buttons %}
 
 {% block control_panel_content %}
-
-<div class="container">
     {# Facilities Section #}
     {% include "control_panel/partials/_facility_table.html" %}
 
     {# Device Section #}
     {% include "control_panel/partials/_device_table.html" %}
-
-</div> <!-- End container -->
 {% endblock control_panel_content %}


### PR DESCRIPTION
(with a .container inside a .container, these inner divs were overflowing their parents; not so apparent on the distributed server, though noticeable, but super bad in the context of the central server's styling, which motivated the fix)

Before:

![image](https://cloud.githubusercontent.com/assets/618416/9322387/18933468-4527-11e5-9e41-becd2a2ee47a.png)


After:

![image](https://cloud.githubusercontent.com/assets/618416/9322365/c95f1e16-4526-11e5-9ec7-6f54d718e566.png)
