### PR TITLE
Add Makefile and distribute docs in sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,15 @@ static-updates
 # Python compiling
 *.pyc
 *.pyo
+
+# Backup files
 *~
+
+# Sublime editor
 *.sublime-*
+
+# Ignore all .zip files!? No comment?? Needs fixing, I guess it's to avoid
+# committing local assessment items.
 *.zip
 
 # Documentation

--- a/MANIFEST.in.dist
+++ b/MANIFEST.in.dist
@@ -22,3 +22,6 @@ recursive-include static-libraries *
 recursive-include data *
 
 recursive-exclude python-packages *pyc
+
+# Docs
+recursive-include docs/_build/html *

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,82 @@
+.PHONY: clean-pyc clean-build docs clean
+
+help:
+	@echo "clean - remove all build, test, coverage and Python artifacts"
+	@echo "clean-build - remove build artifacts"
+	@echo "clean-pyc - remove Python file artifacts"
+	@echo "clean-test - remove test and coverage artifacts"
+	@echo "lint - check style with pep8"
+	@echo "test - run tests quickly with the default Python"
+	@echo "test-all - run tests on every Python version with tox DISABLED"
+	@echo "assets - build all JS/CSS assets"
+	@echo "coverage - check code coverage quickly with the default Python"
+	@echo "docs - generate Sphinx HTML documentation, including API docs"
+	@echo "release - package and upload a release"
+	@echo "dist - package locally"
+	@echo "install - install the package to the active Python's site-packages"
+
+clean: clean-build clean-pyc clean-test
+
+clean-build:
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	rm -fr dist-packages/
+	rm -fr dist-packages-temp/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test:
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+
+lint:
+	pep8 kalite
+
+test:
+	python setup.py test
+
+test-all:
+	@echo "Not supported yet"
+	# tox
+
+coverage:
+	coverage run --source kalite_gtk setup.py test
+	coverage report -m
+	coverage html
+	open htmlcov/index.html
+
+docs:
+	# rm -f docs/ka-lite.rst
+	# rm -f docs/modules.rst
+	# sphinx-apidoc -o docs/ ka-lite-gtk
+	$(MAKE) -C docs clean
+	$(MAKE) -C docs html
+	# open docs/_build/html/index.html
+
+assets: clean
+	# Necessary because NPM may have wrong versions in the cache
+	npm cache clean
+	npm install --production
+	node build.js
+	bin/kalite manage compileymltojson
+
+release: clean docs assets
+	python setup.py sdist --formats=gztar,zip upload --sign
+	python setup.py sdist --formats=gztar,zip upload --sign --static
+	ls -l dist
+
+dist: clean docs assets
+	python setup.py sdist
+	python setup.py sdist --static
+	ls -l dist
+
+install: clean
+	python setup.py install

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ help:
 	@echo "clean-pyc - remove Python file artifacts"
 	@echo "clean-test - remove test and coverage artifacts"
 	@echo "lint - check style with pep8"
-	@echo "test - run tests quickly with the default Python"
-	@echo "test-all - run tests on every Python version with tox DISABLED"
+	@echo "test - run tests the default Python"
+	@echo "test-bdd - run BDD tests only"
+	@echo "test-nobdd - run non-BDD tests only"
 	@echo "assets - build all JS/CSS assets"
 	@echo "coverage - check code coverage quickly with the default Python"
 	@echo "docs - generate Sphinx HTML documentation, including API docs"
@@ -39,19 +40,32 @@ clean-test:
 
 lint:
 	pep8 kalite
+	jshint kalite/*/static/js/*/
 
 test:
-	python setup.py test
+	bin/kalite manage test --bdd-only
+
+test-bdd:
+	bin/kalite manage test --bdd-only
+
+test-nobdd:
+	bin/kalite manage test --no-bdd
 
 test-all:
 	@echo "Not supported yet"
 	# tox
 
 coverage:
-	coverage run --source kalite_gtk setup.py test
+	coverage run --source kalite kalitectl.py test
 	coverage report -m
