### PR TITLE
Create zipfile with `make dist` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,8 @@ release: clean docs assets
 	ls -l dist
 
 dist: clean docs assets
-	python setup.py sdist
-	python setup.py sdist --static
+	python setup.py sdist --formats=gztar,zip
+	python setup.py sdist --formats=gztar,zip --static
 	ls -l dist
 
 install: clean


### PR DESCRIPTION
Building the Windows installer requires a zipfile here. @benjaoming 