### PR TITLE
Escapes %s to stop sprintf throwing an error.

### DIFF
--- a/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
+++ b/kalite/coachreports/static/js/coachreports/student_progress/hbtemplates/playlist-progress-container.handlebars
@@ -24,13 +24,13 @@
                     {{/unless}}
                 {{/if}}
                 {{#if vid_pct_complete}}
-                  <div class="progress-bar progress-bar-success" title={{_ "% Completed" }} style="width: {{vid_pct_complete}}%">
+                  <div class="progress-bar progress-bar-success" title={{_ "%% Completed" }} style="width: {{vid_pct_complete}}%">
                         <span class="sr-only">{{_ "Of those you have completed " }}</span>
                         <span>{{vid_pct_complete}}%</span>
                     </div>
                 {{/if}}
                 {{#if vid_pct_started}}
-                  <div class="progress-bar inprogress" title={{_ "% In-Progress"}} style="width: {{vid_pct_started}}%">
+                  <div class="progress-bar inprogress" title={{_ "%% In-Progress"}} style="width: {{vid_pct_started}}%">
                     {{#ifcond vid_pct_started "<" 100}}
                         <span class="sr-only">{{_ "You are still working on " }}</span>
                         <span>{{vid_pct_started}}%</span>


### PR DESCRIPTION
## Summary

Some text that contained % symbols did not use %% to escape them. This made sprintf get mad.

## Issues addressed

Fixes #4951
