### PR TITLE
Remove trailing slash from API url

### DIFF
--- a/kalite/distributed/static/js/distributed/exercises/models.js
+++ b/kalite/distributed/static/js/distributed/exercises/models.js
@@ -82,7 +82,8 @@ var ExerciseDataModel = ContentModels.ContentDataModel.extend({
 var AssessmentItemModel = Backbone.Model.extend({
 
     urlRoot: function() {
-        return window.sessionModel.get("ALL_ASSESSMENT_ITEMS_URL");
+        var base = window.sessionModel.get("ALL_ASSESSMENT_ITEMS_URL"); // Has a trailing '/'
+        return base.slice(0, base.length - 1); // Remove it so the url can be properly built.
     },
 
     get_item_data: function() {


### PR DESCRIPTION
The model's urlRoot has two trailing slashes, which was misinterpreted by the API endpoint and resulted in not content being returned. This seems to have *been* working, but for some reason I started experiencing errors from it. Could it be that I need to update my JS sources, or that updating them broke this somehow? Or perhaps my browser *used* to handle it gracefully but now it doesn't?

Testable with Selenium, but probably overkill? We need to revive the js testing framework!