### PR TITLE
Change message for the user while they wait for server response

### DIFF
--- a/kalite/distributed/static/js/distributed/utils/api.js
+++ b/kalite/distributed/static/js/distributed/utils/api.js
@@ -57,7 +57,7 @@ function handleFailedAPI(resp, error_prefix) {
     var messages = {};
     switch (resp.status) {
         case 0:
-            messages = {error: gettext("Could not connect to the server.") + " " + gettext("Please try again later.")};
+            messages = {error: gettext("Connecting to the server.") + " " + gettext("Please wait...")};
             break;
         
         case 401:


### PR DESCRIPTION
## Summary

Maybe there is a "real" `case 0` that warrants the previous message, but in 3 months of testing I haven't seen it. Every time this message appears, it's about waiting for the server response at logging in and out, and not really needing to "try again later". 

## Screenshots (if appropriate)

I can't even grab a screenshot, it resolves too fast on my dev setup, which kind of proves a point... :)
Let me know what you think @rtibbles @aronasorman 
 
