### PR TITLE
Don't load facilities into session object.

### DIFF
--- a/kalite/facility/forms.py
+++ b/kalite/facility/forms.py
@@ -165,13 +165,16 @@ class FacilityGroupForm(forms.ModelForm):
         self.fields["facility"].initial = facility
         self.fields["facility"].queryset = Facility.objects.by_zone(facility.get_zone())
 
+        if self.fields["facility"].queryset.count() < 2:
+            self.fields["facility"].widget = forms.HiddenInput()
+
     class Meta:
         model = FacilityGroup
         fields = ("name", "description", "facility", "zone_fallback", )
         widgets = {
-            "facility": forms.HiddenInput(),
             "zone_fallback": forms.HiddenInput(), # TODO(jamalex): this shouldn't be in here
         }
+
 
     def clean_name(self):
         name = self.cleaned_data.get("name", "")

--- a/kalite/facility/middleware.py
+++ b/kalite/facility/middleware.py
@@ -15,10 +15,6 @@ def refresh_session_facility_info(request, facility_count):
     request.session["facility_count"] = facility_count
     request.session["facility_exists"] = request.session["facility_count"] > 0
 
-    # To enable simplified login, also list the id and names of all facilities in the session object.
-    # This keeps it cached so that the status api call can return this to the client side
-    # without significantly increasing DB load on every status call.
-    request.session["facilities"] = [{"id": id, "name": name} for id, name in Facility.objects.values_list("id", "name")]
 
 def flag_facility_cache(**kwargs):
     global FACILITY_CACHE_STALE

--- a/kalite/facility/templates/facility/facility_group.html
+++ b/kalite/facility/templates/facility/facility_group.html
@@ -1,29 +1,12 @@
 {% extends "distributed/base_manage.html" %}
 {% load i18n %}
 
-{% block headcss %}{{ block.super }}
-    <style>
-        #id_facility {
-            display: none;
-        }
-    </style>
-{% endblock headcss %}
-
 {% block headjs %}{{ block.super }}
     <script>
         $(function () {
             $('#facility_group').change(function(){
                 window.location.href = $("#facility_group option:selected").val();
             });
-
-        {# Show facility info #}
-        {% if not singlefacility %}
-            // Show the dropdown
-            $("#id_facility").show();
-        {% else %}
-            // Show that there's only one facility, and it's being selected.
-            $(sprintf("<span>%s</span>", $("#id_facility option:selected").text())).insertAfter($("#id_facility"));
-        {% endif %}
         });
     </script>
 {% endblock headjs %}

--- a/kalite/facility/views.py
+++ b/kalite/facility/views.py
@@ -184,7 +184,6 @@ def group_edit(request, facility, group_id):
         "form": form,
         "group_id": group_id,
         "facility": facility,
-        "singlefacility": request.session["facility_count"] == 1,
         "title": _("Add a new group") if group_id == 'new' else _("Edit group"),
     }
 


### PR DESCRIPTION
## Summary

Don't load facilities into session object.
Don't even bother caching a list of facilities on the central server.

No regression test, as the main offense of this issue was on the central server, not distributed.

## Issues addressed

Fixes #4720 