### PR TITLE
backported doc fix for learningequality/installers#146

### DIFF
--- a/docs/installguide/install_all.rst
+++ b/docs/installguide/install_all.rst
@@ -64,6 +64,15 @@ After that, you can install the .deb file like this::
 
     sudo dpkg -i FILENAME.deb
 
+.. warning::
+    Double-clicking the .deb in Ubuntu will open it in Ubuntu Software Center.
+    This will fail on a default installation due to
+    `a bug <https://bugs.launchpad.net/ubuntu/+source/software-center/+bug/1389582>`_
+    in Ubuntu. To make it work, you need to install ``libgtk2-perl``, for
+    instance by running ``sudo apt-get install libgtk2-perl``. After that, make
+    sure Software Center is closed and double-click the .deb file.
+
+
 
 ``FILENAME`` should be replaced with the name of the file you downloaded.
 The file may be named as if it was intended for Ubuntu but works just as well for any other Debian-based systems like


### PR DESCRIPTION
Cherry-picked docs change from develop affecting all previous .deb releases

learningequality/installers#146