### PR TITLE
automatically generate a manpage and put it in docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ static-updates
 # Documentation
 docs/_build
 docs/images/*
+docs/kalite.1.gz
 
 # oh-my-zsh convention for automatically
 # switching on a venv

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ docs:
 	# sphinx-apidoc -o docs/ ka-lite-gtk
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
+	cli2man bin/kalite -o docs/kalite.1.gz
 	# open docs/_build/html/index.html
 
 assets:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,4 @@ werkzeug # Not sure about version
 django-debug-toolbar # Version was not described in previously bundled files, used by kalite.testing app
 pep8
 sphinx
+cli2man


### PR DESCRIPTION
I would like this included in 0.15, because then the sdist will come with a man page that the debian dist can include.

It's automatically generated from the docutils output using cli2man.

This does not affect the 0.15 code base at all.