-	coverage html
-	open htmlcov/index.html
+
+coverage-bdd:
+	coverage run --source kalite kalitectl.py test --bdd-only
+	coverage report -m
+
+coverage-nobdd:
+	coverage run --source kalite kalitectl.py test --no-bdd
+	coverage report -m
 
 docs:
 	# rm -f docs/ka-lite.rst

--- a/circle.yml
+++ b/circle.yml
@@ -7,24 +7,25 @@ dependencies:
     - "data"
     - "sc-latest-linux"
   override:
+    - make sdist
     - pip install -r requirements_test.txt
-    - pip install -e .
-    - npm install
-    - npm install -g jshint
+    - pip install dist/ka-lite-"$(python setup.py --version)".tar.gz
   post:
     - if [[ ! -e sc-latest-linux/bin/sc ]]; then wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz && tar -xzf sc-latest-linux.tar.gz &&  mv sc-*-linux sc-latest-linux; fi
 
 test:
   override:
-    - node build.js
+    - make assets
     - kalite start --settings=kalite.project.settings.disk_based_cache --traceback -v2
     - kalite status
     - kalite stop --traceback -v2
     - cd sc-*-linux && ./bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --tunnel-identifier $CIRCLE_BUILD_NUM-$CIRCLE_NODE_INDEX --readyfile ~/sauce_is_ready > sc_output.txt 2>&1:
         background: true
     - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done
-    - case $CIRCLE_NODE_INDEX in 0) kalite manage test --bdd-only ;; 1) kalite manage test --no-bdd;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) make test-bdd ;; 1) make test-nobdd;; esac:
         parallel: true
+    # TODO: replace below with "make link" when we're pep8
+    - npm install -g jshint
     - jshint kalite/*/static/js/*/
   post:
     - killall --wait sc  # wait for Sauce Connect to close the tunnel

--- a/circle.yml
+++ b/circle.yml
@@ -7,8 +7,8 @@ dependencies:
     - "data"
     - "sc-latest-linux"
   override:
-    - make dist
     - pip install -r requirements_dev.txt
+    - make dist
     - pip install dist/ka-lite-"$(python setup.py --version)".tar.gz
   post:
     - if [[ ! -e sc-latest-linux/bin/sc ]]; then wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz && tar -xzf sc-latest-linux.tar.gz &&  mv sc-*-linux sc-latest-linux; fi

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
     - "data"
     - "sc-latest-linux"
   override:
-    - make sdist
+    - make dist
     - pip install -r requirements_test.txt
     - pip install dist/ka-lite-"$(python setup.py --version)".tar.gz
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
     - "sc-latest-linux"
   override:
     - make dist
-    - pip install -r requirements_test.txt
+    - pip install -r requirements_dev.txt
     - pip install dist/ka-lite-"$(python setup.py --version)".tar.gz
   post:
     - if [[ ! -e sc-latest-linux/bin/sc ]]; then wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz && tar -xzf sc-latest-linux.tar.gz &&  mv sc-*-linux sc-latest-linux; fi

--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,11 @@ dependencies:
     - "data"
     - "sc-latest-linux"
   override:
-    - pip install -r requirements_dev.txt
-    - make dist
-    - pip install dist/ka-lite-"$(python setup.py --version)".tar.gz
+    - pip install -r requirements_test.txt
+    - pip install -e .
+    # This cannot be done because pip on Circle doesn't understand our sdist
+    # - make sdist
+    # - pip install dist/ka-lite-"$(python setup.py --version)".tar.gz
   post:
     - if [[ ! -e sc-latest-linux/bin/sc ]]; then wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz && tar -xzf sc-latest-linux.tar.gz &&  mv sc-*-linux sc-latest-linux; fi
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,4 @@
 werkzeug # Not sure about version
 django-debug-toolbar # Version was not described in previously bundled files, used by kalite.testing app
 pyyaml==3.11
+pep8

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,5 @@
 -r requirements_test.txt
 werkzeug # Not sure about version
 django-debug-toolbar # Version was not described in previously bundled files, used by kalite.testing app
