### PR TITLE
Prevent TypeErrors getting thrown on partial downloads.

### DIFF
--- a/kalite/updates/static/js/updates/bundle_modules/update_videos.js
+++ b/kalite/updates/static/js/updates/bundle_modules/update_videos.js
@@ -415,10 +415,12 @@ function getSelectedStartedMetadata(data_type) {
 }
 
 function setNodeClass(node, className) {
-    if (node.extraClasses != className) {
-        node.extraClasses = className;
-        if (node.parent !== null) {
-            updateNodeClass(node.parent);
+    if (node !== null) {
+        if (node.extraClasses != className) {
+            node.extraClasses = className;
+            if (node.parent !== null) {
+                updateNodeClass(node.parent);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Prevents Javascript TypeErrors from being thrown.

## Reviewer guidance

UI is unaffected, this just ensures against unnecessary and misleading JS errors in the console.

@MCGallaspy this was reported by @radinamatic as part of her follow up on #4937 - that issue is solved, but these residual errors could be misleading in debug reports.