### PR TITLE
Fix language pack availability issue in 0.14.1

### DIFF
--- a/kalite/updates/static/js/updates/update_languages.js
+++ b/kalite/updates/static/js/updates/update_languages.js
@@ -3,12 +3,18 @@ var installed_languages = [];
 var downloading = false;
 
 function version_comparison(v1, v2) {
-    // compare two version strings and return 1 if the first is higher than the second,
-    // -1 if the first is lower than the second, and 0 if they are equal
+    /*
+    compare two version strings and return 1 if the first is higher than the second,
+    -1 if the first is lower than the second, and 0 if they are equal.
+
+    :params v1, v2: Version strings expected format is either "N.N.N" or "N.N", where N is a positive integer.
+    If both strings have the same format, they're compared using a lexical order.
+    If one string is shorter than the other, then the other is truncated and then compared using lexical order.
+    */
     var v1parts = v1.split('.'), v2parts = v2.split('.');
-    var maxLen = Math.max(v1parts.length, v2parts.length);
+    var minLen = Math.min(v1parts.length, v2parts.length);
     var part1, part2;
-    for(var i = 0; i < maxLen; i++) {
+    for(var i = 0; i < minLen; i++) {
         part1 = parseInt(v1parts[i], 10) || 0;
         part2 = parseInt(v2parts[i], 10) || 0;
         if (part1 > part2) return 1;


### PR DESCRIPTION
Language packs not shown as available, due to version comparison on distributed server. See my commit message/code.

See @aronasorman's note for context: https://github.com/fle-internal/ka-lite-central/commit/7a48ceca9eff#diff-b4c6913ca485fa33b3dfb6040efc3dddR680

We should cherry-pick this to `0.15.x` and `develop` as well.

Commit message:
```text
Change version comparison logic

The central server sends a short version (e.g. 0.14), which the distributed server
then compares to its long version (e.g. 0.14.1). The problem is that 0.14 compares
as less than 0.14.1, so language packs are shown as unavailable. Instead,
when comparing two mismatched-length versions, only consider the shortest version
available -- thus 0.14 and 0.14.1 would compare equal. Then the languagepack versions
will be compared, which is the actual intent.
```

@jamalex or @rtibbles any caveats here I should be aware of?

Due immediately.