### PR TITLE
Add correct status message when running with a proxy setting (nginx)

### DIFF
--- a/kalitectl.py
+++ b/kalitectl.py
@@ -622,6 +622,10 @@ def status():
     Check the server's status. For possible statuses, see the status dictionary
     status.codes
 
+    Status *always* outputs the current status in the first line if stderr.
+    The following lines contain optional information such as the addresses where
+    the server is listening.
+
     :returns: status_code, key has description in status.codes
     """
     try:
@@ -637,7 +641,7 @@ def status():
             if hasattr(settings, 'PROXY_PORT'):
                 if settings.PROXY_PORT != port:
                     sys.stderr.write(
-                        "\n\nKA Lite configured behind another server, primary "
+                        "\nKA Lite configured behind another server, primary "
                         "addresses are:\n\n"
                     )
                     for addr in get_ip_addresses():

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -630,6 +630,24 @@ def status():
         sys.stderr.write("KA Lite running on:\n\n")
         for addr in get_ip_addresses():
             sys.stderr.write("\thttp://%s:%s/\n" % (addr, port))
+
+        # Import settings and check if a proxy port exists
+        try:
+            from django.conf import settings
+            if hasattr(settings, 'PROXY_PORT'):
+                if settings.PROXY_PORT != port:
+                    sys.stderr.write(
+                        "\n\nKA Lite configured behind another server, primary "
+                        "addresses are:\n\n"
+                    )
+                    for addr in get_ip_addresses():
+                        sys.stderr.write("\thttp://%s:%s/\n" % (addr, settings.PROXY_PORT))
+        except Exception as e:
+            sys.stderr.write(
+                "\n\nWarning, exception fetching KA Lite settings module:\n\n" +
+                str(e) + "\n\n"
+            )
+
         return STATUS_RUNNING
     except NotRunning as e:
         status_code = e.status_code

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -617,6 +617,38 @@ def stop(args=[], sys_exit=True):
         sys.exit(0)
 
 
+def get_urls():
+    """
+    Fetch a list of urls
+    :returns: STATUS_CODE, ['http://abcd:1234', ...]
+    """
+    try:
+        __, __, port = get_pid()
+        urls = []
+        for addr in get_ip_addresses():
+            urls.append("http://{}:{}/".format(addr, port))
+        return STATUS_RUNNING, urls
+    except NotRunning as e:
+        return e.status_code, []
+
+
+def get_urls_proxy():
+    """
+    Get addresses of the server if we're using settings.PROXY_PORT
+
+    :raises: Exception for sure if django.conf.settings isn't loaded
+    """
+    # Import settings and check if a proxy port exists
+    from django.conf import settings
+    if hasattr(settings, 'PROXY_PORT') and settings.PROXY_PORT:
+        sys.stderr.write(
+            "\nKA Lite configured behind another server, primary "
+            "addresses are:\n\n"
+        )
+        for addr in get_ip_addresses():
+            yield "http://{}:{}/".format(addr, settings.PROXY_PORT)
+
+
 def status():
     """
     Check the server's status. For possible statuses, see the status dictionary
@@ -628,33 +660,24 @@ def status():
 
     :returns: status_code, key has description in status.codes
     """
-    try:
-        __, __, port = get_pid()
+    status_code, urls = get_urls()
+
+    if status_code == STATUS_RUNNING:
         sys.stderr.write("{msg:s} (0)\n".format(msg=status.codes[0]))
         sys.stderr.write("KA Lite running on:\n\n")
-        for addr in get_ip_addresses():
-            sys.stderr.write("\thttp://%s:%s/\n" % (addr, port))
-
+        for addr in urls:
+            sys.stderr.write("\t{}\n".format(addr))
         # Import settings and check if a proxy port exists
         try:
-            from django.conf import settings
-            if hasattr(settings, 'PROXY_PORT'):
-                if settings.PROXY_PORT != port:
-                    sys.stderr.write(
-                        "\nKA Lite configured behind another server, primary "
-                        "addresses are:\n\n"
-                    )
-                    for addr in get_ip_addresses():
-                        sys.stderr.write("\thttp://%s:%s/\n" % (addr, settings.PROXY_PORT))
+            for addr in get_urls_proxy():
+                sys.stderr.write("\t{}\n".format(addr))
         except Exception as e:
             sys.stderr.write(
                 "\n\nWarning, exception fetching KA Lite settings module:\n\n" +
                 str(e) + "\n\n"
             )
-
         return STATUS_RUNNING
-    except NotRunning as e:
-        status_code = e.status_code
+    else:
         verbose_status = status.codes[status_code]
         sys.stderr.write("{msg:s} ({code:d})\n".format(
             code=status_code, msg=verbose_status))
@@ -709,13 +732,11 @@ def diagnose():
     diag("python", sys.version)
     diag("platform", platform.platform())
 
-    try:
-        __, __, port = get_pid()
-        for addr in get_ip_addresses():
-            diag("server address", "http://%s:%s/" % (addr, port))
-        status_code = STATUS_RUNNING
-    except NotRunning as e:
-        status_code = e.status_code
+    status_code, urls = get_urls()
+    for addr in urls:
+        diag("server address", addr)
+    for addr in get_urls_proxy():
+        diag("server proxy", addr)
 
     diag("server status", status.codes[status_code])
 


### PR DESCRIPTION
Example:

```
➜  ka-lite git:(kalite-command-proxy-status) bin/kalite status
OK, running (0)
KA Lite running on:

	http://192.168.40.146:7007/
	http://127.0.0.1:7007/

KA Lite configured behind another server, primary addresses are:

	http://192.168.40.146:8008/
	http://127.0.0.1:8008/
```