### PR TITLE
Allow positional arguments with dashes inside

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,6 @@ If not all TODOs are marked, this PR is considered WIP (work in progress)
 - [ ] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
 - [ ] Has documentation been written/updated?
 - [ ] New dependencies (if any) added to requirements file
-- [ ] Add an entry to CHANGELOG.rst
 
 ## Reviewer guidance
 

--- a/kalitectl.py
+++ b/kalitectl.py
@@ -89,10 +89,18 @@ import re
 import cherrypy
 
 # We do not understand --option value, only --option=value.
-# Match all patterns of "--option value" and fail if they exist
-__validate_cmd_options = re.compile(r"--?[^\s]+\s+(?:(?!--|-[\w]))")
+# Similarly, we don't understand -o Foo, only -oFoo
+# Match all patterns as above and fail if they exist
+# With single-dash options, there's a corner case if a dash appears in a positional argument, like so:
+#     kalite manage retrievecontentpack local es-ES foo.zip
+# Be sure to match whitespace *before* the option starts, so that dashes *inside* arguments are okay!
+# (?!...) is a negative lookahead assertion. It only matches if the ... pattern *isn't* found!
+__validate_cmd_options = re.compile(r"\s--?[^\s]+\s+(?!--|-[\w])")
 if __validate_cmd_options.search(" ".join(sys.argv[1:])):
-    sys.stderr.write("Please only use --option=value or -x123 patterns. No spaces allowed between option and value. The option parser gets confused if you do otherwise.\n\nWill be fixed in a future release.")
+    sys.stderr.write("Please only use --option=value or -x123 patterns. No spaces allowed between option and value. "
+                     "The option parser gets confused if you do otherwise."
+                     "\nAdditionally, please put all Django management command options *after* positional arguments."
+                     "\n\nWill be fixed in a future release.")
     sys.exit(1)
 
 from threading import Thread


### PR DESCRIPTION
## Summary

Fixes #4935:
```text
Allow positional arguments with dashes inside

It choked on valid commands like:
`kalite manage retrievecontentpack local es-ES foo.zip`
Because of the dash in the middle of a positional argument.
So only match if there is preceding whitespace.

Also remove redundant non-capturing group -- negative lookaheads
don't capture anyway.
```

Remove reference to nonexistent CHANGELOG.rst in our PR template, too.

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Has documentation been written/updated? [[See the warning message, comments]]