### PR TITLE
Add empty db to sdist

### DIFF
--- a/MANIFEST.in.dist
+++ b/MANIFEST.in.dist
@@ -9,6 +9,9 @@ include requirements.txt
 
 recursive-include kalite *.html *.txt *.png *.js *.css *.gif *.less *.otf *.svg *.woff *.eot *.ttf *.zip *.json *.handlebars
 
+# Get the empty DBs -- make sure they are properly generated!
+include kalite/database/data.sqlite
+
 # This can be a huge problem when creating an sdist from
 # a local development environment
 recursive-exclude kalite/static *

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ clean-build:
 	rm -fr .eggs/
 	rm -fr dist-packages/
 	rm -fr dist-packages-temp/
+	rm -f kalite/database/data.sqlite
 	find . -name '*.egg-info' -exec rm -fr {} +
 	find . -name '*.egg' -exec rm -f {} +
 
@@ -87,6 +88,8 @@ assets:
 	node build.js
 	bin/kalite manage compileymltojson
 	bin/kalite manage init_content_items
+	bin/kalite manage syncdb --noinput
+	bin/kalite manage migrate
 
 release: clean docs assets
 	python setup.py sdist --formats=gztar,zip upload --sign

--- a/kalite/__init__.py
+++ b/kalite/__init__.py
@@ -6,13 +6,8 @@ from version import *
 
 __version__ = VERSION
 
-
-# ROOT_DATA_PATH should point to the directory where the source files live, including the "docs" dir
-# TODO-BLOCKER(MCGallaspy): Use setuptools in the windows installer to avoid this nonsense.
-ROOT_DATA_PATH = os.environ.get(
-    "KALITE_ROOT_DATA_PATH",
-    os.path.join(sys.prefix, 'share', 'kalite')
-)
+# ROOT_DATA_PATH is *not* where the source files live. It's a place where non-user-writable data files may be written.
+ROOT_DATA_PATH = os.path.join(sys.prefix, 'share', 'kalite')
 
 
 # TODO: Burn down this function, the name is weird, it just checks if a

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -380,9 +380,13 @@ class Command(BaseCommand):
         # call_command("clean_pyc", interactive=False, verbosity=options.get("verbosity"), path=os.path.join(settings.PROJECT_PATH, ".."))
 
         # If a db template exists, copy it instead of creating a new one, since migrations take a long time.
-        if settings.DB_TEMPLATE_FILE and not os.path.isfile(settings.DEFAULT_DATABASE_PATH):
+        database_exists = os.path.isfile(settings.DEFAULT_DATABASE_PATH)
+        if settings.DB_TEMPLATE_FILE and not database_exists:
             print("Copying database file from {0} to {1}".format(settings.DB_TEMPLATE_FILE, settings.DEFAULT_DATABASE_PATH))
             shutil.copy(settings.DB_TEMPLATE_FILE, settings.DEFAULT_DATABASE_PATH)
+        elif database_exists:
+            print("Migrating existing database.")
+            call_command("migrate", merge=True, verbosity=options.get("verbosity"))
         else:
             print("Baking a fresh database from scratch.")
             call_command("syncdb", interactive=False, verbosity=options.get("verbosity"))

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -379,9 +379,14 @@ class Command(BaseCommand):
         # Should clean_pyc for (clean) reinstall purposes
         # call_command("clean_pyc", interactive=False, verbosity=options.get("verbosity"), path=os.path.join(settings.PROJECT_PATH, ".."))
 
-        # Migrate the database
-        call_command("syncdb", interactive=False, verbosity=options.get("verbosity"))
-        call_command("migrate", merge=True, verbosity=options.get("verbosity"))
+        # If a db template exists, copy it instead of creating a new one, since migrations take a long time.
+        if settings.DB_TEMPLATE_FILE and not os.path.isfile(settings.DEFAULT_DATABASE_PATH):
+            print("Copying database file from {0} to {1}".format(settings.DB_TEMPLATE_FILE, settings.DEFAULT_DATABASE_PATH))
+            shutil.copy(settings.DB_TEMPLATE_FILE, settings.DEFAULT_DATABASE_PATH)
+        else:
+            print("Baking a fresh database from scratch.")
+            call_command("syncdb", interactive=False, verbosity=options.get("verbosity"))
+            call_command("migrate", merge=True, verbosity=options.get("verbosity"))
         Settings.set("database_version", VERSION)
 
         # download assessment items

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -98,6 +98,10 @@ IS_SOURCE = (
 )
 SOURCE_DIR = None
 
+# DB_TEMPLATE_FILE should point to a pre-generated database with no rows.
+# If it exists and DATABASES["default"]["name"] file does not, then the latter will be copied from the former
+# in the setup mgmt command.
+DB_TEMPLATE_FILE = None
 
 if IS_SOURCE:
     # We assume that the project source is 2 dirs up from the settings/base.py file
@@ -127,6 +131,14 @@ if IS_SOURCE:
 
 else:
     _data_path = os.path.join(ROOT_DATA_PATH,)
+
+    # If we're not running as source, then we should include a blank, pre-migrated db in this location,
+    # to be copied to user's KALITE_HOME.
+    DB_TEMPLATE_FILE = os.path.join(
+        ROOT_DATA_PATH,
+        "database",
+        "data.sqlite",
+    )
 
     # BEING DEPRECATED, PLEASE DO NOT USE PROJECT_PATH!
     PROJECT_PATH = os.environ.get(

--- a/setup.py
+++ b/setup.py
@@ -358,6 +358,7 @@ if os.listdir(STATIC_DIST_PACKAGES):
         gen_data_files('dist-packages')
     )
 
+data_files += [(os.path.join(kalite.ROOT_DATA_PATH, "database"), [os.path.join("kalite", "database", "data.sqlite")])]
 
 setup(
     name=DIST_NAME,

--- a/setup.py
+++ b/setup.py
@@ -358,8 +358,6 @@ if os.listdir(STATIC_DIST_PACKAGES):
         gen_data_files('dist-packages')
     )
 
-data_files += [(os.path.join(kalite.ROOT_DATA_PATH, "database"), [os.path.join("kalite", "database", "data.sqlite")])]
-
 setup(
     name=DIST_NAME,
     version=kalite.VERSION,


### PR DESCRIPTION
Not touching content/assessment items right now. Fixes part of #4653. New behavior:

* Create empty db in `assets` make target, and include in sdist.
* If the user has no database at `settings.DEFAULT_DATABASE_PATH` and `settings.DB_TEMPLATE_FILE` is truthy, then the latter file will be copied to the former by the setup mgmt command.

The reason this works -- when the sdist is built `IS_SOURCE` is `True` (or it should be), so we create a db at `kalite/database/data.sqlite` (which is the `DEFAULT_DATABASE_PATH`). We simply preserve this file in the sdist, then when IS_SOURCE is `False` (and `DEFAULT_DATABASE_PATH` has a different value) we set `DB_TEMPLATE_FILE` to point to that file in the source tree. 