### PR TITLE
Fixerror in topic_tools/content_models.py get_content_parents() method

### DIFF
--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -344,7 +344,11 @@ def get_content_parents(ids=None, **kwargs):
         parent_values = Item.select(
             Parent
         ).join(Parent, on=(Item.parent == Parent.pk)).where(Item.id.in_(ids)).distinct()
+	if parent_values is None:
+  	    parent_values = list()
         return parent_values
+    else:
+	return list()
 
 
 

--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -344,11 +344,11 @@ def get_content_parents(ids=None, **kwargs):
         parent_values = Item.select(
             Parent
         ).join(Parent, on=(Item.parent == Parent.pk)).where(Item.id.in_(ids)).distinct()
-	if parent_values is None:
-  	    parent_values = list()
+        if parent_values is None:
+            parent_values = list()
         return parent_values
     else:
-	return list()
+        return list()
 
 
 

--- a/kalite/topic_tools/tests/__init__.py
+++ b/kalite/topic_tools/tests/__init__.py
@@ -3,4 +3,4 @@ from helper_tests import *
 from next_tests import *
 from resume_tests import *
 from annotate_tests import *
-from content_models_tests import UpdateItemTestCase
+from content_models_tests import UpdateItemTestCase, ContentModelsTestCase

--- a/kalite/topic_tools/tests/content_models_tests.py
+++ b/kalite/topic_tools/tests/content_models_tests.py
@@ -32,8 +32,8 @@ class UpdateItemTestCase(KALiteTestCase):
 class ContentModelsTestCase(KALiteTestCase):
 
     def test_get_content_parents(self):
-	"""
-	The function get_content_parents() should return a empty list when an empty list of ids is passed to it.
-	"""
-	self.assertEqual(get_content_parents(ids=list()), list())
+        """
+        The function get_content_parents() should return a empty list when an empty list of ids is passed to it.
+        """
+        self.assertEqual(get_content_parents(ids=list()), list())
 	

--- a/kalite/topic_tools/tests/content_models_tests.py
+++ b/kalite/topic_tools/tests/content_models_tests.py
@@ -1,5 +1,5 @@
 from kalite.testing.base import KALiteTestCase
-from kalite.topic_tools.content_models import update_item, get_random_content, get_content_item, get_content_items
+from kalite.topic_tools.content_models import update_item, get_random_content, get_content_item, get_content_items, get_content_parents
 
 
 class UpdateItemTestCase(KALiteTestCase):
@@ -27,3 +27,13 @@ class UpdateItemTestCase(KALiteTestCase):
         update_item({"available": inverse_available}, item.get("path"))
         items = get_content_items(ids=[item.get("id")])
         self.assertTrue(all([item.get("available") == inverse_available for item in items]))
+
+
+class ContentModelsTestCase(KALiteTestCase):
+
+    def test_get_content_parents(self):
+	"""
+	The function get_content_parents() should return a empty list when an empty list of ids is passed to it.
+	"""
+	self.assertEqual(get_content_parents(ids=list()), list())
+	


### PR DESCRIPTION
get_content_parents() should return an empty list when passed and empty list of ids.

Fixes https://github.com/learningequality/ka-lite/issues/4662