### PR TITLE
Expire cookies whenever we close the browser.

### DIFF
--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -467,6 +467,9 @@ KEY_PREFIX = version.VERSION
 # Separate session caching from file caching.
 SESSION_ENGINE = getattr(
     local_settings, "SESSION_ENGINE", 'django.contrib.sessions.backends.signed_cookies' + (''))
+    
+# Expire session cookies whenever we close the browser.
+SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
 # Use our custom message storage to avoid adding duplicate messages
 MESSAGE_STORAGE = 'fle_utils.django_utils.classes.NoDuplicateMessagesSessionStorage'


### PR DESCRIPTION
Since sessions are now stored in cookies, our default cookie expiration date may have some unintended consequences for computers with multiple KA Lite users. Admins who expect to get logged out on reboot, actually don't get logged out. 

This simple change ensures that the session cookie is cleared *when the browser is closed* ([not tab closed, browser closed](http://stackoverflow.com/questions/3976498/why-doesnt-session-expire-at-browser-close-true-log-the-user-out-when-the-bro)).