### PR TITLE
Don't autofocus on first element to make access to search page easier for keyboard users.

### DIFF
--- a/kalite/distributed/static/js/distributed/search/views.js
+++ b/kalite/distributed/static/js/distributed/search/views.js
@@ -90,7 +90,7 @@ var AutoCompleteView = BaseView.extend({
         this.$el.html(this.template({search_url: window.Urls.search()}));
 
         this.$("#search").autocomplete({
-            autoFocus: true,
+            autoFocus: false,
             minLength: 3,
             appendTo: ".navbar-collapse",
             html: true,  // extension allows html-based labels


### PR DESCRIPTION
Fixes #4011