### PR TITLE
Style splash image responsively

### DIFF
--- a/kalite/distributed/static/css/distributed/homepage.css
+++ b/kalite/distributed/static/css/distributed/homepage.css
@@ -27,8 +27,7 @@
 }
 
 #suggested-action-image-link-homepage {
-    display: block;
-    width: 100%;
+    margin: auto;
 }
 
 .suggested-action-title {

--- a/kalite/distributed/templates/distributed/homepage.html
+++ b/kalite/distributed/templates/distributed/homepage.html
@@ -33,7 +33,7 @@
             <div class="col-sm-4 col-sm-push-4 col-xs-10 col-xs-push-1 vertical-shadow suggested-action">
                 <a href="{% url 'learn' %}">
                      <h3 class="suggested-action-title">{% trans "Learn!" %}</h3>
-                     <img id="suggested-action-image-link-homepage" src="/data/{{ channel }}/images/logo_10_enlarged_2.png" alt="{% trans 'Learn with Khan Academy videos and exercises!' %}">
+                     <img class="img-responsive" id="suggested-action-image-link-homepage" src="/data/{{ channel }}/images/logo_10_enlarged_2.png" alt="{% trans 'Learn with Khan Academy videos and exercises!' %}">
                 </a>
             </div>
         </div>


### PR DESCRIPTION
Fixes #4432. Here's how it looks in various viewport sizes:

__Normal__
![ss2](https://cloud.githubusercontent.com/assets/8888020/9914880/da3654a8-5c68-11e5-8e3a-4ccb14debdb0.png)

__Smaller__
![ss3](https://cloud.githubusercontent.com/assets/8888020/9914881/da382300-5c68-11e5-80c2-52e1cb759bf0.png)

__Smallest__ (when the hamburger shows up)
![ss4](https://cloud.githubusercontent.com/assets/8888020/9914882/da546718-5c68-11e5-9ccf-ebc0d64caf12.png)
