### PR TITLE
Generate a secret key file, and load SECRET_KEY from said file.

### DIFF
--- a/kalite/settings/_utils.py
+++ b/kalite/settings/_utils.py
@@ -1,0 +1,17 @@
+import base64
+import sys
+import uuid
+
+
+def generate_secret_key():
+    key = base64.b64encode(str(uuid.uuid4()))
+    return key
+
+
+def cache_secret_key(key, key_file_path):
+    try:
+        with open(key_file_path, "w") as f:
+            f.write(key)
+            f.flush()
+    except Exception as e:
+        sys.stderr.write("Error writing secret key file. Error was: %s\n" % e)

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -314,8 +314,20 @@ USE_I18N = getattr(local_settings, "USE_I18N", True)
 USE_L10N = getattr(local_settings, "USE_L10N", False)
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = getattr(local_settings, "SECRET_KEY",
-                     "8qq-!fa$92i=s1gjjitd&%s@4%ka9lj+=@n7a&fzjpwu%3kd#u")
+SECRET_KEY_FILE = getattr(local_settings,
+                          "SECRET_KEY_FILE",
+                          os.path.join(USER_DATA_ROOT, "secretkey.txt"))
+
+
+try:
+    with open(SECRET_KEY_FILE) as f:
+        SECRET_KEY = getattr(local_settings, "SECRET_KEY", f.read())
+except Exception as e:
+    sys.stderr.write("Error reading secret key file. Generating one now. Error was: %s\n" % e)
+
+    from ._utils import generate_secret_key, cache_secret_key
+    SECRET_KEY = generate_secret_key()
+    cache_secret_key(SECRET_KEY, SECRET_KEY_FILE)
 
 LANGUAGE_COOKIE_NAME = "django_language"
 
@@ -467,7 +479,7 @@ KEY_PREFIX = version.VERSION
 # Separate session caching from file caching.
 SESSION_ENGINE = getattr(
     local_settings, "SESSION_ENGINE", 'django.contrib.sessions.backends.signed_cookies' + (''))
-    
+
 # Expire session cookies whenever we close the browser.
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 


### PR DESCRIPTION
Fixes #4213. We already have said vulnerability wherein the SECRETT_KEY is both public and the same for each installation. With the introduction of sessions-in-cookies it's a double whammy.

So now the solution is to create a secret key file for each installation if it's not detected, and load that as the value of SECRET_KEY.

Assigning @jamalex, but @benjaoming please take a look too.