### PR TITLE
Add issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,6 @@
+Please include the following information when opening an issue:
+- [ ] The branch or version of KA Lite you found the issue on
+- [ ] The current date / the build that the issue affects
+- [ ] Expected behavior
+- [ ] Actual behavior
+- [ ] Steps to reproduce (be detailed!)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+If opening a PR, please observe the following guidelines:
+- [ ] If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
+- [ ] Additionally, add in a "Fixes `issue number`" for PRs that address a certain issue (e.g. "Fixes #3390").
+- [ ] If your PR changes or adds to the User Interface, please include screenshots in either the description or the comments.
+- [ ] Give a brief summary of your changes in the PR description. Add in any other notes that are important for the reviewer to know.
+- [ ] Update the documentation if your changes affect it (don't just assume they don't, please double check).
+- [ ] Double check your own code for good style.


### PR DESCRIPTION
Adds a handy-dandy template for new PRs and issues. It's a new github feature! See the github docs: https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/

I took the messages directly from out CONTRIBUTING.md file.