### PR TITLE
Adds warning to restart the server on language pack download completion.

### DIFF
--- a/kalite/updates/static/js/updates/bundle_modules/update_languages.js
+++ b/kalite/updates/static/js/updates/bundle_modules/update_languages.js
@@ -216,7 +216,8 @@ $('#beta-checkbox').click(function() {
 //
 
 var languagepack_callbacks = {
-    reset: languagepack_reset_callback
+    reset: languagepack_reset_callback,
+    completed: languagepage_complete_callback
 };
 
 function start_languagepack_download(lang_code) {
@@ -279,6 +280,11 @@ function languagepack_reset_callback(progress, resp) {
     // This will get the latest list of installed languages, and refresh the display.
     get_installed_languages();
     downloading = false;
+}
+
+function languagepack_complete_callback(progress_log) {
+    // Trigger a reminder to restart server when a language pack is installed.
+    messages.show_message("warning", sprintf(gettext("Server must be restarted to activate language pack %(lang)s."), {lang: process_log.process_name}));
 }
 
 function set_server_language(lang) {

--- a/kalite/updates/static/js/updates/updates/base.js
+++ b/kalite/updates/static/js/updates/updates/base.js
@@ -147,6 +147,9 @@ function updatesCheck(process_name, interval) {
                     message = progress_log.notes || (gettext("Completed update successfully.") + " [" + process_name + "]");
                     messages.clear_messages();
                     messages.show_message("success", message);
+                    if (process_callbacks[process_name] && process_callbacks[process_name]["completed"]) {
+                        process_callbacks[process_name]["completed"](process_log);
+                    }
                     updatesReset(process_name);
                 } else if (progress_log.completed && progress_log.stage_status == "cancelled") {
                     messages.show_message("info", gettext("Update cancelled successfully.") + " [" + process_name + "]");


### PR DESCRIPTION
Fixes #4070 

Originally was trying to make this for 0.15.x, but no suitable strings to recycle to dodge string freeze.