### PR TITLE
propagate the request language in user progress.

### DIFF
--- a/kalite/coachreports/api_resources.py
+++ b/kalite/coachreports/api_resources.py
@@ -9,7 +9,7 @@ from .models import PlaylistProgress, PlaylistProgressDetail
 
 class CoachReportBaseResource(Resource):
     """
-    A base resource that houses shared code between the resources we actually use 
+    A base resource that houses shared code between the resources we actually use
     in the API
     """
 
@@ -54,7 +54,7 @@ class PlaylistProgressResource(CoachReportBaseResource):
 
     def get_object_list(self, request):
         user_id = request.GET.get('user_id')
-        result = PlaylistProgress.user_progress(user_id=user_id)
+        result = PlaylistProgress.user_progress(user_id=user_id, language=request.language)
         return result
 
 class PlaylistProgressDetailResource(CoachReportBaseResource):
@@ -72,8 +72,8 @@ class PlaylistProgressDetailResource(CoachReportBaseResource):
     def get_object_list(self, request):
         user_id = request.GET.get("user_id")
         playlist_id = request.GET.get("playlist_id")
-        result = PlaylistProgressDetail.user_progress_detail(user_id=user_id, playlist_id=playlist_id)
+        language = request.language
+        result = PlaylistProgressDetail.user_progress_detail(user_id=user_id, playlist_id=playlist_id, language=language)
         if not result:
-            raise NotFound("User playlist progress details with user ID '%s' and playlist ID '%s' were not found." % (user_id, playlist_id))        
+            raise NotFound("User playlist progress details with user ID '%s' and playlist ID '%s' were not found." % (user_id, playlist_id))
         return result
-

--- a/kalite/coachreports/models.py
+++ b/kalite/coachreports/models.py
@@ -213,7 +213,7 @@ class PlaylistProgressDetail(PlaylistProgressParent):
         objects associated with a specific user and playlist ID.
         """
         if not language:
-            language = settings.LANGUAGE_CODE
+            language = Settings.get("default_language") or settings.LANGUAGE_CODE
 
         user = FacilityUser.objects.get(id=user_id)
         playlist = next((pl for pl in get_leafed_topics() if pl.get("id") == playlist_id), None)

--- a/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
+++ b/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
@@ -24,13 +24,13 @@
                     {{/unless}}
                 {{/if}}
                 {{#if vid_pct_complete}}
-                    <div class="progress-bar progress-bar-success" title="% Completed" style="width: {{vid_pct_complete}}%">
+                  <div class="progress-bar progress-bar-success" title={{_ "% Completed" }} style="width: {{vid_pct_complete}}%">
                         <span class="sr-only">{{_ "Of those you have completed " }}</span>
                         <span>{{vid_pct_complete}}%</span>
                     </div>
                 {{/if}}
                 {{#if vid_pct_started}}
-                    <div class="progress-bar inprogress" title="% In-Progress" style="width: {{vid_pct_started}}%">
+                  <div class="progress-bar inprogress" title={{_ "% In-Progress"}} style="width: {{vid_pct_started}}%">
                     {{#ifcond vid_pct_started "<" 100}}
                         <span class="sr-only">{{_ "You are still working on " }}</span>
                         <span>{{vid_pct_started}}%</span>

--- a/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-details.handlebars
+++ b/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-details.handlebars
@@ -15,10 +15,10 @@
             {{#ifcond attributes.status "===" "struggling"}}
                 {{_ " Struggling. " }}
             {{/ifcond}}
-            
+
             {{#ifcond attributes.status "===" "notstarted"}}
                 {{_ " Not started. " }}
-            {{/ifcond}}                
+            {{/ifcond}}
         </div>
         <div>
             {{!-- Score info for sr-user. --}}
@@ -41,26 +41,26 @@
 {{!-- Whole section is rendered invisible to screen readers --}}
 <div class="col-sm-1 progress-block" aria-hidden="true" role="presentation">
     <a href="/learn/{{attributes.path}}">
-    <div 
+    <div
         class="progress-indicator progress-indicator-sm {{attributes.status}}"
-        data-toggle="popover" data-placement="top" 
-        
+        data-toggle="popover" data-placement="top"
+
         {{!-- Video --}}
         {{#ifcond attributes.kind "===" "Video"}}
             title="{{attributes.title}}"
-            data-content="% Complete: {{attributes.score}}"
+            data-content="{{_ "% Complete:" }} {{attributes.score}}"
         {{/ifcond}}
 
         {{!-- Exercise --}}
         {{#ifcond attributes.kind "===" "Exercise"}}
             title="{{attributes.title}}"
-            data-content="Streak: {{attributes.score}}%"
+            data-content="{{_ "Streak" }}: {{attributes.score}}%"
         {{/ifcond}}
 
         {{!-- Quiz --}}
         {{#ifcond attributes.kind "===" "Quiz"}}
             title="Quiz for {{attributes.title}}"
-            data-content="Score: {{attributes.score}}%"
+            data-content="{{_ "Score" }}: {{attributes.score}}%"
         {{/ifcond}}
     > {{!-- Close starting div --}}
         <div class="sidebar-icon icon-{{ attributes.kind }} icon-label icon-label-sm"></div>

--- a/kalite/coachreports/static/js/coachreports/tabular_reports/hbtemplates/detailspanelbody.handlebars
+++ b/kalite/coachreports/static/js/coachreports/tabular_reports/hbtemplates/detailspanelbody.handlebars
@@ -2,7 +2,7 @@
     <ul class="nav nav-tabs">
         {{#each collection}}
         <li role="presentation" class="detail-tab {{#if correct }}correct{{else}}incorrect{{/if}}{{#if @first}} active{{/if}}">
-            <a href="#{{ id }}" data-toggle="tab" aria-expanded="true">Question {{ math @index "+" ../start_number }}</a>
+          <a href="#{{ id }}" data-toggle="tab" aria-expanded="true">{{_ "Question" }} {{ math @index "+" ../start_number }}</a>
         </li>
         {{/each}}
     </ul>

--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -565,7 +565,7 @@ var ExerciseWrapperBaseView = BaseView.extend({
 
     problem_loaded: function(data) {
         this.current_attempt_log.add_response_log_event({
-            type: "loaded"
+            type: gettext("loaded")
         });
         // if the question hasn't yet been answered (and hence saved), mark the current time as the question load time
         if (this.current_attempt_log.isNew()) {

--- a/kalite/topic_tools/__init__.py
+++ b/kalite/topic_tools/__init__.py
@@ -167,7 +167,7 @@ def get_node_cache(node_type=None, force=False, language=None):
 
     global NODE_CACHE
     if NODE_CACHE is None or force:
-        NODE_CACHE = generate_node_cache()
+        NODE_CACHE = generate_node_cache(language=language)
     if node_type is None:
         return NODE_CACHE
     else:


### PR DESCRIPTION
Fixes #4650. Partially at least. CC @jinchuika


![screen shot 2015-11-17 at 09 32 58](https://cloud.githubusercontent.com/assets/191955/11219245/47e95272-8d0e-11e5-9d83-ff806f3bcb2e.png)

I still couldn't get the exercise text translated, despite propagating the language in `get_exercise_cache` too. Any ideas @rtibbles?
