### PR TITLE
Migrate to VTT subtitle format

### DIFF
--- a/kalite/distributed/features/learn_content.feature
+++ b/kalite/distributed/features/learn_content.feature
@@ -10,3 +10,8 @@ Feature: Content on the Learn page
     Scenario: Content is available
         Given I open some available content
         Then I should see no alert
+
+    @uses_video_with_subtitles
+    Scenario: Subtitles are available when
+        When I visit a video with subtitles
+        Then the video player is aware of the subtitles

--- a/kalite/distributed/features/steps/learn_content.py
+++ b/kalite/distributed/features/steps/learn_content.py
@@ -1,7 +1,7 @@
-from behave import given, then
+from behave import given, then, when
 
 from kalite.testing.behave_helpers import build_url, reverse, alert_in_page, find_css_class_with_wait, \
-    assert_no_element_by_css_selector
+    assert_no_element_by_css_selector, wait_for_video_player_ready
 
 TIMEOUT = 30
 
@@ -33,3 +33,16 @@ def impl(context):
     # Wait for .content, a rule-of-thumb for ajax stuff to finish, and thus for .alerts to appear (if any).
     find_css_class_with_wait(context, "content")
     assert_no_element_by_css_selector(context, ".alert")
+
+
+@when(u'I visit a video with subtitles')
+def impl(context):
+    context.browser.get(build_url(context, reverse("learn") + context.video.path))
+    wait_for_video_player_ready(context)
+    context.browser.execute_script('$("video").trigger("loadedmetadata");')
+
+
+@then(u'the video player is aware of the subtitles')
+def impl(context):
+    text_tracks = context.browser.execute_script('return player.textTracks().length;')
+    assert text_tracks > 0, "The video didn't have any text tracks!"

--- a/kalite/distributed/static/css/distributed/video-js-override.less
+++ b/kalite/distributed/static/css/distributed/video-js-override.less
@@ -1,7 +1,7 @@
 /* Responsive content display for tablets */
 /* Jessica TODO: take off !important tags */
 
-@import "../../../../../node_modules/video.js/dist/video-js/video-js.less";
+@import (inline) "../../../../../node_modules/video.js/dist/video-js.css";
 
 @vjs-font-path: "/static/css/distributed/font/";
 

--- a/kalite/distributed/static/js/distributed/bundle_modules/base.js
+++ b/kalite/distributed/static/js/distributed/bundle_modules/base.js
@@ -20,6 +20,10 @@ global.sessionModel = new SessionModel();
 
 var url = require("url");
 
