### PR TITLE
Much strings -- i18n performance fixes.

### DIFF
--- a/kalite/i18n/__init__.py
+++ b/kalite/i18n/__init__.py
@@ -389,7 +389,7 @@ def update_jsi18n_file(code="en"):
     request.path = output_file
     request.session = {settings.LANGUAGE_COOKIE_NAME: code}
 
-    response = javascript_catalog(request, packages=('ka-lite.locale',), domain="django")
+    response = javascript_catalog(request, packages=('ka-lite.locale',), domain="djangojs")
     icu_js = ""
     for path in settings.LOCALE_PATHS:
         try:

--- a/python-packages/django/core/management/commands/makemessages.py
+++ b/python-packages/django/core/management/commands/makemessages.py
@@ -158,13 +158,12 @@ def process_file(file, dirpath, potfile, domain, verbosity,
         orig_file = os.path.join(dirpath, file)
         with open(orig_file) as fp:
             src_data = fp.read()
-        src_data = prepare_js_for_gettext(src_data)
         thefile = '%s.c' % file
         work_file = os.path.join(dirpath, thefile)
         with open(work_file, "w") as fp:
             fp.write(src_data)
         cmd = (
-            'xgettext -d %s -L C %s %s --keyword=gettext_noop '
+            'xgettext -d %s -L JavaScript %s %s --keyword=gettext_noop '
             '--keyword=gettext_lazy --keyword=ngettext_lazy:1,2 '
             '--keyword=pgettext:1c,2 --keyword=npgettext:1c,2,3 '
             '--from-code UTF-8 --add-comments=Translators -o - "%s"' %


### PR DESCRIPTION
Fixes #4276.

1. Restore the use of the `djangojs` domain. i18n js files are now less than 10KB.
2. Parse a lot of KA's JS strings, thanks to xgettext's builtin `JavaScript` parser.