### PR TITLE
Reduce number of ajax requests in content rating

### DIFF
--- a/kalite/distributed/static/js/distributed/rating/views.js
+++ b/kalite/distributed/static/js/distributed/rating/views.js
@@ -20,11 +20,7 @@ module.exports = BaseView.extend({
         /*
             Prepare self and subviews.
         */
-        this.model = options.model || function() {
-            var model = new Backbone.Model();
-            model.url = "/api/not/gonna/work";
-            return model;
-        }();
+        this.model = options.model || null;
         _.bindAll(this, "delete_callback", "renderAll", "renderSequence", "render");
         this.quality_label_values = {
             1:  gettext("Poor quality"),
@@ -162,7 +158,8 @@ var StarView = BaseView.extend({
         var target = $(ev.target).hasClass("star-rating-option") ? $(ev.target) : $(ev.target).parents(".star-rating-option")[0];
         var val = $(target).attr("data-val");
         this.model.set(this.rating_attr, val);
-    }, 100, true),
+        this.model.debounced_save();
+    }, 500, true),
 
     mouse_enter_callback: function(ev) {
         // The target event could be either the .star-rating-option or a child element, so whatever the case get the
@@ -182,7 +179,6 @@ var StarView = BaseView.extend({
             $opt = $(opt);
             $opt.toggleClass("activated", parseInt($opt.attr("data-val")) <= parseInt(this.model.get(this.rating_attr)));
         }, this);
-        this.model.save();
     }
 });
 

--- a/kalite/distributed/static/js/distributed/rating/views.js
+++ b/kalite/distributed/static/js/distributed/rating/views.js
@@ -61,11 +61,17 @@ module.exports = BaseView.extend({
 
         var self = this;
 
-        this.listenToOnce(this.model, "change:quality", function(){
+        // If the "quality" is already set, display "difficulty" immediately. Otherwise wait.
+        if (parseInt(this.model.get("quality")) === 0) {
+            this.listenToOnce(this.model, "change:quality", function(){
+                self.star_view_difficulty = self.add_subview(StarView, {title: gettext("Difficulty"), el: self.$("#star-container-difficulty"), model: self.model, rating_attr: "difficulty", label_values: this.difficulty_label_values});
+            });
+        } else {
             self.star_view_difficulty = self.add_subview(StarView, {title: gettext("Difficulty"), el: self.$("#star-container-difficulty"), model: self.model, rating_attr: "difficulty", label_values: this.difficulty_label_values});
-        });
+        }
 
         this.listenToOnce(this.model, "change:difficulty", this.renderAll);
+
     },
 
     renderAll: function() {

--- a/kalite/distributed/static/js/distributed/topics/views.js
+++ b/kalite/distributed/static/js/distributed/topics/views.js
@@ -84,27 +84,22 @@ var ContentAreaView = BaseView.extend({
 
         // Secondly, if the rating_view is previously deleted or never shown before at all, then define it.
         if( typeof this.rating_view === "undefined" ) {
-            this.rating_view = this.add_subview(RatingView, {
-                model: new RatingModel({
-                    "user": window.statusModel.get("user_uri"),
-                    "content_kind": "",
-                    "content_id": ""
-                })
-            });
+            this.rating_view = this.add_subview(RatingView, {});
             this.$("#rating-container-wrapper").append(this.rating_view.el);
         }
 
         // Finally, handle the actual display logic
-        if( this.rating_view.model.get("content_id") !== this.model.get("id") ) {
+        if( this.rating_view.model === null || this.rating_view.model.get("content_id") !== this.model.get("id") ) {
             var self = this;
             this.content_rating_collection.fetch().done(function(){
+                // Queue up a save on the model we're about to switch out, in case it hasn't been synced.
+                if (self.rating_view.model !== null && self.rating_view.model.hasChanged()) {
+                    self.rating_view.model.debounced_save();
+                }
                 if(self.content_rating_collection.models.length === 1) {
                     self.rating_view.model = self.content_rating_collection.pop();
                     self.rating_view.render();
                 } else if ( self.content_rating_collection.models.length === 0 ) {
-                    // Since RatingModel uses debounced syncing, let's force one immediate sync before switching out
-                    // the model.
-                    self.rating_view.model.save();
                     self.rating_view.model = new RatingModel({
                             "user": window.statusModel.get("user_uri"),
                             "content_kind": self.model.get("kind"),


### PR DESCRIPTION
Fixes #4407. @rtibbles I wasn't able to replicate the exact circumstances you reported, but I did pare down the # of requests as much as possible. See commit messages for details. Also addresses another issue I noticed.

There is an extra PUT request after POST requests to create a new rating model. It seems to be done automatically -- can we live with that?