+// An object we can use for checking the state of our models and views.
+// Be sure to clean up after yourself if you use it, so there's no memory bloat!
+window._kalite_debug = {};
+
 window.onerror=function(msg){
     window.js_errors = window.js_errors || [];
     window.js_errors.push(msg);

--- a/kalite/distributed/static/js/distributed/video/views.js
+++ b/kalite/distributed/static/js/distributed/video/views.js
@@ -62,8 +62,6 @@ var VideoPlayerView = ContentBaseView.extend({
         if (player_id) {
             var video_player_options = {
                 "controls": true,
-                "width": "auto",
-                "height": "auto",
                 "playbackRates": [0.5, 1, 1.25, 1.5, 2]
             };
             if( this.data_model.get("content_urls").thumbnail ) {

--- a/kalite/distributed/static/js/distributed/video/views.js
+++ b/kalite/distributed/static/js/distributed/video/views.js
@@ -2,6 +2,7 @@ var _ = require("underscore");
 var BaseView = require("base/baseview");
 var Handlebars = require("base/handlebars");
 var _V_ = require("video.js");
+global.videojs = _V_;
 require("../../../css/distributed/video-js-override.less");
 
 var ContentBaseView = require("content/baseview");
@@ -47,6 +48,8 @@ var VideoPlayerView = ContentBaseView.extend({
             that.initialize_player(width, height);
 
         });
+
+        window._kalite_debug.video_player_initialized = true;
     },
 
     initialize_player: function(width, height) {
@@ -96,7 +99,7 @@ var VideoPlayerView = ContentBaseView.extend({
         var width = container_width;
         var height = container_height;
 
-        var ratio = this.data_model.get("width") / this.data_model.get("height");
+        var ratio = this.data_model.get("width") / (this.data_model.get("height") || 1);
 
         if (container_ratio > ratio) {
             width = container_height * ratio;

--- a/kalite/distributed/static/js/distributed/video/views.js
+++ b/kalite/distributed/static/js/distributed/video/views.js
@@ -62,7 +62,10 @@ var VideoPlayerView = ContentBaseView.extend({
         if (player_id) {
             var video_player_options = {
                 "controls": true,
-                "playbackRates": [0.5, 1, 1.25, 1.5, 2]
+                "playbackRates": [0.5, 1, 1.25, 1.5, 2],
+                "html5": {
+                    nativeTextTracks: false
+                }
             };
             if( this.data_model.get("content_urls").thumbnail ) {
                 video_player_options['poster'] = this.data_model.get("content_urls").thumbnail;

--- a/kalite/testing/base_environment.py
+++ b/kalite/testing/base_environment.py
@@ -289,7 +289,7 @@ def _make_video(context):
 
 
 def _teardown_video(context):
-    context.video.delete_instance()
+    delete_instances([context.video.id])
     try:
         os.remove(context._subtitle_file_path)
     except WindowsError as e:

--- a/kalite/testing/base_environment.py
+++ b/kalite/testing/base_environment.py
@@ -3,6 +3,7 @@ environment.py defines setup and teardown behaviors for behave tests.
 The behavior in this file is appropriate for integration tests, and
 could be used to bootstrap other integration tests in our project.
 """
+import json
 import os
 import tempfile
 import shutil
@@ -19,9 +20,11 @@ from django.db import connections
 from django.db.transaction import TransactionManagementError
 from peewee import Using
 
+from kalite.i18n.base import get_srt_path, get_srt_url
 from kalite.testing.base import KALiteTestCase
 from kalite.testing.behave_helpers import login_as_admin, login_as_coach, logout, login_as_learner
-from kalite.topic_tools.content_models import Item, set_database, annotate_content_models
+from kalite.topic_tools.content_models import Item, set_database, annotate_content_models, create, get, \
+    delete_instances
 
 from securesync.models import Zone, Device, DeviceZone
 
@@ -77,6 +80,7 @@ def setup_content_paths(context, db):
             slug="unavail",
             path=context.unavailable_content_path
         )
+
 
 @set_database
 def teardown_content_paths(context, db):
@@ -154,6 +158,9 @@ def setup_local_browser(context):
 def before_scenario(context, scenario):
     database_setup(context)
 
+    if "uses_video_with_subtitles" in context.tags:
+        _make_video(context)
+
     if "registered_device" in context.tags:
         do_fake_registration()
 
@@ -183,6 +190,9 @@ def before_scenario(context, scenario):
 
 
 def after_scenario(context, scenario):
+    if "uses_video_with_subtitles" in context.tags:
+        _teardown_video(context)
+
     if context.logged_in:
         logout(context)
 
@@ -245,3 +255,45 @@ def do_fake_registration():
     device = Device.get_own_device()
     device_zone = DeviceZone(device=device, zone=zone)
     device_zone.save()
+
+
+def _make_video(context):
+    root = get({"parent": None})
+    lang_code = "en"
+    youtube_id = "my_cool_id"
+    item_dict = {
+        "title": "Subtitled Video",
+        "description": "A video with subtitles",
+        "available": True,
+        "kind": "Video",
+        "id": "video_with_subtitles",
+        "slug": "video_with_subtitles",
+        "path": "khan/video_with_subtitles",
+        "extra_fields": {
+            "subtitle_urls": [{"url": get_srt_url(youtube_id=youtube_id, code=lang_code),
+                               "code": lang_code,
+                               "name": "English"}],
+            "content_urls": {"stream": "/foo", "stream_type": "video/mp4"},
+        },
+        "parent": root,
+    }
+    # `create` will quietly do nothing if the item already exists. Possible from pathological test runs.
+    # So delete any identical Items first.
+    delete_instances(ids=[item_dict["id"]])
+    context.video = create(item_dict)
+
+    subtitle_path = get_srt_path(lang_code=lang_code, youtube_id=youtube_id)
+    with open(subtitle_path, "w") as f:
+        f.write("foo")
+    context._subtitle_file_path = subtitle_path
+
+
+def _teardown_video(context):
+    context.video.delete_instance()
+    try:
+        os.remove(context._subtitle_file_path)
+    except WindowsError as e:
+        print("Couldn't remove temporary subtitle file {}. Exception:\n\t{}".format(
+            context._subtitle_file_path,
+            str(e))
+        )

--- a/kalite/topic_tools/annotate.py
+++ b/kalite/topic_tools/annotate.py
@@ -91,13 +91,6 @@ def update_content_availability(content_list, language="en", channel="khan"):
                         "stream_type": "{kind}/{format}".format(kind=content.get("kind").lower(), format=format),
                         "thumbnail": thumbnail,
                     }
-            elif django_settings.BACKUP_VIDEO_SOURCE:
-                update["available"] = True
-                update["content_urls"] = {
-                    "stream": django_settings.BACKUP_VIDEO_SOURCE.format(youtube_id=dubbed_id, video_format=format),
-                    "stream_type": "{kind}/{format}".format(kind=content.get("kind").lower(), format=format),
-                    "thumbnail": django_settings.BACKUP_VIDEO_SOURCE.format(youtube_id=dubbed_id, video_format="png"),
-                }
 
             if update.get("available"):
                 # Don't bother doing this work if the video is not available at all

--- a/kalite/topic_tools/annotate.py
+++ b/kalite/topic_tools/annotate.py
@@ -1,16 +1,12 @@
 import os
-import json
 
 from django.conf import settings as django_settings
-logging = django_settings.LOG
 
 from kalite.i18n.base import get_srt_path, get_language_name
-
-from . import settings
-from .base import database_exists
-
 from kalite.updates.videos import get_local_video_size
-from kalite.contentload import settings as contentload_settings
+
+
+logging = django_settings.LOG
 
 
 def is_content_on_disk(content_id, format="mp4", content_path=None):
@@ -74,7 +70,7 @@ def update_content_availability(content_list, language="en", channel="khan"):
             filename = file_id + "." + format
 
             # Get list of subtitle language codes currently available
-            subtitle_lang_codes = subtitle_langs.get("{id}.srt".format(id=content.get("id")), [])
+            subtitle_lang_codes = subtitle_langs.get("{id}.vtt".format(id=content.get("id")), [])
 
             if filename in contents_folder or language in subtitle_lang_codes:
                 if (filename not in contents_folder) and language in subtitle_lang_codes:
@@ -109,7 +105,7 @@ def update_content_availability(content_list, language="en", channel="khan"):
                 # Generate subtitle URLs for any subtitles that do exist for this content item
                 subtitle_urls = [{
                     "code": lc,
-                    "url": django_settings.STATIC_URL + "srt/{code}/subtitles/{id}.srt".format(code=lc, id=content.get("id")),
+                    "url": django_settings.STATIC_URL + "srt/{code}/subtitles/{id}.vtt".format(code=lc, id=content.get("id")),
                     "name": get_language_name(lc)
                     } for lc in subtitle_lang_codes]
 

--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -518,6 +518,38 @@ def create(item, **kwargs):
 
 
 @set_database
+def get(item, **kwargs):
+    """
+    Fetch a content item, automatically choosing the correct content database (because of the set_database
+    decorator).
+
+    :param item: A dictionary containing content metadata for one node. "extra_fields" should not be inflated!
+    :return: Item, or None if no such item is found
+    """
+    if item:
+        selector = None
+        for attr, value in item.iteritems():
+            if not selector:
+                selector = (getattr(Item, attr) == value)
+            else:
+                selector &= (getattr(Item, attr) == value)
+        return Item.get(selector)
+
+
+@set_database
+def delete_instances(ids, **kwargs):
+    """
+    Given a list of Item ids, deletes all instances with that id.
+
+    :param item: A list of `Item.id`s
+    :return: None
+    """
+    if ids:
+        for item in Item.select().where(Item.id.in_(ids)):
+            item.delete_instance()
+
+
+@set_database
 def get_or_create(item, **kwargs):
     """
     Wrapper around get or create that allows us to specify a database

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "through": "^2.3.8",
     "underscore": "~1.8.3",
     "url": "^0.10.3",
-    "video.js": "4.11.4",
+    "video.js": "^5.7.1",
     "watchify": "^3.3.1"
   }
 }


### PR DESCRIPTION
## Summary

Migrate to VTT subtitle format. They're included in the content packs, so we just have to serve them (and tweak a few things). Upgrade to the latest video.js as well.

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
- [x] New dependencies (if any) added to requirements file

## Reviewer guidance

Native text track support seems to be sparse or broken. Look at the commit messages for a description of the issue.

I would like guidance on writing a test for this. One thing that might not be too brittle, assuming we stick to video.js, would be to load a video page and assert that the "CC" button appears. Alternatively, we could use the video.js api to assert that the expected [textTracks](http://docs.videojs.com/docs/api/player.html#MethodstextTracks) are present.

Both would involve installing a content pack on the test server and downloading at least one video. Thoughts on this approach?

## Issues addressed

Fixes #4166.

## Screenshots

Check out the snazzy new interface.

![image](https://cloud.githubusercontent.com/assets/8888020/13447725/91d24cd8-dfd2-11e5-8861-e010dc74818f.png)