### PR TITLE
0.16b1

### DIFF
--- a/kalite/updates/static/js/updates/bundle_modules/update_videos.js
+++ b/kalite/updates/static/js/updates/bundle_modules/update_videos.js
@@ -415,10 +415,12 @@ function getSelectedStartedMetadata(data_type) {
 }
 
 function setNodeClass(node, className) {
-    if (node.extraClasses != className) {
-        node.extraClasses = className;
-        if (node.parent !== null) {
-            updateNodeClass(node.parent);
+    if (node !== null) {
+        if (node.extraClasses != className) {
+            node.extraClasses = className;
+            if (node.parent !== null) {
+                updateNodeClass(node.parent);
+            }
         }
     }
 }

--- a/kalite/version.py
+++ b/kalite/version.py
@@ -7,7 +7,7 @@ from kalite.shared.utils import open_json_or_yml
 # Must also be of the form N.N.N for internal use, where N is a non-negative integer
 MAJOR_VERSION = "0"
 MINOR_VERSION = "16"
-PATCH_VERSION = "0"
+PATCH_VERSION = "b1"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
 


### PR DESCRIPTION
**WARNING!** Merging this, merges and closes all PRs contained in this PR, and they may have a separate review process and amendments following. So don't merge this PR!! :)

Takes over  0.16a4 #4915

New release, manually brewing the distributions:

 * [ ] [ka-lite on pypi](https://pypi.python.org/pypi/ka-lite)
 * [ ] [ka-lite-static on pypi](https://pypi.python.org/pypi/ka-lite-static)
 * [ ] [ka-lite on Launchpad PPA](https://launchpad.net/~learningequality/+archive/ubuntu/ka-lite)
 * [ ] OSX installer
 * [ ] Windows installer

## Known issues

 * [x] Raspberry Pi still can only download 1 video at a time #4892
 * [x] Content packs are to be updated, videos show up twice on Video download page
 * [x] After you create the first admin user account, you need to reload the page before clicking Login #4896
 * [x] Video download counts reported misleading #4929 
 * [ ] [See remaining issue list for Milestone](https://github.com/learningequality/ka-lite/issues?q=is%3Aopen+is%3Aissue+milestone%3A0.16.0)

## Included PRs

 * #4942

## Installer links

  * [Debian/Ubuntu]() TODO
  * [Windows]() TODO
  * [Mac]() TODO
