### PR TITLE
Video download fixes

### DIFF
--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -286,6 +286,7 @@ def get_topic_update_nodes(parent=None, **kwargs):
             Item.total_files,
             Item.id,
             Item.path,
+            Item.youtube_id,
         ).join(Parent, on=(Item.parent == Parent.pk)).where((selector) & (Item.total_files != 0))
         return values
 

--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -119,11 +119,11 @@ def cancel_update_progress(request, process_log):
 @require_admin
 @api_handle_error_with_json
 def start_video_download(request):
-    force_job("videodownload", stop=True, locale=request.language)
-
     """
     API endpoint for launching the videodownload job.
     """
+    force_job("videodownload", stop=True, locale=request.language)
+
     paths = OrderedSet(json.loads(request.body or "{}").get("paths", []))
 
     lang = json.loads(request.body or "{}").get("lang", "en")
@@ -150,7 +150,7 @@ def delete_videos(request):
 
     lang = json.loads(request.body or "{}").get("lang", "en")
 
-    youtube_ids = get_download_youtube_ids(paths)
+    youtube_ids = get_download_youtube_ids(paths, language=lang)
 
     num_deleted = 0
 

--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -124,15 +124,17 @@ def start_video_download(request):
     """
     API endpoint for launching the videodownload job.
     """
-    paths = OrderedSet(simplejson.loads(request.body or "{}").get("paths", []))
+    paths = OrderedSet(json.loads(request.body or "{}").get("paths", []))
+
+    lang = json.loads(request.body or "{}").get("lang", "en")
 
     youtube_ids = get_download_youtube_ids(paths)
 
     queue = VideoQueue()
 
-    queue.add_files(youtube_ids, language=request.language)
+    queue.add_files(youtube_ids, language=lang)
 
-    force_job("videodownload", _("Download Videos"), locale=request.language)
+    force_job("videodownload", _("Download Videos"), locale=lang)
 
     return JsonResponseMessageSuccess(_("Launched video download process successfully."))
 
