### PR TITLE
Remove that custom pt-BR -> pt mapping.

### DIFF
--- a/kalite/main/api_views.py
+++ b/kalite/main/api_views.py
@@ -44,11 +44,6 @@ def search_api(request, channel):
 def content_item(request, channel, content_id):
     language = request.language
 
-    # Hardcode the Brazilian Portuguese mapping that only the central server knows about
-    # TODO(jamalex): BURN IT ALL DOWN!
-    if language == "pt-BR":
-        language = "pt"
-
     content = get_content_item(channel=channel, content_id=content_id, language=language)
 
     if not content:

--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -104,12 +104,7 @@ def set_database(function):
     """
 
     def wrapper(*args, **kwargs):
-        # Hardcode the Brazilian Portuguese mapping that only the central server knows about
-        # TODO(jamalex): BURN IT ALL DOWN!
         language = kwargs.get("language", "en")
-
-        if language == "pt-BR":
-            language = "pt"
 
         path = kwargs.pop("database_path", None)
         if not path:


### PR DESCRIPTION
## Summary

For 0.15 we made a hack that manually maps `pt-BR` to `pt`. This hack is not needed anymore, in fact it actively hinders `pt-BR` from working properly by causing annotation to happen on a nonexistent DB.