### PR TITLE
Add get_cookie to base module & global scope

### DIFF
--- a/kalite/distributed/static/js/distributed/bundle_modules/base.js
+++ b/kalite/distributed/static/js/distributed/bundle_modules/base.js
@@ -14,6 +14,9 @@ require("browsernizr/test/canvas");
 require("browsernizr/test/touchevents");
 var Modernizr = require("browsernizr");
 
+// Expose this as a global object for use in central server inline JS.
+global.getCookie = require("utils/get_cookie");
+
 global.$ = $;
 global._ = _;
 global.sessionModel = new SessionModel();

--- a/python-packages/fle_utils/django_utils/command.py
+++ b/python-packages/fle_utils/django_utils/command.py
@@ -153,7 +153,7 @@ def call_outside_command_with_output(command, *args, **kwargs):
 
     # build the command
     if kalite_dir:
-        kalite_bin = os.path.join(kalite_dir, "bin/kalite")
+        kalite_bin = os.path.join(kalite_dir, "bin", "kalite")
     else:
         kalite_bin = 'kalite'
 


### PR DESCRIPTION
Add it to the global scope, so that it can be accessed by inline JS
  in central server templates.

@rtibbles is this what you were thinking?