### PR TITLE
Strictly enforce video-js version for srt compatability. 

### DIFF
--- a/kalite/distributed/static/css/distributed/video-js-override.less
+++ b/kalite/distributed/static/css/distributed/video-js-override.less
@@ -5,6 +5,18 @@
 
 @vjs-font-path: "/static/css/distributed/font/";
 
+@font-face{
+  font-family: 'VideoJS';
+  src: url('/static/css/distributed/font/vjs.eot');
+  src: url('/static/css/distributed/font/vjs.eot?#iefix') format('embedded-opentype'),
+  url('/static/css/distributed/font/vjs.woff') format('woff'),
+  url('/static/css/distributed/font/vjs.ttf') format('truetype'),
+  url('/static/css/distributed/font/vjs.svg#icomoon') format('svg');
+
+  font-weight: normal;
+  font-style: normal;
+}
+
 #video-player {
     height: 500px;
 }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "through": "^2.3.8",
     "underscore": "~1.8.3",
     "url": "^0.10.3",
-    "video.js": "^4.11.4",
+    "video.js": "4.11.4",
     "watchify": "^3.3.1"
   }
 }


### PR DESCRIPTION
Fix icons for old video-js version.

Fixes #4578