### PR TITLE
0.15.x cherry-picks from 0.14.x

### DIFF
--- a/data/version.yml
+++ b/data/version.yml
@@ -15,6 +15,20 @@
 
   bugs_fixed:
     all: []
+
+0.14.1:
+  release_date: "2015/10/02"
+  git_commit: "0818d65"
+  new_features:
+    all: []
+    students:
+    coaches: []
+    admins: []
+  bugs_fixed:
+    all:
+      - Fix assessment items not getting translated (#4482)
+      - Notify users that they need to restart their server after downloading a language pack (#4491)
+      - Generate a new secret key when the server starts (#4494)
     students: []
     coaches: []
     admins: []

--- a/data/version.yml
+++ b/data/version.yml
@@ -9,12 +9,22 @@
 
   bugs_fixed:
     all: []
-    students: []
+
+0.14.2:
+  release_date: "2015/10/02"
+  git_commit: "dceccca"
+  new_features:
+    all: []
+    students:
     coaches: []
     admins: []
 
   bugs_fixed:
-    all: []
+    all:
+      Properly compare language pack versions (#4587).
+    students: []
+    coaches: []
+    admins: []
 
 0.14.1:
   release_date: "2015/10/02"

--- a/docs/installguide/install_all.rst
+++ b/docs/installguide/install_all.rst
@@ -93,7 +93,7 @@ It can be installed by downloading the latest .deb on the Pi and installing it::
     # Install dependencies
     sudo apt-get install python-m2crypto python-pkg-resources nginx python-psutil
     # Fetch the latest .deb
-    sudo wget https://learningequality.org/r/deb-pi-installer-0-15
+    sudo wget https://learningequality.org/r/deb-pi-installer-0-14 --no-check-certificate
     # Install the .deb
     sudo dpkg -i ka-lite-raspberry-pi*.deb
 

--- a/kalite/main/api_resources.py
+++ b/kalite/main/api_resources.py
@@ -9,8 +9,8 @@ from .models import VideoLog, ExerciseLog, AttemptLog, ContentLog, ContentRating
 from kalite.topic_tools.models import AssessmentItem
 
 from kalite.distributed.api_views import get_messages_for_api_calls
-from kalite.topic_tools import get_exercise_data, get_content_data, get_assessment_item_data
 from kalite.topic_tools.settings import CHANNEL
+from kalite.topic_tools import get_exercise_data, get_content_data, get_assessment_item_data
 from kalite.shared.api_auth.auth import UserObjectsOnlyAuthorization
 from kalite.facility.api_resources import FacilityUserResource
 


### PR DESCRIPTION
Supersedes https://github.com/learningequality/ka-lite/pull/4593. Most of the commits were already applied to 0.15.x.