### PR TITLE
Attempts to ensure against inappropriately flagging topics as complete.

### DIFF
--- a/kalite/updates/static/js/updates/bundle_modules/update_videos.js
+++ b/kalite/updates/static/js/updates/bundle_modules/update_videos.js
@@ -125,7 +125,7 @@ $(function() {
         },
         postProcess: function(event, data) {
             data.response = _.map(data.response, function(node) {
-                if (node.files_complete === 0) {
+                if (node.files_complete === 0 || node.files_complete === null || typeof node.files_complete === "undefined") {
                     node["extraClasses"] = "unstarted";
                 } else if (node.files_complete < node.total_files) {
                     node["extraClasses"] = "partial";


### PR DESCRIPTION
## Summary

Speculative attempt to prevent uncompleted topics from being shown as complete.

## Reviewer guidance

Stronger checking on files_complete attribute.

## Issues addressed

Tries to fix #4959

