### PR TITLE
Import channel test

### DIFF
--- a/kalite/contentload/management/commands/channels/import_channel.py
+++ b/kalite/contentload/management/commands/channels/import_channel.py
@@ -74,7 +74,7 @@ channel_data = {
 
 whitewash_node_data = partial(base.whitewash_node_data, channel_data=channel_data)
 
-def build_full_cache(items, id_key="id"):
+def build_full_cache(items, id_key="id", ids=None):
     """
     Uses list of items retrieved from building the topic tree
     to create an item cache with look up keys.

--- a/kalite/contentload/management/commands/contentload.py
+++ b/kalite/contentload/management/commands/contentload.py
@@ -66,17 +66,19 @@ class Command(NoArgsCommand):
         make_option('-c', '--channel',
             dest='channel',
             default="khan",
-            help='Create content files for a channel'),
+            help='Create content files for a channel. Value of argument is the name of the channel.'),
         make_option('-i', '--import',
             action='store',
             dest='import_files',
             default=None,
-            help="Import a file structure as a topic tree and move over the appropriate content"),
+            help=("Import a file structure as a topic tree and move over the appropriate content.\n"
+                  "The value of this argument is the path to the content to be imported.")),
         make_option('-d', '--data',
             action='store',
             dest='channel_data',
             default=None,
-            help="Add custom path to channel data files"),
+            help=("Add custom path to channel data files.\n"
+                  "Value of the argument is path to channel metadata file.")),
     )
 
     def handle(self, *args, **options):

--- a/kalite/contentload/management/commands/contentload.py
+++ b/kalite/contentload/management/commands/contentload.py
@@ -98,6 +98,8 @@ class Command(NoArgsCommand):
             if not channel_name or channel_name=="khan":
                 channel_name = os.path.basename(options["import_files"])
 
+        assert channel_name, "Channel name must not be empty. Make sure you used correct arguments."
+
         if options["channel_data"]:
             channel_tools.channel_data_path = options["channel_data"]
 

--- a/kalite/contentload/management/commands/contentload.py
+++ b/kalite/contentload/management/commands/contentload.py
@@ -72,13 +72,15 @@ class Command(NoArgsCommand):
             dest='import_files',
             default=None,
             help=("Import a file structure as a topic tree and move over the appropriate content.\n"
-                  "The value of this argument is the path to the content to be imported.")),
+                  "The value of this argument is the path to the content to be imported."
+                  "Do not include a trailing slash.")),
         make_option('-d', '--data',
             action='store',
             dest='channel_data',
             default=None,
             help=("Add custom path to channel data files.\n"
-                  "Value of the argument is path to channel metadata file.")),
+                  "Value of the argument is path to directory containing channel metadata file(s?)."
+                  "Do not include trailing slash.")),
     )
 
     def handle(self, *args, **options):


### PR DESCRIPTION
On this branch, I ran this command:
`python bin\kalite manage contentload --import=D:\ka-lite\import_test\`

Got this output:
```
WARNING:kalite:No metadata for file
WARNING:kalite:No metadata for file
WARNING:kalite:Title missing from file , using file name instead
WARNING:kalite:No metadata for file
WARNING:kalite:Title missing from file , using file name instead
WARNING:kalite:Title missing from file , using file name instead
WARNING:kalite:Removing childless topic: _1
WARNING:kalite:Removing childless topic: _2
INFO:kalite:Downloaded topic_tree data for
            0 exercises
            0 content files
            0 assessment items

```

After staring the server (and changed the settings to use new channel) it's apparently empty.

Archive of `D:\ka-lite\import_test\`: https://www.dropbox.com/s/00ruyucsa8ifraq/import_test.7z?dl=0

Looking in to it. Any insight @rtibbles?