### PR TITLE
Update install_all.rst

### DIFF
--- a/docs/installguide/install_all.rst
+++ b/docs/installguide/install_all.rst
@@ -72,7 +72,7 @@ It can be installed by downloading the latest .deb on the Pi and installing it::
     # Install dependencies
     sudo apt-get install python-m2crypto python-pkg-resources nginx python-psutil
     # Fetch the latest .deb
-    sudo wget https://learningequality.org/r/deb-pi-installer-0-14
+    sudo wget https://learningequality.org/r/deb-pi-installer-0-14 --no-check-certificate
     # Install the .deb
     sudo dpkg -i ka-lite-raspberry-pi*.deb
 


### PR DESCRIPTION
Raspbian uses an old distribution of wget resulting in a certificate error upon attempting the download as documented in the installation guidelines. Including the "--no-check-certificate" parameter fixes this issue.