@@ -144,7 +146,9 @@ def delete_videos(request):
     API endpoint for deleting videos.
     """
 
-    paths = OrderedSet(simplejson.loads(request.body or "{}").get("paths", []))
+    paths = OrderedSet(json.loads(request.body or "{}").get("paths", []))
+
+    lang = json.loads(request.body or "{}").get("lang", "en")
 
     youtube_ids = get_download_youtube_ids(paths)
 
@@ -155,7 +159,7 @@ def delete_videos(request):
         if delete_downloaded_files(id):
             num_deleted += 1
 
-    annotate_content_models_by_youtube_id(youtube_ids=youtube_ids.keys(), language=request.language)
+    annotate_content_models_by_youtube_id(youtube_ids=youtube_ids.keys(), language=lang)
 
     return JsonResponseMessageSuccess(_("Deleted %(num_videos)s video(s) successfully.") % {"num_videos": num_deleted})
 
@@ -164,7 +168,7 @@ def delete_videos(request):
 @api_handle_error_with_json
 def cancel_video_download(request):
 
-    force_job("videodownload", stop=True, locale=request.language)
+    force_job("videodownload", stop=True)
 
     queue = VideoQueue()
 
@@ -177,7 +181,9 @@ def cancel_video_download(request):
 @api_handle_error_with_json
 def video_scan(request):
 
-    force_job("videoscan", _("Scan for Videos"), language=request.language)
+    lang = json.loads(request.body or "{}").get("lang", "en")
+
+    force_job("videoscan", _("Scan for Videos"), language=lang)
 
     return JsonResponseMessageSuccess(_("Scanning for videos started."))
 

--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -128,7 +128,7 @@ def start_video_download(request):
 
     lang = json.loads(request.body or "{}").get("lang", "en")
 
-    youtube_ids = get_download_youtube_ids(paths)
+    youtube_ids = get_download_youtube_ids(paths, language=lang)
 
     queue = VideoQueue()
 
@@ -222,10 +222,10 @@ def delete_language_pack(request):
 
 @require_admin
 @api_handle_error_with_json
-def get_update_topic_tree(request, lang_code=None):
+def get_update_topic_tree(request):
 
     parent = request.GET.get("parent")
-    lang_code = lang_code or request.language      # Get annotations for the current language.
+    lang_code = request.GET.get("lang") or request.language      # Get annotations for the current language.
 
     return JsonResponse(get_topic_update_nodes(parent=parent, language=lang_code))
 

--- a/kalite/updates/static/js/updates/bundle_modules/update_videos.js
+++ b/kalite/updates/static/js/updates/bundle_modules/update_videos.js
@@ -86,6 +86,7 @@ function video_check_callback(progress_log, resp) {
 }
 
 var tree;
+var lang_code;
 
 var video_callbacks = {
     start: video_start_callback,
@@ -108,6 +109,7 @@ var scan_callbacks = {
 
 
 $(function() {
+    lang_code = $("#download_language_selector option:selected")[0].value;
 
     $("#content_tree").html("");
 
@@ -120,7 +122,7 @@ $(function() {
         clickFolderMode: 2,
         source: {
             url: window.Urls.get_update_topic_tree(),
-            data: { parent: "root"},
+            data: { parent: "root", lang: lang_code},
             cache: false
         },
         postProcess: function(event, data) {
@@ -143,7 +145,7 @@ $(function() {
             var node = data.node;
             data.result = {
               url: window.Urls.get_update_topic_tree(),
-              data:{ parent: node.key},
+              data:{ parent: node.key, lang: lang_code},
               cache: false
             };
         },
@@ -215,7 +217,7 @@ $(function() {
         var paths = _.map(tree.getSelectedNodes(true), function(node) { return node.data.path; });
 
         // Do the request
-        api.doRequest(window.Urls.start_video_download(), {paths: paths})
+        api.doRequest(window.Urls.start_video_download(), {paths: paths, lang: lang_code})
             .success(function() {
                 base.updatesStart("videodownload", 2000, video_callbacks);
             })
@@ -260,7 +262,7 @@ $(function() {
 
                     var paths = _.map(tree.getSelectedNodes(true), function(node) { return node.data.path; });
                     // Do the request
-                    api.doRequest(window.Urls.delete_videos(), {paths: paths})
+                    api.doRequest(window.Urls.delete_videos(), {paths: paths, lang: lang_code})
                         .success(function() {
                             //update fancytree to reflect the current status of the videos
                             $.each(downloading_node, function(ind, node) {
@@ -324,7 +326,7 @@ $(function() {
     }
 
     $("#download_language_selector").change(function() {
-         var lang_code = $("#download_language_selector option:selected")[0].value;
+        lang_code = $("#download_language_selector option:selected")[0].value;
          window.location.href = get_params.setGetParam(window.location.href, "lang", lang_code);
     });
 
@@ -336,7 +338,7 @@ $(function() {
         $("#scan-videos").attr("disabled", "disabled");
 
         // Do the request
-        api.doRequest(window.Urls.video_scan())
+        api.doRequest(window.Urls.video_scan(), {lang: lang_code})
             .success(function() {
                 base.updatesStart("videoscan", 2000, scan_callbacks);
 

--- a/kalite/updates/static/js/updates/bundle_modules/update_videos.js
+++ b/kalite/updates/static/js/updates/bundle_modules/update_videos.js
@@ -149,6 +149,10 @@ $(function() {
               cache: false
             };
         },
+        loadChildren: function(event, data) {
+            // Apply parent's state to new child nodes:
+            data.node.fixSelection3AfterClick();
+        },
         select: function(event, node) {
             // only allow selection if we're not currently downloading
             if (!videos_downloading) {

--- a/kalite/updates/static/js/updates/bundle_modules/update_videos.js
+++ b/kalite/updates/static/js/updates/bundle_modules/update_videos.js
@@ -47,7 +47,7 @@ function video_check_callback(progress_log, resp) {
         var status = progress_log.stage_status;
 
         if (keyCompleted) {
-            if (!status) {
+            if (!status && (status !== "error")) {
                 setNodeClass(tree.getNodeByKey(keyCompleted), "complete");
             } else if (status == "error") {
                 // update # errors
@@ -67,8 +67,6 @@ function video_check_callback(progress_log, resp) {
                 });
                 return;
 
-            } else if (lastKey != currentKey) {
-                setNodeClass(tree.getNodeByKey(currentKey), "partial");
             }
 
         } else if (progress_log.completed) {
@@ -138,7 +136,7 @@ $(function() {
                     node["lazy"] = true;
                     node["folder"] = true;
                 }
-                node["key"] = node["id"];
+                node["key"] = node.youtube_id || node.id;
             });
         },
         lazyLoad: function(event, data){
@@ -419,7 +417,7 @@ function getSelectedStartedMetadata(data_type) {
 function setNodeClass(node, className) {
     if (node.extraClasses != className) {
         node.extraClasses = className;
-        if (node.parent) {
+        if (node.parent !== null) {
             updateNodeClass(node.parent);
         }
     }


### PR DESCRIPTION
## Summary

Properly sets the language codes on the client side, and then properly parses them on the server side in order to ensure that video download, video deletion, and video scanning all actually do this for multiple languages, rather than just English.

## TODO

- [x] Have **tests** been written for the new code?

## Issues addressed

Fixes #4937, fixes #4933, fixes a behaviour noted in #4929 by @radinamatic.

