### PR TITLE
Properly triggers login on API 403.

### DIFF
--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -457,7 +457,7 @@ var UserView = BaseView.extend({
             // Check the GET params to see if a 'login' flag has been set
             // If this is the case, the modal should start open
             var login = get_params.getParamValue("login");
-            if (login) {
+            if (login || this.login_start_open) {
                 // Set an option for the modal to start open
                 options.start_open = true;
             }

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -469,7 +469,9 @@ var UserView = BaseView.extend({
                 // If there is already a loginModalView for some reason, just set the above options on it
                 // and rerender
                 this.loginModalView.set_options(options);
-                this.loginModalView.render();
+                if (this.login_start_open) {
+                    this.loginModalView.show_modal();
+                }
             } else {
                 // Otherwise just start the modal view with these options, but add in the statusModel with it
                 options.model = this.model;

--- a/kalite/distributed/static/js/distributed/utils/api.js
+++ b/kalite/distributed/static/js/distributed/utils/api.js
@@ -65,9 +65,8 @@ function handleFailedAPI(resp, error_prefix) {
         case 403:
             messages = {error: gettext("You are not authorized to complete the request.  Please login as an authorized user, then retry the request.")};
             if (window.statusModel) {
-                window.statusModel.fetch().success(function() {
-                    window.userView.login_start_open = true;
-                });
+                window.toggleNavbarView.userView.login_start_open = true;
+                window.statusModel.fetch();
             }
             break;
 


### PR DESCRIPTION
Fixes #4449 

Currently, if you are logged out and an API request returns a 403 forbidden, then our modal login does not get triggered (it will produce a Javascript error instead).

To test this, go to developer console, resources, and delete the sessionId cookie while on the video download page.