### PR TITLE
Registration redirect does nothing when offline

### DIFF
--- a/kalite/updates/tests/__init__.py
+++ b/kalite/updates/tests/__init__.py
@@ -4,3 +4,4 @@ from base import *
 from class_tests import *
 from command_tests import *
 from unicode_tests import *
+from regression_tests import *

--- a/kalite/updates/tests/regression_tests.py
+++ b/kalite/updates/tests/regression_tests.py
@@ -1,0 +1,32 @@
+from django.conf import settings
+from django.test.utils import override_settings
+
+from fle_utils.internet.functions import am_i_online
+
+from securesync.models import Device
+
+from kalite.testing.base import KALiteClientTestCase
+from kalite.testing.mixins.django_mixins import CreateAdminMixin
+
+class RegistrationRedirectTestCase(CreateAdminMixin, KALiteClientTestCase):
+    """
+    Tests that the when the user is unregistered and "offline", they are not redirected to the registration page.
+    "Offline" in this case just means the central server is unreachable.
+    See #4282: https://github.com/learningequality/ka-lite/issues/4282
+    """
+
+    def setUp(self):
+        super(RegistrationRedirectTestCase, self).setUp()
+        admin_data = {"username": "admin", "password": "admin"}
+        self.create_admin(**admin_data)
+        self.client.login(**admin_data)
+
+    @override_settings(CENTRAL_SERVER_URL="http://127.0.0.1:8997")  # We hope this is unreachable
+    def test_not_redirected_when_offline(self):
+        self.assertFalse(Device.get_own_device().is_registered(), "The device should be unregistered!")
+        self.assertFalse(am_i_online(url=settings.CENTRAL_SERVER_URL), "Central server should be unreachable!")
+        updated_videos_url = self.reverse("update_videos")
+        response = self.client.get(updated_videos_url, follow=True)
+        redirect_chain = response.redirect_chain  # Will be the empty list if there are no redirects
+        self.assertFalse(redirect_chain, "Should not be redirected when the central server is not reachable! "
+                                         "Redirect chain: {0}".format(redirect_chain))

--- a/python-packages/securesync/devices/decorators.py
+++ b/python-packages/securesync/devices/decorators.py
@@ -1,10 +1,11 @@
+from django.conf import settings
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext as _
 
 from .models import Device
-from fle_utils.internet.functions import set_query_params
+from fle_utils.internet.functions import set_query_params, am_i_online
 
 
 def require_registration(resource_name):
@@ -13,10 +14,14 @@ def require_registration(resource_name):
     """
     def real_decorator_wrapper(handler):
         def real_decorator_wrapper_fn(request, *args, **kwargs):
-            if Device.get_own_device().is_registered():
+            if Device.get_own_device().is_registered() or not am_i_online(settings.CENTRAL_SERVER_URL):
                 return handler(request, *args, **kwargs)
             else:
-                messages.warning(request, _("In order to access %(resource_name)s, you must register your device first." % {"resource_name": unicode(resource_name)}))
+                messages.warning(
+                    request,
+                    _("In order to access %(resource_name)s, you must register your device first."
+                      % {"resource_name": unicode(resource_name)})
+                )
                 return HttpResponseRedirect(
                     set_query_params(reverse('register_public_key'), {'next': request.path})
                 )


### PR DESCRIPTION
Fixes #4282. Replaces #4283. Implemented as a client test instead of a browser test (execution time of ~10s vs ~30s).