### PR TITLE
Add playback speed button to video player

### DIFF
--- a/kalite/distributed/static/js/distributed/video/hbtemplates/video-player.handlebars
+++ b/kalite/distributed/static/js/distributed/video/hbtemplates/video-player.handlebars
@@ -1,5 +1,5 @@
 <div id="video-player"{{#unless content_urls }} class="client-online-only"{{/unless}}>
-    <video class="video-player video-js vjs-default-skin vjs-fullscreen" id="{{ random_id }}" controls preload="auto" width="auto" height="auto" {{#if content_urls.thumbnail }}poster="{{ content_urls.thumbnail }}" {{/if}}data-setup="{}">
+    <video class="video-player video-js vjs-default-skin vjs-fullscreen" id="{{ random_id }}">
         <source src="{{ content_urls.stream }}" type="{{ content_urls.stream_type }}" />
         {{#each subtitle_urls }}
         <track kind="captions" src="{{ this.url }}" srclang="{{ code }}" label="{{ name }}" {{#ifcond code "==" ../selected_language }}{{#ifcond ../code "!=" "en" }}default="True"{{/ifcond}}{{/ifcond}}/>

--- a/kalite/distributed/static/js/distributed/video/views.js
+++ b/kalite/distributed/static/js/distributed/video/views.js
@@ -60,7 +60,16 @@ var VideoPlayerView = ContentBaseView.extend({
         var player_id = this.$(".video-js").attr("id");
 
         if (player_id) {
-            this.player = this.player = _V_(player_id);
+            var video_player_options = {
+                "controls": true,
+                "width": "auto",
+                "height": "auto",
+                "playbackRates": [0.5, 1, 1.5, 2]
+            };
+            if( this.data_model.get("content_urls").thumbnail ) {
+                video_player_options['poster'] = this.data_model.get("content_urls").thumbnail;
+            }
+            this.player = window.player = _V_(player_id, video_player_options);
             this.initialize_listeners();
         } else {
             console.warn("Warning: Could not find Video.JS player!");

--- a/kalite/distributed/static/js/distributed/video/views.js
+++ b/kalite/distributed/static/js/distributed/video/views.js
@@ -64,7 +64,7 @@ var VideoPlayerView = ContentBaseView.extend({
                 "controls": true,
                 "width": "auto",
                 "height": "auto",
-                "playbackRates": [0.5, 1, 1.5, 2]
+                "playbackRates": [0.5, 1, 1.25, 1.5, 2]
             };
             if( this.data_model.get("content_urls").thumbnail ) {
                 video_player_options['poster'] = this.data_model.get("content_urls").thumbnail;


### PR DESCRIPTION
## Summary

Adds the playback speed button back to our video player. Removed inline video.js configuration options in favor of explicit configuration in our view. @jamalex you're identified as my bug-buddy for videos, but if you don't have the opportunity to review this then please indicate that's the case.

## TODO

- [x] ~~Have **tests** been written for the new code?~~ No. There's no good way to test KA Lite's javascript.

## Issues addressed

Fixes #4639.