### PR TITLE
0.14b4

### DIFF
--- a/kalite/version.py
+++ b/kalite/version.py
@@ -7,7 +7,7 @@ from kalite.shared.utils import open_json_or_yml
 # Must also be of the form N.N.N for internal use, where N is a non-negative integer
 MAJOR_VERSION = "0"
 MINOR_VERSION = "14"
-PATCH_VERSION = "0"
+PATCH_VERSION = "beta4"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
 


### PR DESCRIPTION
**WARNING!** Merging this, merges and closes all PRs contained in this PR, and they may have a separate review process and amendments following. So don't merge this PR!! :)

New release, manually brewing the distributions:

 * [x] [ka-lite on pypi](https://pypi.python.org/pypi/ka-lite)
 * [x] [ka-lite-static on pypi](https://pypi.python.org/pypi/ka-lite-static)
 * [ ] [ka-lite on Launchpad PPA](https://launchpad.net/~learningequality/+archive/ubuntu/ka-lite)
 * [ ] OSX installer
 * [ ] Windows installer

## Known issues

None ATM. Please update this @aronasorman @MCGallaspy if there are known issues worh a mention that've been pushed to 0.15.

Debian/Ubuntu:

* [x] Replaced python-setuptools with python-pkg-resources to remove non-default dependencies on ka-lite and ka-lite-bundle
* [ ] We still need a separate PPA for ka-lite-bundle. This does not affect the release of the .deb, it doesn't matter where it's built.
* [ ] Ubuntu Software Center seems to hang while installing ka-lite: https://github.com/learningequality/installers/issues/145

## Included PRs

(none)

## Installer links

  * [Windows](http://field.learningequality.org/KALiteSetup-0.14.0.exe)
  * [Mac]()