### PR TITLE
Propagates topic selection to tabular coach report.

### DIFF
--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -13,6 +13,22 @@ from kalite.facility.models import FacilityUser
 from kalite.shared.decorators.auth import require_admin
 from kalite.topic_tools.content_models import get_topic_contents, get_topic_nodes, get_leafed_topics, get_content_parents
 
+
+def unique_by_id_and_kind_sort(seq):
+
+    seq.sort(key=lambda x: x.get("sort_order", 0))
+    seen = {}
+    result = []
+    for item in seq:
+        marker = item.get("id") + item.get("kind")
+
+        if marker in seen:
+            continue
+        seen[marker] = 1
+        result.append(item)
+    return result
+
+
 def get_learners_from_GET(request):
     learner_ids = request.GET.getlist("user_id")
 
@@ -106,6 +122,8 @@ def learner_logs(request):
             objects = dict([(item.get("id"), item) for item in get_topic_nodes(ids=[obj[id_field] for obj in topic_objects]) or []]).values()
         output_objects.extend(objects)
         output_logs.extend(log_objects)
+
+    output_objects = unique_by_id_and_kind_sort(output_objects)
 
     return JsonResponse({
         "logs": output_logs,

--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -15,6 +15,12 @@ from kalite.topic_tools.content_models import get_topic_contents, get_topic_node
 
 
 def unique_by_id_and_kind_sort(seq):
+    """
+    Due to the fact that we have duplicate content items for the same content id in our topic tree, as the way that
+    we have implemented duplication of content across the topic tree.
+    :param seq: an iterator of content items.
+    :return: A unique, sorted list of content items.
+    """
 
     seq.sort(key=lambda x: x.get("sort_order", 0))
     seen = {}
@@ -126,7 +132,9 @@ def learner_logs(request):
     output_objects = unique_by_id_and_kind_sort(output_objects)
 
     return JsonResponse({
+        # All learner log objects for each content item.
         "logs": output_logs,
+        # All content items for which logs are being returned.
         "contents": output_objects,
         # Sometimes 'learners' gets collapsed to a list from the Queryset. This insures against that eventuality.
         "learners": [{

--- a/kalite/coachreports/api_views.py
+++ b/kalite/coachreports/api_views.py
@@ -74,7 +74,7 @@ def learner_logs(request):
 
     end_date = request.GET.get("end_date")
 
-    topic_ids = request.GET.getlist("topic_id", [])
+    topic_ids = json.loads(request.GET.get("topic_ids", "[]"))
 
     learners = get_learners_from_GET(request)
 

--- a/kalite/coachreports/static/js/coachreports/coach_reports/models.js
+++ b/kalite/coachreports/static/js/coachreports/coach_reports/models.js
@@ -11,6 +11,11 @@ var StateModel = Backbone.Model.extend({
                 group_name: undefined
             });
         }
+        if (key === "facility" || key.facility || key === "group" || key.group) {
+            this.set({
+                topic_ids: undefined
+            });
+        }
 
         Backbone.Model.prototype.set.call(this, key, val, options);
     }
@@ -34,6 +39,7 @@ var CoachReportModel = Backbone.Model.extend({
         this.group = options.group;
         this.start_date = options.start_date;
         this.end_date = options.end_date;
+        this.topic_ids = options.topic_ids;
     },
 
     url: function() {
@@ -41,7 +47,8 @@ var CoachReportModel = Backbone.Model.extend({
             facility_id: this.facility,
             group_id: this.group,
             start_date: this.start_date,
-            end_date: this.end_date
+            end_date: this.end_date,
+            topic_ids: this.topic_ids
         });
     }
 });

--- a/kalite/coachreports/static/js/coachreports/tabular_reports/views.js
+++ b/kalite/coachreports/static/js/coachreports/tabular_reports/views.js
@@ -375,7 +375,8 @@ var TabularReportView = BaseView.extend({
             facility: this.model.get("facility"),
             group: this.model.get("group"),
             start_date: date_string(this.model.get("start_date")),
-            end_date: date_string(this.model.get("end_date"))
+            end_date: date_string(this.model.get("end_date")),
+            topic_ids: this.model.get("topic_ids")
         });
         if (this.model.get("facility")) {
             this.data_model.fetch().then(function() {

--- a/kalite/testing/mixins/student_progress_mixins.py
+++ b/kalite/testing/mixins/student_progress_mixins.py
@@ -45,7 +45,7 @@ class CreateExerciseLogMixin(object):
     @classmethod
     def create_exercise_log(cls, **kwargs):
         fields = CreateExerciseLogMixin.DEFAULTS.copy()
-        fields['user'] = kwargs.get("user")
+        fields.update(kwargs)
 
         return ExerciseLog.objects.create(**fields)
 

--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -510,14 +510,27 @@ def bulk_insert(items, **kwargs):
 
 
 @set_database
+def create(item, **kwargs):
+    """
+    Wrapper around create that allows us to specify a database
+    and also parse the model data to compress extra fields.
+    :param item: A dictionary containing content metadata for one node.
+    :return Item
+    """
+    if item:
+        return Item.create(**parse_model_data(item))
+
+
+@set_database
 def get_or_create(item, **kwargs):
     """
     Wrapper around get or create that allows us to specify a database
     and also parse the model data to compress extra fields.
     :param item: A dictionary containing content metadata for one node.
+    :return tuple of Item and Boolean for whether created or not.
     """
     if item:
-        Item.create_or_get(**parse_model_data(item))
+        return Item.create_or_get(**parse_model_data(item))
 
 
 @set_database


### PR DESCRIPTION
## Summary

Ensures that when the topic selector is used in the coach reports, this also restricts the data used in the tabular report to just those topics.

I have not written any tests, because we need Javascript unit tests to properly check this. Sorry, the integration tests are just too flakey and difficult to implement at this juncture.

## Reviewer guidance

To test this, generate some data using `generaterealdata`, go to the coach reports, look at the tabular report.

Select a topic from the topic drop down. The report view will refresh. Show the tabular report again. Now only content items in the topic drop down will display.

## Issues addressed

Fixes #4869.
Also puts in the KA Lite side fix for #4728 - sort_order is being set incorrectly by content packs though, so this change is not yet visible.
