### PR TITLE
Massage the Popen arguments into windows form

### DIFF
--- a/python-packages/fle_utils/django_utils/command.py
+++ b/python-packages/fle_utils/django_utils/command.py
@@ -157,7 +157,7 @@ def call_outside_command_with_output(command, *args, **kwargs):
     else:
         kalite_bin = 'kalite'
 
-    cmd = (kalite_bin, "manage", command)
+    cmd = (kalite_bin, "manage", command) if os.name != "nt" else (sys.executable, kalite_bin, "manage", command)
     for arg in args:
         cmd += (arg,)
 


### PR DESCRIPTION
On windows we need to specify the python interpreter for invoking bin/kalite.

This allows me to run tests on the central server on Windows.