### PR TITLE
0.15.x docs changes

### DIFF
--- a/data/version.yml
+++ b/data/version.yml
@@ -1,4 +1,18 @@
-0.15:
+0.15.1:
+  release_date: "2015/12/01"
+  git_commit: "746d0d"
+  new_features:
+    all: []
+    students: []
+    coaches: []
+    admins: []
+
+  bugs_fixed:
+    all:
+      - Fix some i18n issues (#4673)
+      - Fix some content recommendation bugs (#4675)
+
+0.15.0:
   release_date:
   git_commit: ""
   new_features:

--- a/kalite/version.py
+++ b/kalite/version.py
@@ -7,7 +7,7 @@ from kalite.shared.utils import open_json_or_yml
 # Must also be of the form N.N.N for internal use, where N is a non-negative integer
 MAJOR_VERSION = "0"
 MINOR_VERSION = "15"
-PATCH_VERSION = "0"
+PATCH_VERSION = "1"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
 


### PR DESCRIPTION
Publish to 'latest' on RTD (which tracks the master branch)

http://ka-lite.readthedocs.org/en/latest/