### PR TITLE
Don't invalidate caches on the Mac, and warn users that they need to restart after video download

### DIFF
--- a/kalite/caching/__init__.py
+++ b/kalite/caching/__init__.py
@@ -19,6 +19,7 @@ For any app implementing cacheable data or writing to the web cache, the app sho
 """
 import os
 import glob
+import sys
 
 from django.conf import settings; logging = settings.LOG
 from django.core.urlresolvers import reverse
@@ -79,7 +80,9 @@ def invalidate_all_caches():
         
         for filename in glob.glob(os.path.join(CHANNEL_DATA_PATH, "*.cache")):
             os.remove(filename)
-    else:
+    elif sys.platform != 'darwin':
+        # Macs have to run video download in a subprocess, and as this is only ever called during runtime from
+        # video download or the videoscan subprocess, this never actually affects variables in the main KA Lite thread.
         initialize_content_caches(force=True)
     if caching_is_enabled():
         invalidate_web_cache()

--- a/kalite/updates/views.py
+++ b/kalite/updates/views.py
@@ -1,3 +1,5 @@
+import sys
+
 from annoying.decorators import render_to
 
 from django.utils.translation import ugettext as _, ugettext_lazy
@@ -32,7 +34,7 @@ def update_videos(request, max_to_show=4):
     if getattr(settings, 'USING_RASPBERRY_PI', False):
         messages.warning(request, _('For low-powered devices like the Raspberry Pi, please download less than 25 videos at a time.'))
 
-    if DO_NOT_RELOAD_CONTENT_CACHE_AT_STARTUP:
+    if DO_NOT_RELOAD_CONTENT_CACHE_AT_STARTUP or sys.platform == 'darwin':
         messages.warning(request, _('After video download, the server must be restarted for them to be available to users.'))
     context.update({
         "video_count": VideoFile.objects.filter(percent_complete=100).count(),


### PR DESCRIPTION
edit by @cpauya: fixes #4483