### PR TITLE
remove is_installed, replace with explicit check for database file

### DIFF
--- a/kalite/__init__.py
+++ b/kalite/__init__.py
@@ -8,23 +8,3 @@ __version__ = VERSION
 
 # ROOT_DATA_PATH is *not* where the source files live. It's a place where non-user-writable data files may be written.
 ROOT_DATA_PATH = os.path.join(sys.prefix, 'share', 'kalite')
-
-
-# TODO: Burn down this function, the name is weird, it just checks if a
-# database exists... not really significant enough to put it in kalite.__init__
-def is_installed():
-    """Returns True if KA Lite is installed."""
-
-    from django.conf import settings
-
-    if "sqlite" in settings.DATABASES["default"]["ENGINE"]:
-        return os.path.exists(settings.DATABASES["default"]["NAME"])  # this is the db filepath for SQLite
-    else:
-        # TODO(bcipolli): use django raw connection to test; something like:
-        # from django.db import connection
-        # try:
-        #     connection.introspection.table_names()
-        #     return True
-        # except:
-        #     return False
-        return True

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -274,11 +274,6 @@ class Command(BaseCommand):
         if git_migrate_path:
             call_command("gitmigrate", path=git_migrate_path, interactive=options["interactive"])
 
-        # TODO(benjaoming): This is used very loosely, what does it mean?
-        # Does it mean that the installation path is clean or does it mean
-        # that we should remove (clean) items from a previous installation?
-        install_clean = not kalite.is_installed()
-
         database_kind = settings.DATABASES["default"]["ENGINE"]
         if "sqlite" in database_kind:
             database_file = settings.DATABASES["default"]["NAME"]
@@ -290,6 +285,8 @@ class Command(BaseCommand):
         # An empty file is created automatically even when the database dosn't
         # exist. But if it's empty, it's safe to overwrite.
         database_exists = database_exists and os.path.getsize(database_file) > 0
+
+        install_clean = not database_exists
 
         if database_file:
             if not database_exists:
@@ -316,7 +313,7 @@ class Command(BaseCommand):
                     print(
                         "the database file will be moved to a deletable location.")
 
-        if not install_clean and not database_file and not kalite.is_installed():
+        if not install_clean and not database_file:
             # Make sure that, for non-sqlite installs, the database exists.
             raise Exception(
                 "For databases not using SQLite, you must set up your database before running setup.")


### PR DESCRIPTION
## Summary

This function was already considered really odd. In addition to that, having utility functions in `kalite/__init__.py` is bad practice.

## TODO

None

## Reviewer guidance

Not expecting this to be a challenge to merge. Searched through the codebase, and this was the only occurrence.