### PR TITLE
enable login right after superuser is created

### DIFF
--- a/kalite/distributed/static/js/distributed/bundle_modules/homepage.js
+++ b/kalite/distributed/static/js/distributed/bundle_modules/homepage.js
@@ -21,7 +21,8 @@ $(function() {
         if (!window.statusModel.get("has_superuser")) { // "has_superuser" is true if an admin user exists.
             window.super_user_create_modal = new user.SuperUserCreateModalView();
         } else if ( typeof window.super_user_create_modal !== "undefined" ) {
-            window.super_user_create_modal.remove();
+            // super_user_create_modal might not be properly hidden yet if remove too fast 
+            setTimeout(function () {window.super_user_create_modal.remove();}, 2000);
         }
     });
 });

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -67,6 +67,7 @@ var SuperUserCreateModalView = BaseView.extend({
                 success : function(e){
                     if (e.Status == 'Success') {
                         this.close_modal();
+                        window.statusModel.set("has_superuser", true);
                     }else if (e.Status == 'Invalid'){
                         $('#superusercreate-container').html(e.data);
                         this.highlight_form();


### PR DESCRIPTION
## Summary

fix issue #4879
The current behavior will be, right after the superuser is created, the login modal will pop up.

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [ ] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

#4879 