### PR TITLE
Remove duplicate TestCase subclass

### DIFF
--- a/kalite/contentload/tests/generate_assessment_zips.py
+++ b/kalite/contentload/tests/generate_assessment_zips.py
@@ -67,19 +67,6 @@ class TestUrlConversion(TestCase):
         self.assertNotIn("web+graphie://ka-perseus", new_item_data)
 
 
-class TestUrlConversion(TestCase):
-    
-    def test_url_converted(self):
-        url_string = "A string with http://example.com/cat_pics.gif"
-        expected_string = "A string with /content/khan/cat_pics.gif"
-        self.assertEqual(expected_string, mod.convert_urls(url_string))
-    
-    def test_multiple_urls_in_one_string_converted(self):
-        url_string = "A string with http://example.com/cat_pics.JPEG http://example.com/cat_pics2.gif"
-        expected_string = "A string with /content/khan/cat_pics.JPEG /content/khan/cat_pics2.gif"
-        self.assertEqual(expected_string, mod.convert_urls(url_string))
-
-
 class GenerateAssessmentItemsCommandTests(KALiteTestCase):
 
     def setUp(self):


### PR DESCRIPTION
TestUrlConversion is defined twice... one was clearly inadvertantly left in, since
  the other has the same tests, but updated.

Let's see if our test overlords agree.