### PR TITLE
Replace deprecation warning by raising exception

### DIFF
--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -31,8 +31,6 @@ import kalite
 from kalite.contentload.settings import KHAN_ASSESSMENT_ITEM_ROOT, OLD_ASSESSMENT_ITEMS_LOCATION
 from kalite.topic_tools.settings import CHANNEL
 
-from kalite.shared.warnings import RemovedInKALite_v016_Warning
-
 from fle_utils.config.models import Settings
 from fle_utils.general import get_host_name
 from fle_utils.platforms import is_windows
@@ -244,10 +242,7 @@ class Command(BaseCommand):
             logging.warning(
                 "It's recommended that you install Python version 2.7.9. Your version is: %d.%d.%d\n" % sys.version_info[:3])
             if sys.version_info < (2, 7):
-                warnings.warn(
-                    "Support for Python 2.6 will be discontinued in 0.16, please upgrade.",
-                    RemovedInKALite_v016_Warning
-                )
+                raise CommandError("Support for Python version 2.6 and below had been discontinued, please upgrade.")
 
         if options["interactive"]:
             print(

--- a/kalite/settings/__init__.py
+++ b/kalite/settings/__init__.py
@@ -1,14 +1,7 @@
 import sys
 import warnings
 from kalite import version
-from kalite.shared.warnings import RemovedInKALite_v016_Warning
-
-
-warnings.warn(
-    "Wrong settings module imported! Please do not import kalite.settings "
-    "directly. Instead, import kalite.project.settings.base",
-    RemovedInKALite_v016_Warning
-)
+from kalite.shared.exceptions import RemovedInKALite_v016_Error
 
 
 ##############################
@@ -41,10 +34,7 @@ CONFIG_PACKAGE = [cp.lower() for cp in CONFIG_PACKAGE]
 
 
 if CONFIG_PACKAGE:
-    warnings.warn(
-        "CONFIG_PACKAGE is outdated, use a settings module from kalite.project.settings",
-        RemovedInKALite_v016_Warning
-    )
+    raise RemovedInKALite_v016_Error("CONFIG_PACKAGE is outdated, use a settings module from kalite.project.settings")
 
 if package_selected("nalanda"):
     TURN_OFF_MOTIVATIONAL_FEATURES = True

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -7,38 +7,16 @@ import sys
 import warnings
 
 from kalite import ROOT_DATA_PATH
-from kalite.shared.warnings import RemovedInKALite_v016_Warning
+from kalite.shared.exceptions import RemovedInKALite_v016_Error
 
 from django.utils.translation import ugettext_lazy
 
-# Load local settings first... loading it again later to have the possibility
-# to overwrite default app settings.. very strange method, will be refactored
-# and completely fixed ~0.14 or 0.15. /benjaoming
-
 try:
-    # Not sure if vars from local_settings are accessed ATM. This is one of
-    # the big disadvantage of this whole implicit importing chaos... will be
-    # fixed later.
     from kalite import local_settings
-    # This is not a DeprecationWarning by purpose, because those are
-    # ignored during settings module load time
-    warnings.warn(
-        "We will be deprecating the old way of statically importing custom "
-        "settings, in favor of a more flexible way. The easiest way to update "
-        "your installation is to rename your local_settings.py (keeping it in "
-        "the same directory) and add an import statement in the very first "
-        "line of the new file so it looks like this:\n\n"
-        "    from kalite.project.settings.base import *\n"
-        "    # Put custom settings here...\n"
-        "    FOO = BAR\n\n"
-        "and then call kalite start with an additional argument pointing to "
-        "your new settings module:\n\n"
-        "    kalite start --settings=kalite.my_settings\n\n"
-        "In the future, it is recommended not to keep your own settings module "
-        "in the kalite code base but to put the file somewhere else in your "
-        "python path, for instance in the current directory when running "
-        "'kalite --settings=my_module'.",
-        RemovedInKALite_v016_Warning
+    raise RemovedInKALite_v016_Error(
+        "The local_settings.py method for using custom settings has been removed."
+        "In order to use custom settings, please add them to the special 'settings.py'"
+        "file found in the '.kalite' subdirectory in your home directory."
     )
 except ImportError:
     local_settings = object()

--- a/kalite/shared/exceptions.py
+++ b/kalite/shared/exceptions.py
@@ -1,0 +1,2 @@
+class RemovedInKALite_v016_Error(Exception):
+    pass

--- a/kalite/shared/warnings.py
+++ b/kalite/shared/warnings.py
@@ -1,4 +1,0 @@
-# Do not import other kalite modules here, they depend on this quite
-
-class RemovedInKALite_v016_Warning(Warning):
-    pass


### PR DESCRIPTION
Fixes #4496. Decided it would be safest to raise an exception, rather than both trying to remove the warnings *and* refactor old code to remove cruft -- will open separate issue for that.