### PR TITLE
Put cache database in user-writable location

### DIFF
--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -146,7 +146,8 @@ else:
 # ...OR it's been installed in:
 # sys.prefix/share/kalite/content
 # sys.prefix/share/kalite/locales
-
+#
+# It's NOT user-writable -- requires privileges, so any writing must be done at install time.
 
 _data_path_channels = os.path.join(_data_path, 'data')
 

--- a/kalite/topic_tools/settings.py
+++ b/kalite/topic_tools/settings.py
@@ -28,6 +28,11 @@ TOPICS_FILEPATHS = {
 }
 EXERCISES_FILEPATH = os.path.join(CHANNEL_DATA_PATH, "exercises.json")
 CONTENT_FILEPATH = os.path.join(CHANNEL_DATA_PATH, "contents.json")
-CONTENT_CACHE_FILEPATH = os.path.join(CHANNEL_DATA_PATH, "contents.sqlite")
+
+# User needs write access, since this is generated at runtime. So, put in user data space.
+__cache_data_path = os.path.join(settings.USER_DATA_ROOT, "channel_cache_data")
+if not os.path.exists(__cache_data_path):
+    os.mkdir(__cache_data_path)
+CONTENT_CACHE_FILEPATH = os.path.join(__cache_data_path, "contents.sqlite")
 
 TOPIC_RECOMMENDATION_DEPTH = 3


### PR DESCRIPTION
@aronasorman @benjaoming let me know if this seems tenable. Will test it out on the deb by pulling source and setting `IS_SOURCE=False`, assuming this essentially replicates installing using deb.