### PR TITLE
Remove duplicate requirements

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,3 @@
 werkzeug # Not sure about version
 django-debug-toolbar # Version was not described in previously bundled files, used by kalite.testing app
 pyyaml==3.11
-hachoir-core==1.3.3
-hachoir-parser==1.3.4
-hachoir-metadata==1.3.3


### PR DESCRIPTION
These requirements are duplicated in `requirements_test.txt`, resulting in an error when you run `pip install -r requirements_dev.txt`.