### PR TITLE
Create top-level nav item for docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ lint:
 test:
 	bin/kalite manage test --bdd-only
 
-test-bdd:
+test-bdd: docs
 	bin/kalite manage test --bdd-only
 
 test-nobdd:

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,7 @@ dependencies:
     - "data"
     - "sc-latest-linux"
   override:
-    - pip install -r requirements_test.txt
+    - pip install -r requirements_sphinx.txt
     - pip install -e .
     # This cannot be done because pip on Circle doesn't understand our sdist
     # - make sdist

--- a/kalite/distributed/features/steps/ui_regression.py
+++ b/kalite/distributed/features/steps/ui_regression.py
@@ -1,11 +1,13 @@
-from behave import *
+from behave import given, then, when
 from django.core.urlresolvers import reverse
 
-from kalite.testing.behave_helpers import *
+from kalite.testing.behave_helpers import find_id_with_wait, assert_no_element_by_id, \
+    elem_is_visible_with_wait, build_url, login_as_coach
 
 DROPDOWN_MENU_ID = "username"
 NAVBAR_TOGGLE_ID = "navbar_toggle"
 LOGOUT_LINK_ID = "nav_logout"
+DOCS_LINK_ID = "nav_documentation"
 
 
 @given("I'm logged in as a coach")
@@ -13,7 +15,7 @@ def step_impl(context):
     login_as_coach(context)
 
 
-@given("I can see the username dropdown menu")
+@given(u"I can see the username dropdown menu")
 def step_impl(context):
     go_to_homepage(context)
     context.dropdown_menu = dropdown_menu = find_id_with_wait(context, DROPDOWN_MENU_ID)
@@ -34,6 +36,18 @@ def step_impl(context):
     logout_link = find_id_with_wait(context, LOGOUT_LINK_ID)
     assert logout_link is not None, "Couldn't find the logout link in the DOM!"
     assert elem_is_visible_with_wait(context, logout_link), "Logout link is not visible!"
+
+
+@then(u"I see the documentation link")
+def step_impl(context):
+    docs_link = find_id_with_wait(context, DOCS_LINK_ID)
+    assert elem_is_visible_with_wait(context, docs_link), "Documentation link is not visible!"
+
+
+@then(u"I do not see the documentation link")
+def step_impl(context):
+    find_id_with_wait(context, 'user-name')  # Ensure the menu has loaded at all
+    assert_no_element_by_id(context, '#' + DOCS_LINK_ID)
 
 
 def go_to_homepage(context):

--- a/kalite/distributed/features/ui_regression.feature
+++ b/kalite/distributed/features/ui_regression.feature
@@ -12,3 +12,18 @@ Feature: UI regression tests
         Given I'm on update_videos page
         Then I'm redirected to the homepage
         Then I see only superusercreate modal
+
+    @as_coach
+    Scenario: Documentation link shown to coaches
+        Given I am on the homepage
+        Then I see the documentation link
+
+    @as_admin
+    Scenario: Documentation link shown to admins
+        Given I am on the homepage
+        Then I see the documentation link
+
+    @as_learner
+    Scenario: Documentation link not shown to learners
+        Given I am on the homepage
+        Then I do not see the documentation link

--- a/kalite/distributed/static/js/distributed/user/hbtemplates/navigation.handlebars
+++ b/kalite/distributed/static/js/distributed/user/hbtemplates/navigation.handlebars
@@ -11,7 +11,7 @@
 {{/unless}}
 
 {{#if docs_exist}}
-  <li role="menuitem" id="documentation">
+  <li role="menuitem" id="nav_documentation">
     <a role="menuitem" tabindex="-1" id="documentation_a" href="/static/html/usermanual/userman_main.html">
       {{_ "User Manual" }}
      </a>

--- a/kalite/distributed/static/js/distributed/user/hbtemplates/navigation.handlebars
+++ b/kalite/distributed/static/js/distributed/user/hbtemplates/navigation.handlebars
@@ -11,11 +11,13 @@
 {{/unless}}
 
 {{#if docs_exist}}
-  <li role="menuitem" id="nav_documentation">
-    <a role="menuitem" tabindex="-1" id="documentation_a" href="/static/html/usermanual/userman_main.html">
-      {{_ "User Manual" }}
-     </a>
-  </li>
+  {{#if is_admin}}
+    <li role="menuitem" id="nav_documentation">
+      <a role="menuitem" tabindex="-1" id="documentation_a" href="/static/html/usermanual/userman_main.html">
+        {{_ "User Manual" }}
+       </a>
+    </li>
+  {{/if}}
 {{/if}}
 
   <hr class="nav-divider">

--- a/kalite/distributed/static/js/distributed/user/hbtemplates/navigation.handlebars
+++ b/kalite/distributed/static/js/distributed/user/hbtemplates/navigation.handlebars
@@ -10,6 +10,14 @@
   <li role="menuitem"><a href="{{ url "facility_user_signup" }}" id="nav_signup">{{_ "Sign Up" }}</a></li>
 {{/unless}}
 
+{{#if docs_exist}}
+  <li role="menuitem" id="documentation">
+    <a role="menuitem" tabindex="-1" id="documentation_a" href="/static/html/usermanual/userman_main.html">
+      {{_ "User Manual" }}
+     </a>
+  </li>
+{{/if}}
+
   <hr class="nav-divider">
 {{#if is_admin}}
   <hr class="nav-divider">
@@ -41,13 +49,6 @@
           {{_ "Logout" }}
         </a>
       </li>
-    {{#if docs_exist}}
-      <li role="presentation" id="documentation">
-        <a role="menuitem" tabindex="-1" id="documentation_a" href="/static/html/index.html">
-          {{_ "Documentation" }}
-        </a>
-      </li>
-    {{/if}}
     </ul>
   </li>
 {{/if}}

--- a/kalite/testing/behave_helpers.py
+++ b/kalite/testing/behave_helpers.py
@@ -86,6 +86,15 @@ def _assert_no_element_by(context, by, value, wait_time=MAX_PAGE_LOAD_TIME):
     )
 
 
+def assert_no_element_by_id(context, _id, wait_time=MAX_PAGE_LOAD_TIME):
+    """
+    Assert that no element is found. Use a wait in case the element currently exists
+    on the page, and we want to wait for it to disappear before doing the assert.
+    Finds the element using an id.
+    """
+    _assert_no_element_by(context, By.ID, _id, wait_time)
+
+
 def assert_no_element_by_css_selector(context, css_value, wait_time=MAX_PAGE_LOAD_TIME):
     """
     Assert that no element is found. Use a wait in case the element currently exists


### PR DESCRIPTION
Fixes #4375 by adding a top-level item to the menu for docs if they are detected. Appears regardless of whether the user is logged in or not. Now also links directly to the user manual section, and I changed the display name accordingly. @radinamatic your opinion on this?

Screenshot:
![screenshot](https://cloud.githubusercontent.com/assets/8888020/13086527/735c34b6-d498-11e5-818e-6710dd61d127.png)
