### PR TITLE
Inline help fixes

### DIFF
--- a/data/narratives.yml
+++ b/data/narratives.yml
@@ -38,7 +38,7 @@ update/languages:
   - '#language-packs-selection':
     - step: 2
     - text: Click on this drop down menu to view the available language packs...
-  - '#option-bg':
+  - '#language-packs-ul li':
     - step: 3
     - text: ...select the language of your choice...
     - before-showing:
@@ -47,7 +47,7 @@ update/languages:
     - step: 4
     - text: ...and details such as the number of subtitles, translation completion, and total download size will be displayed for the chosen language pack!
     - before-showing:
-      - click: '#option-bg'
+      - click: '#language-packs-ul li'
   - '#get-language-button':
     - step: 5
     - text: Just click this button to start your download!

--- a/data/narratives.yml
+++ b/data/narratives.yml
@@ -1,4 +1,4 @@
-management/zone/.*:
+management/zone/[^/]*/$:
   - li.manage-tab.active:
     - step: 1
     - text: Welcome! This is the landing page for admins. If at any point you would like to navigate back to this page, click on this tab!

--- a/data/narratives.yml
+++ b/data/narratives.yml
@@ -28,9 +28,9 @@ update/videos:
   - '#content_tree':
     - step: 2
     - text: Downloadable content will be organized in this topic tree.
-  - span.dynatree-node.dynatree-folder.dynatree-has-children.unstarted.dynatree-exp-c.dynatree-ico-cf:
+  - .fancytree-node:
     - step: 3
-    - text: Simply toggle the "+" button to view see more subtopics under a topic....
+    - text: Simply toggle topic button to view see more subtopics.
 update/languages:
   - li.languages.active:
     - step: 1

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -78,6 +78,10 @@
         {% block headjs %}{% endblock headjs %}
         {% block analytics %}{% endblock analytics %}
 
+        <script>
+            // Inline help module may need to reload bootstrap src, so keep a reference to it.
+            window.bootstrap_src="{% static 'js/inline/bundles/bundle_bootstrap.js' %}";
+        </script>
         <script type="text/javascript" src="{% static 'js/inline/bundles/bundle_inline_help.js' %}"></script>
     </head>
 

--- a/kalite/inline/api_views.py
+++ b/kalite/inline/api_views.py
@@ -4,10 +4,12 @@ Views accessible as an API endpoint for inline.  All should return JsonResponses
 import os
 import re
 
+from django.utils.translation import ugettext as _
+
 from kalite.shared.utils import open_json_or_yml
 from kalite import settings
 
-from fle_utils.internet.classes import JsonResponse
+from fle_utils.internet.classes import JsonResponse, JsonResponseMessageWarning
 
 
 def narrative_view(request, narrative_id):
@@ -24,5 +26,8 @@ def narrative_view(request, narrative_id):
         if exp.search(narrative_id):
             the_narrative[key] = narr
             break
+
+    if not the_narrative:
+        return JsonResponseMessageWarning(_("No inline help is available for this page."), status=404)
 
     return JsonResponse(the_narrative)

--- a/kalite/inline/static/js/inline/bundle_modules/bootstrap.js
+++ b/kalite/inline/static/js/inline/bundle_modules/bootstrap.js
@@ -1,0 +1,4 @@
+// This file exists so that inline help can reload the bootstrap src, if it needs to.
+// Sometimes bootstrap events might be disabled, such as when demonstrating an interactive menu, and then need to be
+// re-enabled.
+require("bootstrap/dist/js/bootstrap.min.js");

--- a/kalite/inline/static/js/inline/views.js
+++ b/kalite/inline/static/js/inline/views.js
@@ -79,6 +79,7 @@ var ButtonView = BaseView.extend({
 
             error: function(model, response, options) {
                 console.log("Unable to load inline tutorial narrative!");
+                self.$("#inline-btn").prop("disabled", true);
             }
         });
     },


### PR DESCRIPTION
## Summary

Fixes #4986. Clicking on the inline help on that page now disables the button and creates a warning bubble. See screenshots.

Also fixes up the existing inline help which was broken due to UI changes.

## TODO

Not clear how to test this... Maybe in the future, when the UI changes the changer must be responsible for double checking the inline help feature on that page?

- [ ] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)

## Issues addressed

Fixes #4986.

## Screenshots (if appropriate)

![ss2](https://cloud.githubusercontent.com/assets/8888020/13829564/e269832e-eb84-11e5-96ff-f258d3998fd2.png)