### PR TITLE
remove absolute with of the `th.headrow, th.headrow div`

### DIFF
--- a/kalite/coachreports/static/css/coachreports/tabular_view.css
+++ b/kalite/coachreports/static/css/coachreports/tabular_view.css
@@ -61,7 +61,6 @@ table.tab_report th.username {
 }
 
 th.headrow, th.headrow div {
-    width: 80px;
     table-layout: fixed;
     font-weight: bold;
     word-wrap: break-word;


### PR DESCRIPTION
Hi @aronasorman and @MCGallaspy  - this fixes #4340

**Branch:** 0.15.x

**Expected Behaviour:** Able to remove the unwanted line breaks in the titles. 
![screenshot 2015-09-09 14 57 23](https://cloud.githubusercontent.com/assets/4099119/9755447/b2e32c82-5704-11e5-8cc8-6b1ea599d967.png)

**Current Behavior:**  Long words in content titles have weird line breaks.
![screenshot 2015-09-09 14 56 41](https://cloud.githubusercontent.com/assets/4099119/9755478/de1628aa-5704-11e5-91c9-6f28b4f2dd3c.png)

I remove the declared absolute value of the `th.headrow` that causes to have line breaks in the titles.