### PR TITLE
Languagepack progress bar fix

### DIFF
--- a/kalite/updates/static/css/updates/update_languages.css
+++ b/kalite/updates/static/css/updates/update_languages.css
@@ -47,7 +47,7 @@
     font-weight: bold;
 }
 
-#languagepackdownload-progressbar {
+#retrievecontentpack-progressbar {
     margin-top: 25px;
     margin-bottom: 25px;
 }

--- a/kalite/updates/static/js/updates/bundle_modules/update_languages.js
+++ b/kalite/updates/static/js/updates/bundle_modules/update_languages.js
@@ -229,13 +229,13 @@ function start_languagepack_download(lang_code) {
     messages.clear_messages();  // get rid of any lingering messages before starting download
     $("#get-language-button").prop("disabled", true);
     downloading = true;
-    // tell server to start languagepackdownload job
+    // tell server to start retrievecontentpack job
     api.doRequest(
         Urls.start_languagepack_download(),
         { lang: lang_code }
     ).success(function(progress, status, req) {
         base.updatesStart(
-            "languagepackdownload",
+            "retrievecontentpack",
             2000, // 2 seconds
             languagepack_callbacks
         );
@@ -307,7 +307,7 @@ function update_server_status() {
         // We assume the distributed server is offline; if it's online, then we enable buttons that only work with internet.
         // Best to assume offline, as online check returns much faster than offline check.
         if(server_is_online){
-            base.updatesStart("languagepackdownload", 1000, languagepack_callbacks);
+            base.updatesStart("retrievecontentpack", 1000, languagepack_callbacks);
         } else {
             messages.clear_messages();
             messages.show_message("error", gettext("Could not connect to the central server; language packs cannot be downloaded at this time."));

--- a/kalite/updates/static/js/updates/bundle_modules/update_languages.js
+++ b/kalite/updates/static/js/updates/bundle_modules/update_languages.js
@@ -288,8 +288,7 @@ function languagepack_reset_callback(progress, resp) {
 }
 
 function languagepack_complete_callback(progress_log) {
-    // Trigger a reminder to restart server when a language pack is installed.
-    messages.show_message("warning", sprintf(gettext("Server must be restarted to activate language pack %(lang)s."), {lang: progress_log.process_name}));
+    // This is a no-op for now. Used to remind the user to restart the server, but that's not necessary anymore.
 }
 
 function set_server_language(lang) {

--- a/kalite/updates/templates/updates/update_languages.html
+++ b/kalite/updates/templates/updates/update_languages.html
@@ -69,7 +69,7 @@
             </div>
         </div>
 
-        <div id="languagepackdownload-progressbar">
+        <div id="retrievecontentpack-progressbar">
             {% include "updates/progress-bar.html" %}
         </div>
         <div class="clear"></div>


### PR DESCRIPTION
## Summary

Fixes #4955. But while looking in to this I went down a dead end with the updates management command base classes: https://github.com/learningequality/ka-lite/blob/0.16.x/kalite/updates/management/commands/classes.py#L41

As far as I can tell, it's not possible to pass kwargs to a command's constructor using the `call_command` function (or possibly at all). For instance, it doesn't seem possible to set the `process_name`, which was the first thing I attempted. Instead changes to the back-end (like in this case changing the management command that's being called) require changes to the front-end. Is this worth a refactor?

## TODO

Test incoming.

- [ ] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)

## Issues addressed

Fixes #4955.