### PR TITLE
Add date and time to log messages

### DIFF
--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -65,8 +65,11 @@ if DEBUG:
 LOGGING_LEVEL = getattr(local_settings, "LOGGING_LEVEL", logging.INFO)
 LOG = getattr(local_settings, "LOG", logging.getLogger("kalite"))
 
-logging.basicConfig()
 LOG.setLevel(LOGGING_LEVEL)
+ch = logging.StreamHandler()
+formatter = logging.Formatter('%(asctime)s - %(levelname)s:%(name)s: %(message)s')
+ch.setFormatter(formatter)
+LOG.addHandler(ch)
 
 logging.getLogger("requests").setLevel(logging.WARNING)  # shut up requests!
 


### PR DESCRIPTION
Got fairly annoying that log messages don't carry a proper time signature.


Before:

```
>>> from django.conf import settings
>>> settings.LOG.info("test")
INFO:kalite:test
```

After:

```
>>> from django.conf import settings
>>> settings.LOG.info("test")
2016-01-29 19:10:29,216 - INFO:kalite: test
```