### PR TITLE
Removed overlapping text of content recommendation explore

### DIFF
--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.less
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.less
@@ -410,14 +410,6 @@ form .input-group {
   text-align: center;
 }
 
-.content-explore-topic .row div.col-xs-5{
-  width: 100%;
-}
-
-.content-explore-topic .row div.col-xs-7{
-  width: 100%;
-}
-
 #content-nextsteps-lesson h3 {
     margin-top: 10px;
 }

--- a/kalite/distributed/static/css/distributed/bootstrap-overrides.less
+++ b/kalite/distributed/static/css/distributed/bootstrap-overrides.less
@@ -410,6 +410,14 @@ form .input-group {
   text-align: center;
 }
 
+.content-explore-topic .row div.col-xs-5{
+  width: 100%;
+}
+
+.content-explore-topic .row div.col-xs-7{
+  width: 100%;
+}
+
 #content-nextsteps-lesson h3 {
     margin-top: 10px;
 }

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-explore-topic.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-explore-topic.handlebars
@@ -7,11 +7,11 @@
       </div>
     </div>
     <div class="row">
-      <div class="col-xs-5">
+      <div class="col-xs-12">
           <h2 class="h3">{{ suggested_topic.title }}:</h2>
       </div>
       {{#if suggested_topic.description }}
-      <div class="col-xs-7">
+      <div class="col-xs-12">
         <p class="h4">{{_ "Description" }}:</p>
         <p aria-hidden="true">{{ truncate suggested_topic.description 70 }}</p>
         <span class="sr-only">{{ suggested_topic.description }}</span>


### PR DESCRIPTION
## Summary

Width value change to 100% so as to avoid overlapping of text.

## Issues addressed

Fixes #3863

## Screenshots 
![explore in different rows](https://cloud.githubusercontent.com/assets/13970876/13360115/8e749dfe-dcdd-11e5-968a-ae5e2d148980.png)