### PR TITLE
Remove doubly-declared requirement.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,5 +5,4 @@ django-debug-toolbar==1.3.2
 django-extensions==1.5.9  # Found in installed apps in kalite.project.settings.dev
 pep8
 sphinx
-django_extensions
 #cli2man


### PR DESCRIPTION
Hi @aronasorman - this removes the re-declared `django-extensions` pip requirement so we can build the OSX 0.16.x installer on Bamboo.