### PR TITLE
Remove docs GitHub link for offline users

### DIFF
--- a/docs/kalite-theme/breadcrumbs.html
+++ b/docs/kalite-theme/breadcrumbs.html
@@ -17,7 +17,7 @@
             <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> View page source</a>
           {% endif %}
         {% endif %}
-        {% if not display_github %}
+        {% if "" and not display_github %}
           <a href="http://github.com/learningequality/ka-lite/blob/{{ theme_git_branch }}/sphinx-docs/{{ pagename }}.rst" class="fa fa-github">
               View on Github
           </a>

--- a/docs/kalite-theme/breadcrumbs.html
+++ b/docs/kalite-theme/breadcrumbs.html
@@ -13,7 +13,7 @@
             <a href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}" class="fa fa-bitbucket"> Edit on Bitbucket</a>
           {% elif show_source and source_url_prefix %}
             <a href="{{ source_url_prefix }}{{ pagename }}{{ source_suffix }}">View page source</a>
-          {% elif show_source and has_source and sourcename %}
+          {% elif "" and show_source and has_source and sourcename %}
             <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> View page source</a>
           {% endif %}
         {% endif %}

--- a/docs/kalite-theme/theme.conf
+++ b/docs/kalite-theme/theme.conf
@@ -1,5 +1,2 @@
 [theme]
 inherit = sphinx_rtd_theme
-
-[options]
-git_branch = 0.14.x


### PR DESCRIPTION
Targeting #4831 for 0.16.x instead, fixes #4348