-pyyaml==3.11
 pep8
 sphinx

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,4 @@ werkzeug # Not sure about version
 django-debug-toolbar # Version was not described in previously bundled files, used by kalite.testing app
 pyyaml==3.11
 pep8
+sphinx

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,3 +8,7 @@ hachoir-core==1.3.3
 hachoir-parser==1.3.4
 hachoir-metadata==1.3.3
 sauceclient==0.2.1
+
+# Used for building assets, which is necessary for testing
+pyyaml==3.11
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,8 +6,16 @@
 [metadata]
 description-file = README.md
 
+# This is the one we use officially
+[pep8]
+ignore = E226,E302,E41,E402
+max-line-length = 160
+exclude = kalite/*/migrations/*
+
+# Using flake8 is also supported..
 [flake8]
 # E124: closing bracket does not match indentation
 # E702: semicolon at end of line; ignored because we have `from django.conf import settings; logging = settings.LOG` lines and others
 ignore = E702,E124
-max-line-length = 130
+max-line-length = 160
+

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ def get_installed_packages():
 # site-packages directory.
 
 
-def gen_data_files(*dirs):
+def gen_data_files(*dirs, **kwargs):
     """
     We can only link files, not directories. Therefore, we use an approach
     that scans all files to pass them to the data_files kwarg for setup().
@@ -131,12 +131,17 @@ def gen_data_files(*dirs):
     """
     results = []
 
+    optional = kwargs.pop('optional', False)
+
     def filter_illegal_extensions(f):
         return os.path.splitext(f)[1] != ".pyc"
 
     for src_dir in dirs:
         if not os.path.isdir(src_dir):
-            raise RuntimeError("{dir:s} does not exist, cannot continue").format(dir=src_dir)
+            if optional:
+                continue
+            else:
+                raise RuntimeError("{dir:s} does not exist, cannot continue".format(dir=src_dir))
 
         for root, dirs, files in os.walk(src_dir):
             results.append(
@@ -168,7 +173,7 @@ data_files += map(
 
 data_files += map(
     lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
-    gen_data_files('docs/_build/html')
+    gen_data_files('docs/_build/html', optional=True)
 )
 
 # For now, just disguise the kalitectl.py script here as it's only to be accessed

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,9 @@ def gen_data_files(*dirs):
         return os.path.splitext(f)[1] != ".pyc"
 
     for src_dir in dirs:
+        if not os.path.isdir(src_dir):
+            raise RuntimeError("{dir:s} does not exist, cannot continue").format(dir=src_dir)
+
         for root, dirs, files in os.walk(src_dir):
             results.append(
                 (

--- a/setup.py
+++ b/setup.py
@@ -130,9 +130,10 @@ def gen_data_files(*dirs):
     Thanks: http://stackoverflow.com/a/7288382/405682
     """
     results = []
-    
-    filter_illegal_extensions = lambda f: os.path.splitext(f)[1] != ".pyc"
-    
+
+    def filter_illegal_extensions(f):
+        return os.path.splitext(f)[1] != ".pyc"
+
     for src_dir in dirs:
         for root, dirs, files in os.walk(src_dir):
             results.append(
@@ -228,37 +229,37 @@ class my_install_scripts(install_scripts):
 # If it's a static build, we invoke pip to bundle dependencies in python-packages
 # This would be the case for commands "bdist" and "sdist"
 if STATIC_BUILD:
-    
+
     manifest_content = file(os.path.join(where_am_i, 'MANIFEST.in.dist'), 'r').read()
     manifest_content += "\n" + "recursive-include dist-packages *\nrecursive-exclude dist-packages *pyc"
     file(os.path.join(where_am_i, 'MANIFEST.in'), "w").write(manifest_content)
-    
+
     sys.stderr.write(
         "This is a static build... invoking pip to put static dependencies in "
         "dist-packages/\n"
     )
-    
+
     STATIC_DIST_PACKAGES_DOWNLOAD_CACHE = os.path.join(where_am_i, 'dist-packages-downloads')
     STATIC_DIST_PACKAGES_TEMP = os.path.join(where_am_i, 'dist-packages-temp')
-    
+
     # Create directory where dynamically created dependencies are put
     if not os.path.exists(STATIC_DIST_PACKAGES_DOWNLOAD_CACHE):
         os.mkdir(STATIC_DIST_PACKAGES_DOWNLOAD_CACHE)
-    
+
     # Should remove the temporary directory always
     if os.path.exists(STATIC_DIST_PACKAGES_TEMP):
         print("Removing previous temporary sources for pip {}".format(STATIC_DIST_PACKAGES_TEMP))
         shutil.rmtree(STATIC_DIST_PACKAGES_TEMP)
-    
+
     # Install from pip
-    
+
     # Code modified from this example:
     # http://threebean.org/blog/2011/06/06/installing-from-pip-inside-python-or-a-simple-pip-api/
     import pip.commands.install
-    
+
     # Ensure we get output from pip
     enable_log_to_stdout('pip.commands.install')
-    
+
     def install_distributions(distributions):
         command = pip.commands.install.InstallCommand()
         opts, ___ = command.parser.parse_args([])
@@ -273,17 +274,17 @@ if STATIC_BUILD:
         command.run(opts, distributions)
         # requirement_set.source_dir = STATIC_DIST_PACKAGES_TEMP
         # requirement_set.install(opts)
-    
+
     # Install requirements into dist-packages
     if DIST_BUILDING_COMMAND:
         install_distributions(STATIC_REQUIREMENTS)
-    
+
     # Empty the requirements.txt file
 
 
 # It's not a build command with --static or it's not a build command at all
 else:
-    
+
     # If the dist-packages directory is non-empty
     if os.listdir(STATIC_DIST_PACKAGES):
         # If we are building something or running from the source
@@ -302,7 +303,7 @@ else:
             # everything in the requirements.txt file
             DIST_REQUIREMENTS = []
             DIST_NAME = 'ka-lite-static'
-            
+
             if "ka-lite" in get_installed_packages():
                 raise RuntimeError(
                     "Already installed ka-lite so cannot install ka-lite-static. "
@@ -314,7 +315,7 @@ else:
                     "...or other possible installation mechanisms you may have "
                     "been using."
                 )
-    
+
     # No dist-packages/ and not building, so must be installing the dynamic
     # version
     elif not DIST_BUILDING_COMMAND:
@@ -335,7 +336,7 @@ else:
         manifest_content = file(os.path.join(where_am_i, 'MANIFEST.in.dist'), 'r').read()
         manifest_content += "\n" + "recursive-include dist-packages *"
         file(os.path.join(where_am_i, 'MANIFEST.in'), "w").write(manifest_content)
-    
+
 
 # All files from dist-packages are included if the directory exists
 if os.listdir(STATIC_DIST_PACKAGES):

--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,11 @@ data_files += map(
     gen_data_files('static-libraries')
 )
 
+data_files += map(
+    lambda x: (os.path.join(kalite.ROOT_DATA_PATH, x[0]), x[1]),
+    gen_data_files('docs/_build/html')
+)
+
 # For now, just disguise the kalitectl.py script here as it's only to be accessed
 # with the bin/kalite proxy.
 data_files += [(


### PR DESCRIPTION
# Change affecting 0.15 release

Docs are included in the sdist and built automatically by running `make sdist`.

PR for #4348 (partly) and #4375

# Change affecting build process

The PyPi and .deb for 0.15 will be released by using a new Makefile. Yay!

#4459 

Makefile does this:

```
➜  ka-lite git:(dist-docs) make help
clean - remove all build, test, coverage and Python artifacts
clean-build - remove build artifacts
clean-pyc - remove Python file artifacts
clean-test - remove test and coverage artifacts
lint - check style with pep8
test - run tests quickly with the default Python
test-all - run tests on every Python version with tox DISABLED
assets - build all JS/CSS assets
coverage - check code coverage quickly with the default Python
docs - generate Sphinx HTML documentation, including API docs
release - package and upload a release
dist - package locally
install - install the package to the active Python's site-packages
```