### PR TITLE
Parallelize bdd tests to use all 4 circle nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ test:
 	bin/kalite manage test $(KALITE_TEST_LABELS) --bdd-only
 
 test-bdd:
-	bin/kalite manage test --bdd-only
+	bin/kalite manage test $(KALITE_TEST_LABELS) --bdd-only
 
 test-nobdd:
-	bin/kalite manage test --no-bdd
+	bin/kalite manage test $(KALITE_TEST_LABELS) --no-bdd
 
 test-all:
 	@echo "Not supported yet"

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lint:
 	jshint kalite/*/static/js/*/
 
 test:
-	bin/kalite manage test --bdd-only
+	bin/kalite manage test $(KALITE_TEST_LABELS) --bdd-only
 
 test-bdd:
 	bin/kalite manage test --bdd-only

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ test:
     - cd sc-*-linux && ./bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --tunnel-identifier $CIRCLE_BUILD_NUM-$CIRCLE_NODE_INDEX --readyfile ~/sauce_is_ready > sc_output.txt 2>&1:
         background: true
     - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done
-    - case $CIRCLE_NODE_INDEX in 0) make test-bdd ;; 1) make test-nobdd;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) KALITE_TEST_LABELS=distributed make test-bdd ;; 1) KALITE_TEST_LABELS="coachreports control_panel" make test-bdd ;; 2) KALITE_TEST_LABELS="facility inline" make test-bdd ;; 3) make test-nobdd ;; esac:
         parallel: true
     # TODO: replace below with "make lint" when we're pep8
     - npm install -g jshint

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ test:
     - cd sc-*-linux && ./bin/sc -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY --tunnel-identifier $CIRCLE_BUILD_NUM-$CIRCLE_NODE_INDEX --readyfile ~/sauce_is_ready > sc_output.txt 2>&1:
         background: true
     - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done
-    - case $CIRCLE_NODE_INDEX in 0) KALITE_TEST_LABELS=distributed make test-bdd ;; 1) KALITE_TEST_LABELS="coachreports control_panel" make test-bdd ;; 2) KALITE_TEST_LABELS="facility inline" make test-bdd ;; 3) make test-nobdd ;; esac:
+    - case $CIRCLE_NODE_INDEX in 0) KALITE_TEST_LABELS=distributed make test-bdd ;; 1) KALITE_TEST_LABELS="coachreports facility" make test-bdd ;; 2) KALITE_TEST_LABELS="control_panel inline" make test-bdd ;; 3) make test-nobdd ;; esac:
         parallel: true
     # TODO: replace below with "make lint" when we're pep8
     - npm install -g jshint


### PR DESCRIPTION
Opening this after parallelization changes made on circle site -- previously it wasn't using all four VMs.