### PR TITLE
Modified makefile for bamboo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,6 @@ release: clean docs assets
 
 dist: clean docs assets
 	python setup.py sdist --formats=gztar,zip
-	python setup.py sdist --formats=gztar,zip --static
 	ls -l dist
 
 install: clean

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ release: clean docs assets
 
 dist: clean docs assets
 	python setup.py sdist --formats=gztar,zip
+	python setup.py sdist --formats=gztar,zip --static
 	ls -l dist
 
 install: clean

--- a/setup.py
+++ b/setup.py
@@ -358,6 +358,20 @@ if os.listdir(STATIC_DIST_PACKAGES):
         gen_data_files('dist-packages')
     )
 
+import fcntl
+
+def make_blocking(fd):
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    if flags & os.O_NONBLOCK:
+        sys.stderr.write("Setting to blocking...\n")
+        fcntl.fcntl(fd, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
+    else:
+        sys.stderr.write("Already blocking...\n")
+    sys.stderr.flush()
+
+make_blocking(sys.stdout.fileno())
+make_blocking(sys.stderr.fileno())
+
 setup(
     name=DIST_NAME,
     version=kalite.VERSION,


### PR DESCRIPTION
To keep track of my ongoing investigation as to why the build process for the Windows installer (used to?) fail on the build server running OSX.

See the middle commit message:
```text
If I make these blocking, will it stop the error? Seems to have worked in similar cases:
http://trac.edgewall.org/ticket/2066#comment:1
```

However I added a little output to see if the flag was already set -- it was. See [the bamboo logs for the build](http://dungeon.learningequality.org:8085/browse/KL-KALITE016-WIN-78), note the lines `Already blocking...` So presumably nothing has changed, but now the build succeeds. ?:(?