### PR TITLE
Remove unnecessary steps from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,6 @@ assets:
 	npm install --production
 	node build.js
 	bin/kalite manage compileymltojson
-	bin/kalite manage init_content_items
-	bin/kalite manage annotate_content_items
 	bin/kalite manage syncdb --noinput
 	bin/kalite manage migrate
 


### PR DESCRIPTION
From the commit message:
```
Remove unnecessary steps from Makefile

From the assets directive, we don't use the `init_content_items` or `annotate_content_items` commands while making
the sdist anymore -- this should be replaced with a post-install call to `retrievecontentpack`.
```

@benjaoming is this true?