### PR TITLE
Update install_all.rst

### DIFF
--- a/docs/installguide/install_all.rst
+++ b/docs/installguide/install_all.rst
@@ -106,7 +106,7 @@ It can be installed by downloading the latest .deb on the Pi and installing it::
     # Install dependencies
     sudo apt-get install python-m2crypto python-pkg-resources nginx python-psutil
     # Fetch the latest .deb
-    sudo wget https://learningequality.org/r/deb-pi-installer-0-15 --no-check-certificate
+    sudo wget https://learningequality.org/r/deb-pi-installer-0-15 --no-check-certificate --content-disposition 
     # Install the .deb
     sudo dpkg -i ka-lite-raspberry-pi*.deb
 


### PR DESCRIPTION
Instructions were inaccurate -- downloaded file had a different name that what appears in the docs. Use `--content-disposition` option to infer name correctly. Will target to all branches. Supersedes #4725.