### PR TITLE
Fixes display issues for icomoon icons used in content recommendation.

### DIFF
--- a/kalite/distributed/static/css/distributed/content_recommendation.less
+++ b/kalite/distributed/static/css/distributed/content_recommendation.less
@@ -2,3 +2,9 @@
 	background-color: #5aa685;
 	color: white;
 }
+
+i.content-rec-icon {
+	font-size:4em;
+	top: 0.2em;
+    position: relative;
+}

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-nextsteps-lesson.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-nextsteps-lesson.handlebars
@@ -12,7 +12,7 @@
                   alt="{{ truncate description 150 }}"
               {{/if}}>
           {{else}}
-          <span aria-hidden="true" role="presentation"><i class="icon-{{kind}} glyphicon glyphicon-expand gly-h1"></i></span>
+          <span aria-hidden="true" role="presentation"><i class="icon-{{kind}} content-rec-icon"></i></span>
           {{/if}}
         </center>
       </div>

--- a/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-resume.handlebars
+++ b/kalite/distributed/static/js/distributed/contentrec/hbtemplates/content-resume.handlebars
@@ -49,7 +49,7 @@
       <div class="row">
         <div class="col-xs-3">
           <center>
-            <span aria-hidden="true" role="presentation"><i id="exercise-icon" class="icon-{{kind}} glyphicon glyphicon-pencil gly-h1"></i></span>
+            <span aria-hidden="true" role="presentation"><i class="icon-{{kind}} content-rec-icon"></i></span>
           </center>
         </div> 
         


### PR DESCRIPTION
## Summary

Fixes display issues for icomoon icons on the content recommendation templates.

No tests - we don't have a testing framework for css rendering.

## Issues addressed

Fixes #4911 

## Screenshots (if appropriate)

![image](https://cloud.githubusercontent.com/assets/1680573/13444387/c728b9c0-dfba-11e5-977b-7ff066cda4d1.png)
