### PR TITLE
Content recommendation bugs

### DIFF
--- a/kalite/coachreports/models.py
+++ b/kalite/coachreports/models.py
@@ -110,9 +110,9 @@ class PlaylistProgress(PlaylistProgressParent):
             n_ex_started = len([ex for ex in pl_ex_logs if ex["attempts"] > 0])
             n_ex_incomplete = len([ex for ex in pl_ex_logs if (ex["attempts"] > 0 and not ex["complete"])])
             n_ex_struggling = len([ex for ex in pl_ex_logs if ex["struggling"]])
-            ex_pct_mastered = int(float(n_ex_mastered) / n_pl_exercises * 100)
-            ex_pct_incomplete = int(float(n_ex_incomplete) / n_pl_exercises * 100)
-            ex_pct_struggling = int(float(n_ex_struggling) / n_pl_exercises * 100)
+            ex_pct_mastered = int(float(n_ex_mastered) / (n_pl_exercises or 1) * 100)
+            ex_pct_incomplete = int(float(n_ex_incomplete) / (n_pl_exercises or 1) * 100)
+            ex_pct_struggling = int(float(n_ex_struggling) / (n_pl_exercises or 1) * 100)
             if not n_ex_started:
                 ex_status = "notstarted"
             elif ex_pct_struggling > 0:

--- a/kalite/distributed/features/steps/content_recommendation.py
+++ b/kalite/distributed/features/steps/content_recommendation.py
@@ -22,7 +22,7 @@ def impl(context):
 @when(u'I click on the right of an exercise suggestion on the next steps card')
 def impl(context):
     element = find_css_class_with_wait(context, "content-nextsteps-topic-link")
-    click_and_wait_for_page_load(context, element, wait_time=15)
+    click_and_wait_for_page_load(context, element.find_element_by_xpath(".//div"), wait_time=15)
 
 @then(u'I should be taken to that topic')
 def impl(context):
@@ -31,7 +31,7 @@ def impl(context):
 @when(u'I click in the middle of an exercise suggestion on the next steps card')
 def impl(context):
     element = find_css_class_with_wait(context, "content-nextsteps-lesson-link")
-    click_and_wait_for_page_load(context, element, wait_time=15)
+    click_and_wait_for_page_load(context, element.find_element_by_xpath(".//div[2]"), wait_time=15)
 
 @then(u'the content recommendation cards should be shown')
 def impl(context):

--- a/kalite/testing/behave_helpers.py
+++ b/kalite/testing/behave_helpers.py
@@ -180,7 +180,7 @@ def find_css_class_with_wait(context, css_class, **kwargs):
     css_class: A string with the css class (no leading .)
     kwargs: can optionally pass "wait_time", which will be the max wait time in
         seconds. Default is defined by behave_helpers.py
-    Returns the element if found or None
+    Returns the element if found or raises TimeoutException
     """
     return _find_elem_with_wait(context, (By.CLASS_NAME, css_class), **kwargs)
 
@@ -223,7 +223,7 @@ def find_xpath_with_wait(context, id_str, **kwargs):
     id_str: A string with the XPATH (no leading #)
     kwargs: can optionally pass "wait_time", which will be the max wait time in
         seconds. Default is defined by behave_helpers.py
-    Returns the element if found or None
+    Returns the element if found or raises TimeoutException
     """
     return _find_elem_with_wait(context, (By.XPATH, id_str), **kwargs)
 
@@ -233,7 +233,7 @@ def find_css_with_wait(context, id_str, **kwargs):
     id_str: A string with the CSS Selector
     kwargs: can optionally pass "wait_time", which will be the max wait time in
         seconds. Default is defined by behave_helpers.py
-    Returns the element if found or None
+    Returns the element if found or raises TimeoutException
     """
     return _find_elem_with_wait(context, (By.CSS_SELECTOR, id_str), **kwargs)
 

--- a/kalite/topic_tools/content_recommendation.py
+++ b/kalite/topic_tools/content_recommendation.py
@@ -6,6 +6,7 @@ Three main functions:
     - get_explore_recommendations(user)
 '''
 import datetime
+import itertools
 import random
 import collections
 
@@ -108,6 +109,7 @@ def get_next_recommendations(user, request):
     #final recommendations are a combination of struggling, group filtering, and topic_tree filtering
     return final
 
+
 def get_group_recommendations(user):
     """Returns a list of exercises immediately tackled by other individuals in the same group."""
 
@@ -123,12 +125,11 @@ def get_group_recommendations(user):
             .extra(select={'null_complete': "completion_timestamp is null"},
                 order_by=["-null_complete", "-completion_timestamp"])
     
-        exercise_counts = collections.defaultdict(lambda :0)
+        exercise_counts = collections.defaultdict(lambda: 0)
 
         for user in user_list:
-            user_logs = user_exercises.filter(user=user)
-            for i, log in enumerate(user_logs[1:]):
-                prev_log = user_logs[i]
+            logs = list(user_exercises.filter(user=user))
+            for log, prev_log in itertools.izip(logs[1:], logs):
                 if log.exercise_id in recent_exercises:
                     exercise_counts[prev_log.exercise_id] += 1
 

--- a/kalite/topic_tools/content_recommendation.py
+++ b/kalite/topic_tools/content_recommendation.py
@@ -157,13 +157,18 @@ def get_struggling_exercises(user):
 
     return struggles
 
-def get_exercise_prereqs(exercises):
-    """Return a list of prequisites (if applicable) for each specified exercise."""
+def get_exercise_prereqs(exercise_ids):
+    """
+    Return a list of prequisites (if applicable) for each specified exercise.
 
+    :param exercise_ids: A list of exercise ids.
+    :return: A list of prerequisite exercises (as dicts), if any are known.
+    """
     ex_cache = get_exercise_cache()
     prereqs = []
-    for exercise in exercises:
-        prereqs += ex_cache[exercise]['prerequisites']
+    for exercise_id in exercise_ids:
+        exercise = ex_cache.get(exercise_id)
+        prereqs += exercise['prerequisites'] if exercise else []
 
     return prereqs
 
@@ -199,16 +204,13 @@ def get_explore_recommendations(user, request):
 
         related_subtopics = data[subtopic_id]['related_subtopics'][2:7] #get recommendations based on this, can tweak numbers!
 
-        recommended_topic = next(topic for topic in related_subtopics if not topic in added and not topic in recent_subtopics)
-
-        if recommended_topic:
-
-            final.append({
-                'suggested_topic': get_topic_data(request, recommended_topic),
-                'interest_topic': get_topic_data(request, subtopic_id),
-            })
-
-            added.append(recommended_topic)
+        for topic in related_subtopics:
+            if topic not in added and topic not in recent_subtopics:
+                final.append({
+                    'suggested_topic': get_topic_data(request, topic),
+                    'interest_topic': get_topic_data(request, subtopic_id),
+                })
+                added.append(topic)
 
     return final
 


### PR DESCRIPTION
commit message:
```text
Handles three errors.

1. In get_exercise_prereqs, if an unknown exercise id is passed in, it
now contributes nothing to the prereqs instead of raising an error.

2. Avoid a divide-by-zero error in coachreports.models.

3. Finally, in get_explore_recommendations, use of `next` built-in could
result in an unhandled StopIteration exception. Refactor to use for..in block.
```

@rtibbles inspite of the fact that no errors are now raised, the content_recommender api endpoint takes a really long time to return (one run took me 3.7 minutes). I think we can do two things (perhaps for 0.16), let me know if you agree:

1. Add a placeholder when awaiting the response.
2. Separate the content recommendation endpoint into three separate endpoints.