### PR TITLE
Bumping version to 0.15 to distinguish current develop branch

### DIFF
--- a/data/version.yml
+++ b/data/version.yml
@@ -1,3 +1,24 @@
+0.15:
+  release_date:
+  git_commit: ""
+  new_features:
+    all: []
+    students: []
+    coaches: []
+    admins: []
+
+  bugs_fixed:
+    all: []
+    students: []
+    coaches: []
+    admins: []
+
+  bugs_fixed:
+    all: []
+    students: []
+    coaches: []
+    admins: []
+
 0.14.dev0:
   release_date:
   git_commit: ""

--- a/kalite/version.py
+++ b/kalite/version.py
@@ -6,7 +6,7 @@ from kalite.shared.utils import open_json_or_yml
 # Must be PEP 440 compliant: https://www.python.org/dev/peps/pep-0440/
 # Must also be of the form N.N.N for internal use, where N is a non-negative integer
 MAJOR_VERSION = "0"
-MINOR_VERSION = "14"
+MINOR_VERSION = "15"
 PATCH_VERSION = "0"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)


### PR DESCRIPTION
@rtibbles or @jamalex could you build a 0.15 assessment.zip?

Anything else that needs doing?