### PR TITLE
Content pack download v2

### DIFF
--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -65,6 +65,7 @@ class Command(UpdatesStaticCommand):
         with tempfile.NamedTemporaryFile() as f:
             zf = download_content_pack(f, lang)
             self.process_content_pack(zf, lang)
+            zf.close()
 
     def local(self, *args, **options):
 

--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -68,7 +68,7 @@ class Command(BaseCommand):
         extract_content_db(zf, lang)
         extract_content_pack_metadata(zf, lang)
 
-        call_command("annotate_content_items")
+        call_command("annotate_content_items", language=lang)
 
 
 def extract_content_pack_metadata(zf, lang):

--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -4,7 +4,7 @@ contents to their correct locations.
 
 Usage:
   contentpackretrieve download <lang>
-  contentpackretrieve retrieve <lang> <packpath>
+  contentpackretrieve local <lang> <packpath>
   contentpackretrieve -h | --help
 
 """
@@ -38,8 +38,8 @@ class Command(BaseCommand):
 
         if operation == "download":
             self.download(*args, **options)
-        elif operation == "retrieve":
-            self.retrieve(*args, **options)
+        elif operation == "local":
+            self.local(*args, **options)
         else:
             raise CommandError("Unknown operation: %s" % operation)
 
@@ -51,7 +51,7 @@ class Command(BaseCommand):
             zf = download_content_pack(f, lang)
             self.process_content_pack(zf, lang)
 
-    def retrieve(self, *args, **options):
+    def local(self, *args, **options):
 
         lang = args[1]
         zippath = args[2]

--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -21,7 +21,7 @@ from kalite.updates.management.commands.classes import UpdatesStaticCommand
 
 from kalite.version import SHORTVERSION
 
-CONTENT_PACK_URL_TEMPLATE = ("http://pantry.learningequality.org/downloads" +
+CONTENT_PACK_URL_TEMPLATE = ("http://pantry.learningequality.org/downloads"
                              "/ka-lite/{version}/content/contentpacks/{code}.zip")
 
 

--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -1,13 +1,3 @@
-"""
-Management command for downloading a language pack and extracting the
-contents to their correct locations.
-
-Usage:
-  kalite manage retrievecontentpack download <lang>
-  kalite manage retrievecontentpack local <lang> <packpath>
-  kalite manage retrievecontentpack -h | --help
-
-"""
 import json
 import os
 import urllib
@@ -36,6 +26,18 @@ CONTENT_PACK_URL_TEMPLATE = ("http://pantry.learningequality.org/downloads" +
 
 
 class Command(UpdatesStaticCommand):
+    """
+    Management command for downloading a language pack and extracting the
+    contents to their correct locations.
+
+    Usage:
+    kalite manage retrievecontentpack download <lang>
+    kalite manage retrievecontentpack local <lang> <packpath>
+    kalite manage retrievecontentpack -h | --help
+
+    """
+
+    help = __doc__
 
     stages = (
         "retrieve_language_pack",

--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -20,7 +20,8 @@ from django.core.management import call_command
 
 from fle_utils.general import ensure_dir
 
-from kalite.i18n.base import lcode_to_django_lang, get_po_filepath, get_locale_path
+from kalite.i18n.base import lcode_to_django_lang, get_po_filepath, get_locale_path, \
+    update_jsi18n_file
 from kalite.topic_tools import settings
 
 from kalite.version import SHORTVERSION
@@ -63,6 +64,7 @@ class Command(BaseCommand):
     def process_content_pack(self, zf, lang):
 
         extract_catalog_files(zf, lang)
+        update_jsi18n_file(lang)
         extract_content_db(zf, lang)
         extract_content_pack_metadata(zf, lang)
 

--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -3,9 +3,9 @@ Management command for downloading a language pack and extracting the
 contents to their correct locations.
 
 Usage:
-  contentpackretrieve download <lang>
-  contentpackretrieve local <lang> <packpath>
-  contentpackretrieve -h | --help
+  kalite manage retrievecontentpack download <lang>
+  kalite manage retrievecontentpack local <lang> <packpath>
+  kalite manage retrievecontentpack -h | --help
 
 """
 import json

--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -91,7 +91,14 @@ class Command(UpdatesStaticCommand):
 
 
 def extract_content_pack_metadata(zf, lang):
-    # stub for now, until we implement metadata creation on the maker side.
+    # NOTE (aronasorman): For KA Lite to detect and display a new language
+    # there has to be a metadata file present in the content pack. However I
+    # have not implemented the metadata generation on the content-pack-maker
+    # repo yet. To get around that and allow non-english language packs to be
+    # detected this function generates a fake metadata file.
+
+    # the eventual goal of this function is, as indicated by the function name,
+    # to extract the soon-to-be present metadata file into the right directory.
     metadata_path = os.path.join(get_locale_path(lang), "{lang}_metadata.json".format(lang=lang))
     barebones_metadata = {
         "code": lang,

--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -121,8 +121,13 @@ def download_content_pack(fobj, lang):
         code=lang,
     )
 
-    urllib.urlretrieve(url, filename=fobj.name)
-    zf = zipfile.ZipFile(fobj.name)
+    httpf = urllib.urlopen(url)  # returns a file-like object not exactly to zipfile's liking, so save first
+
+    shutil.copyfileobj(httpf, fobj)
+    fobj.seek(0)
+    zf = zipfile.ZipFile(fobj)
+
+    httpf.close()
 
     return zf
 

--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -231,6 +231,7 @@ def get_topic_nodes(parent=None, ids=None, **kwargs):
             Item.path,
             Item.slug,
         ).join(Parent, on=(Item.parent == Parent.pk)).where(selector)
+        return values
     elif ids:
         values = Item.select(
             Item.title,
@@ -242,8 +243,7 @@ def get_topic_nodes(parent=None, ids=None, **kwargs):
             Item.path,
             Item.slug,
         ).where(Item.id.in_(ids))
-
-    return values
+        return values
 
 
 @parse_data


### PR DESCRIPTION
Done:
- Fixes test failure relating to unreferenced variable 'values'
- `retrievecontentpack` now supports installing from a local content pack.
- Annotate the right content database.
- Generate the language specific JS file.
- ~~non-english content packs are not getting translated. Figure out why.~~ (fix is in the content-pack-maker repo)
- Integrated `retrievecontentpack` with the updates framework.

WIP. I'll try to get as many changes as I can before EOD.

Todo:

- Write docs on how to use `retrievecontentpack`.
- Port the language pack download interface to use `retrievecontentpack`.

Link to the first PR: https://github.com/learningequality/ka-lite/pull/4757