### PR TITLE
DB Backup: Fix backup_filepath referencing issue and error out invalid filepath

### DIFF
--- a/kalite/distributed/management/commands/restorebackup.py
+++ b/kalite/distributed/management/commands/restorebackup.py
@@ -18,9 +18,12 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        backup_filepath = options['backup_filepath']
         if(options['backup_filepath']):
             if(os.path.isfile(backup_filepath)):
                 call_command('dbrestore', filepath=backup_filepath, database='default') #perform restore from the given filepath
+            else:
+                print 'The given file was not found.'
         else:
             file_list = os.listdir(settings.BACKUP_DIRPATH) #Retrieve the filenames present in the BACKUP_DIRPATH
             filelist = []

--- a/kalite/distributed/management/commands/restorebackup.py
+++ b/kalite/distributed/management/commands/restorebackup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
@@ -24,10 +25,10 @@ class Command(BaseCommand):
                 call_command('dbrestore', filepath=backup_filepath, database='default') #perform restore from the given filepath
             else:
                 print 'The given file was not found.'
+                sys.exit(1)
         else:
             file_list = os.listdir(settings.BACKUP_DIRPATH) #Retrieve the filenames present in the BACKUP_DIRPATH
             filelist = []
-            filenumber = 0
             for i, f in enumerate(file_list):
                 print i, f.replace(".backup", "")
                 filelist.append(f)
@@ -40,5 +41,7 @@ class Command(BaseCommand):
                     call_command('dbrestore', filepath=backup_filepath, database='default') #perform restore
                 except IndexError:
                     print 'Number option out of bounds.'
+                    sys.exit(1)
             else:
                 print 'No files available to restore.'
+                sys.exit(1)


### PR DESCRIPTION
DB Backup currently has a functionality for restoring backup from a given file. This PR fixes the referencing issue in 'restorebackup' management command which occurs while restoring a backup from a given file. Also, prints an error message if the given filepath is invalid.