### PR TITLE
Fix #4251. filter securesync api calls in the demo middleware.

### DIFF
--- a/kalite/distributed/demo_middleware.py
+++ b/kalite/distributed/demo_middleware.py
@@ -20,6 +20,7 @@ def is_static_file(path):
     url_exceptions = [
         "^/admin/*",
         "^/api/*",
+        "^/securesync/api/*",
         "^{url}/*".format(url=settings.STATIC_URL),
         "^/data/*",
         "^{url}/*".format(url=settings.MEDIA_URL),
@@ -33,6 +34,7 @@ def is_static_file(path):
             return True
 
     return False
+
 
 class LinkUserManual:
     """Shows a message with a link to the user's manual, from the homepage."""


### PR DESCRIPTION
Fixes #4251. The cause of the bug here is that messages are already rendered in the
template, but making an API call that's unfiltered (in this case
/securesync/api) causes another reload of the same messages from the
demo server, hence the duplicates.

The change here is simple: we just filter out /securesync/api/.

![image](https://cloud.githubusercontent.com/assets/191955/9390475/2c5d5cfc-4726-11e5-9818-0a44d9a64d62.png)
