### PR TITLE
'Done' and 'Skip' button now appear enabled

### DIFF
--- a/kalite/distributed/static/css/distributed/khan-lite.less
+++ b/kalite/distributed/static/css/distributed/khan-lite.less
@@ -985,5 +985,5 @@ to items you want to have the icon appear with.
 }
 
 .introjs-skipbutton {
-    color: #000000
+    color: #000000;
 }

--- a/kalite/distributed/static/css/distributed/khan-lite.less
+++ b/kalite/distributed/static/css/distributed/khan-lite.less
@@ -983,3 +983,7 @@ to items you want to have the icon appear with.
     height: 25px;
     width: 25px;
 }
+
+.introjs-skipbutton {
+    color: #000000
+}


### PR DESCRIPTION
## Summary

Color that was initially set for the inline skip button text was #7a7a7a that was basically **gray**, now the button text color is changed to **black**.

## Issues addressed

Fixes #4905 

## Screenshots
![done1](https://cloud.githubusercontent.com/assets/13970876/13332969/70cbe37e-dc2a-11e5-8fad-85a073e0db5b.png)
![skip](https://cloud.githubusercontent.com/assets/13970876/13332971/7342fca0-dc2a-11e5-888a-b3f1caaa9627.png)




