### PR TITLE
Update points if there is server-client discrepancy

### DIFF
--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -677,10 +677,22 @@ var ExerciseWrapperBaseView = BaseView.extend({
     },
 
     update_total_points: function(data) {
-        // update the top-right point display, now that we've saved the points successfully
-        if (this.log_model.has("points")) {
-            window.statusModel.update_total_points(this.log_model.get("points") - this.status_points);
-            this.status_points = this.log_model.get("points");
+        /*
+            Update the top-right point display, now that we've saved the points successfully.
+            However, we should *only* update the points display if it's actually changed.
+
+            This is called in case there is a discrepancy between the points reported by the server and the points
+            known to the client.
+
+            :param data: Is in fact a log_model instance, since this is a callback to the
+              built-in "sync" event. It should be the *same* object as this.log_model.
+         */
+        if (data.has("points")) {
+            if(data.changed.points) {
+                var points_diff = data.get("points") - this.points_before_sync;
+                window.statusModel.update_total_points(points_diff);
+            }
+            this.points_before_sync = data.get("points");
         }
     },
 
@@ -773,7 +785,7 @@ var ExercisePracticeView = ExerciseWrapperBaseView.extend({
 
         // store the number of points that are currently in the ExerciseLog, so we can calculate the difference
         // once it changes, for updating the "total points" in the nav bar display
-        this.status_points = this.log_model.get("points");
+        this.points_before_sync = this.log_model.get("points");
 
 
         if ( !window.statusModel.get("is_django_user") ) {


### PR DESCRIPTION
## Summary

Fixes error in points display. For exercise log sync events, only update the points display if there is a discrepancy between the points reported by the server and the points known to the client.

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)

Here's my really good reason. Testing this using selenium would take the following steps:

1. Create new student account and set the points to some appropriate initial value.
2. Navigate to an exercise.
3. Interact with the exercise to gain points.
4. Make assertion about observed points in user menu.

This is challenging because we don't provide a testing api for interacting with content nor a reliable way to determine the "state" of the page in order to avoid race conditions (e.g. polling the `#points` element too soon or not waiting long enough after a page is loaded). I also wrote a [similar test that was removed](https://github.com/learningequality/ka-lite/commit/bc13993fa319eec9084773f71cc81413e8c2a3d7#diff-5460c9ea5f5d69ca7164a26b56b092a9L407). I think I can write a better, less error-prone test now in about a day. I'm on the fence as to whether that's a good use of time right now. Dear reviewer, what do you think?

## Issues addressed

Fixes #4643
