### PR TITLE
use twine for PyPi uploads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,10 +99,10 @@ assets:
 	cp kalite/database/data.sqlite kalite/database/templates/
 	bin/kalite manage retrievecontentpack download en --minimal --foreground --template
 
-release: clean clean-dev-db docs assets man
-	python setup.py sdist --formats=$(format) upload --sign
-	python setup.py sdist --formats=$(format) upload --sign --static
+release: dist man
 	ls -l dist
+	echo "uploading above to PyPi, using twine"
+	twine upload -s dist/*
 
 dist: clean clean-dev-db docs assets
 	python setup.py sdist --formats=$(format)


### PR DESCRIPTION
## Summary

Cleans up the `release` command and uses twine instead of `setup.py upload` because the latter is considered unsafe.

It's already tested because the 0.16b1 was released with it...