### PR TITLE
0.16a4

### DIFF
--- a/kalite/distributed/static/js/distributed/exercises/models.js
+++ b/kalite/distributed/static/js/distributed/exercises/models.js
@@ -65,7 +65,7 @@ var ExerciseDataModel = ContentModels.ContentDataModel.extend({
                 "secondsPerFastProblem": this.get("seconds_per_fast_problem"),
                 "authorName": this.get("author_name"),
                 "relatedVideos": this.get("related_videos"),
-                "fileName": this.get("template")
+                "fileName": this.get("file_name")
             },
             "exerciseProgress": {
                 "level": "" // needed to keep khan-exercises from blowing up

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -60,7 +60,7 @@
 
           STATIC_URL                  : "{% static "" %}",
 
-          ALL_ASSESSMENT_ITEMS_URL    : "{% url 'assessment_item' assessment_item='' %}",
+          ALL_ASSESSMENT_ITEMS_URL    : "{% url 'assessment_item' assessment_item_id='' %}",
           GET_VIDEO_LOGS_URL          : "{% url 'api_dispatch_list' resource_name='videolog' %}",
           GET_EXERCISE_LOGS_URL       : "{% url 'api_dispatch_list' resource_name='exerciselog' %}",
           GET_CONTENT_LOGS_URL        : "{% url 'api_dispatch_list' resource_name='contentlog' %}",

--- a/kalite/main/api_urls.py
+++ b/kalite/main/api_urls.py
@@ -18,7 +18,7 @@ urlpatterns = patterns(__package__ + '.api_views',
     url(r'^', include(ContentLogResource().urls)),
     url(r'^', include(ContentRatingResource().urls)),
 
-    url(r'^assessment_item/(?P<assessment_item>.*)/$', 'assessment_item', {}, 'assessment_item'),
+    url(r'^assessment_item/(?P<assessment_item_id>.*)/$', 'assessment_item', {}, 'assessment_item'),
     url(r'^content_recommender/?$', 'content_recommender', {}, 'content_recommender'),
 
     # A flat data structure for building a graphical knowledge map

--- a/kalite/main/api_views.py
+++ b/kalite/main/api_views.py
@@ -107,8 +107,8 @@ def content_recommender(request):
 
 
 @api_handle_error_with_json
-def assessment_item(request, assessment_item):
-    assessment_item = get_assessment_item_data(channel=getattr(request, "channel", "khan"),
-                                               language=getattr(request, "language", "en"),
-                                               assessment_item_id=assessment_item)
-    return JsonResponse(assessment_item)
+def assessment_item(request, assessment_item_id):
+    assessment_item_dict = get_assessment_item_data(channel=getattr(request, "channel", "khan"),
+                                                    language=getattr(request, "language", "en"),
+                                                    assessment_item_id=assessment_item_id)
+    return JsonResponse(assessment_item_dict)

--- a/kalite/main/tests/api_tests.py
+++ b/kalite/main/tests/api_tests.py
@@ -1,9 +1,49 @@
 """
 """
+import json
+from django.core.urlresolvers import reverse
+
 from ..models import VideoLog, ExerciseLog
 from kalite.facility.models import Facility, FacilityUser
-from kalite.testing.base import KALiteTestCase
+from kalite.testing.base import KALiteTestCase, KALiteClientTestCase
 from kalite.testing.client import KALiteClient
+
+
+class ContentItemApiViewTestCase(KALiteClientTestCase):
+    def test_sanity(self):
+        resp = self.client.get(reverse('content_item', kwargs={
+            'channel': 'khan',
+            'content_id': 'subtraction_1',
+        }))
+        expected = json.loads('{"available": true, "kind": "Exercise", "description": "Subtract small numbers. All answers are four or less.", "parent": {}, "title": "Subtraction within five", "extra_fields": "{\\\"curated_related_videos\\\":[\\\"x2fefc435\\\"],\\\"display_name\\\":\\\"Subtraction within five\\\",\\\"prerequisites\\\":[\\\"addition_1\\\"],\\\"uses_assessment_items\\\":false,\\\"file_name\\\":\\\"subtraction_1.html\\\",\\\"all_assessment_items\\\":[],\\\"name\\\":\\\"subtraction_1\\\"}", "youtube_id": null, "messages": [], "slug": "subtraction_1", "files_complete": 0, "total_files": 0, "pk": 31, "path": "khan/math/arithmetic/addition-subtraction/basic_addition/subtraction_1/", "size_on_disk": 0, "sort_order": 0.0, "id": "subtraction_1", "remote_size": 0}')  # noqa
+        self.assertDictEqual(json.loads(resp.content), expected)
+
+    def test_template_key_not_in_extra_fields(self):
+        """
+        A regression test -- hard to test the JS, but at least we can assert which keys we expect to find and which
+        we do not.
+        """
+        resp = self.client.get(reverse('content_item', kwargs={
+            'channel': 'khan',
+            'content_id': 'subtraction_1',
+        }))
+        resp_dict = json.loads(resp.content)
+        extra_fields = json.loads(resp_dict['extra_fields'])
+        self.assertNotIn('template', extra_fields)
+
+    def test_file_name_key_in_extra_fields(self):
+        """
+        A regression test -- hard to test the JS, but at least we can assert which keys we expect to find and which
+        we do not.
+        """
+        resp = self.client.get(reverse('content_item', kwargs={
+            'channel': 'khan',
+            'content_id': 'subtraction_1',
+        }))
+        resp_dict = json.loads(resp.content)
+        extra_fields = json.loads(resp_dict['extra_fields'])
+        self.assertIn('file_name', extra_fields)
+
 
 class TestSaveExerciseLog(KALiteTestCase):
 
@@ -120,7 +160,6 @@ class TestSaveExerciseLog(KALiteTestCase):
         self.assertEqual(exerciselog.points, self.NEW_POINTS_SMALLER, "The ExerciseLog's points were not saved correctly.")
         self.assertEqual(exerciselog.streak_progress, self.NEW_STREAK_PROGRESS_SMALLER, "The ExerciseLog's streak progress was not saved correctly.")
         self.assertEqual(exerciselog.attempts, self.NEW_ATTEMPTS + 1, "The ExerciseLog did not have the correct number of attempts.")
-
 
 
 class TestSaveVideoLog(KALiteTestCase):

--- a/kalite/version.py
+++ b/kalite/version.py
@@ -7,7 +7,7 @@ from kalite.shared.utils import open_json_or_yml
 # Must also be of the form N.N.N for internal use, where N is a non-negative integer
 MAJOR_VERSION = "0"
 MINOR_VERSION = "16"
-PATCH_VERSION = "0"
+PATCH_VERSION = "a4"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
 


### PR DESCRIPTION
**WARNING!** Merging this, merges and closes all PRs contained in this PR, and they may have a separate review process and amendments following. So don't merge this PR!! :)

Takes over  0.16a3 #4891 

New release, manually brewing the distributions:

 * [x] [ka-lite on pypi](https://pypi.python.org/pypi/ka-lite)
 * [x] [ka-lite-static on pypi](https://pypi.python.org/pypi/ka-lite-static)
 * [x] [ka-lite on Launchpad PPA](https://launchpad.net/~learningequality/+archive/ubuntu/ka-lite)
 * [ ] OSX installer
 * [ ] Windows installer

## Known issues

 * [x] Raspberry Pi still can only download 1 video at a time #4892
 * [x] Content packs are to be updated, videos show up twice on Video download page
 * [x] After you create the first admin user account, you need to reload the page before clicking Login #4896
 * [ ] [See remaining issue list for Milestone](https://github.com/learningequality/ka-lite/issues?q=is%3Aopen+is%3Aissue+milestone%3A0.16.0)

## Included PRs

 * #4872

## Installer links

  * [Debian/Ubuntu]() TODO
  * [Windows]() TODO
  * [Mac]() TODO
