### PR TITLE
doc fix for learningequality/installers#146

### DIFF
--- a/docs/installguide/install_all.rst
+++ b/docs/installguide/install_all.rst
@@ -64,6 +64,15 @@ After that, you can install the .deb file like this::
 
     sudo dpkg -i FILENAME.deb
 
+.. warning::
+    Double-clicking the .deb in Ubuntu will open it in Ubuntu Software Center.
+    This will fail on a default installation due to
+    `a bug <https://bugs.launchpad.net/ubuntu/+source/software-center/+bug/1389582>`_
+    in Ubuntu. To make it work, you need to install ``libgtk2-perl``, for
+    instance by running ``sudo apt-get install libgtk2-perl``. After that, make
+    sure Software Center is closed and double-click the .deb file.
+
+
 
 ``FILENAME`` should be replaced with the name of the file you downloaded.
 The file may be named as if it was intended for Ubuntu but works just as well for any other Debian-based systems like


### PR DESCRIPTION
Because of an upstream problem in Ubuntu, Software Center will not display our debconf dialogues unless libgtk2-perl is installed. Actually, it will lock up. This has been recently accepted as one of their "One Hundred Papercuts", so it seems likely, it will be backported for Trusty.

Anyways, here's a fix. Should be backported for 0.15.x as it doesn't need a new release to make it to RTD.

learningequality/installers#146

@EdDixon @radinamatic 