### PR TITLE
Let commands actually set their progress log.

### DIFF
--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -73,6 +73,8 @@ class Command(UpdatesStaticCommand):
 
     def handle(self, *args, **options):
 
+        self.setup(options)
+
         operation = args[0]
         self.minimal = options.get('minimal', False)
         self.foreground = options.get('foreground', False)

--- a/kalite/updates/management/commands/classes.py
+++ b/kalite/updates/management/commands/classes.py
@@ -40,22 +40,24 @@ class UpdatesCommand(LocaleAwareCommand):
 
     def __init__(self, process_name=None, *args, **kwargs):
 
+        self.process_name = process_name or self.__class__.__module__.split(".")[-1]
+
+        super(UpdatesCommand, self).__init__(*args, **kwargs)
+
+    def setup(self, options):
+
         # Should be set by command's handle() method since there's no clear
         # call structure defined. Respected by the methods that update stuff
         # in the database.
-        self.foreground = False
+        self.foreground = options["foreground"]
 
-        self.process_name = process_name or self.__class__.__module__.split(".")[-1]
-
-        if self.foreground:
+        if not self.foreground:
             self.progress_log = UpdateProgressLog.get_active_log(process_name=self.process_name)
         else:
             self.progress_log = None
         if self.progress_log and self.progress_log.current_stage:
             self.progress_log.cancel_progress(notes=_("Starting fresh."))
             self.progress_log = UpdateProgressLog.get_active_log(process_name=self.process_name)
-
-        super(UpdatesCommand, self).__init__(*args, **kwargs)
 
     @skip_if_no_progress_log
     def display_notes(self, notes, ignore_same=True):

--- a/kalite/updates/management/commands/videodownload.py
+++ b/kalite/updates/management/commands/videodownload.py
@@ -101,7 +101,7 @@ class Command(UpdatesDynamicCommand, CronCommand):
 
 
     def handle(self, *args, **options):
-        self.stdout.write(_("Nothing to download; exiting.") + "\n")
+        self.setup(options)
         self.video = {}
 
         handled_youtube_ids = []  # stored to deal with caching

--- a/kalite/updates/management/commands/videoscan.py
+++ b/kalite/updates/management/commands/videoscan.py
@@ -27,6 +27,8 @@ class Command(UpdatesStaticCommand):
 
     def handle(self, *args, **kwargs):
 
+        self.setup(kwargs)
+
         language = kwargs["language"]
         channel = kwargs["channel"]
 


### PR DESCRIPTION
## Summary

Removes the seemingly superfluous foreground flag on UpdatesCommands - as it is set during init, can't be modified post hoc after handle (as suggested in the comment that implemented it).

## Reviewer guidance

This is a reversion of a previous change that caused this bug.

## Issues addressed

Fixes #4817.

@benjaoming please comment as to why the foreground flag is necessary if I am removing it in this way (and just letting the process_log be None), and I will try to update this to account for that use case, but for now, it just seemed to block the intended use of these UpdatesCommands.

