### PR TITLE
Causes syntax error when page is loaded

### DIFF
--- a/kalite/facility/middleware.py
+++ b/kalite/facility/middleware.py
@@ -16,8 +16,17 @@ def error_view(request):
     return {}
 
 class ErrorMiddleware:
-    def process_request(self, request):
-        return error_view(request)
+    def process_response(self, request, response):
+        # could also look at the request object, e.g.
+        # for the request to http://localhost/blah
+        # request['PATH_INFO'] is '/blah'
+        # Could try to create a whitelist or blacklist of paths to redirect.
+        # request['CONTENT_TYPE'] might be helpful -- but not all of our requests might honor it. :(
+        # I like looking at the response content type.
+        if response.get("content-type") == "text/html":
+            return error_view(request)
+        else:
+            return response
 
 def refresh_session_facility_info(request, facility_count):
     # Fix for #1211

--- a/kalite/facility/middleware.py
+++ b/kalite/facility/middleware.py
@@ -5,9 +5,19 @@ from django.conf import settings
 from django.db.models import signals
 from django.db.models.signals import post_save
 
+from annoying.decorators import render_to
+
 from .models import Facility
 
 FACILITY_CACHE_STALE = False
+
+@render_to("distributed/homepage.html")
+def error_view(request):
+    return {}
+
+class ErrorMiddleware:
+    def process_request(self, request):
+        return error_view(request)
 
 def refresh_session_facility_info(request, facility_count):
     # Fix for #1211

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -364,7 +364,8 @@ MIDDLEWARE_CLASSES = [
     'kalite.distributed.middleware.LockdownCheck',
     'kalite.student_testing.middleware.ExamModeCheck',
     'django.middleware.gzip.GZipMiddleware',
-    'django_snippets.session_timeout_middleware.SessionIdleTimeout'
+    'django_snippets.session_timeout_middleware.SessionIdleTimeout',
+    'kalite.facility.middleware.ErrorMiddleware',
 ] + getattr(local_settings, 'MIDDLEWARE_CLASSES', [])
 
 TEMPLATE_CONTEXT_PROCESSORS = [


### PR DESCRIPTION
Contains a minimal example of how to replicate an error.

So bizarre. @tk21 discovered this.

To replicate: start the server, middleware will intercept your request and render the homepage instead (this function is identical to the homepage view function), but you'll see the following error in the js console (which throws a wrench in everything): `Uncaught SyntaxError: Unexpected token <`

It's referring to the very first character in the document: `<!DOCTYPE HTML>`

@rtibbles @aronasorman @jamalex any idea what's up?
