### PR TITLE
Open docs link in a separate window (accessible)

### DIFF
--- a/kalite/distributed/static/js/distributed/user/hbtemplates/navigation.handlebars
+++ b/kalite/distributed/static/js/distributed/user/hbtemplates/navigation.handlebars
@@ -13,9 +13,11 @@
 {{#if docs_exist}}
   {{#if is_admin}}
     <li role="menuitem" id="nav_documentation">
-      <a role="menuitem" tabindex="-1" id="documentation_a" href="/static/html/usermanual/userman_main.html">
-        {{_ "User Manual" }}
-       </a>
+      <a role="menuitem" tabindex="-1" id="documentation_a" href="/static/html/usermanual/userman_main.html" title="{{_ "Open user manual in new window" }}" target="_blank" >
+        {{_ "Docs" }}
+        <span class="sr-only">{{_ "Open user manual in new window" }}</span>
+        <i aria-hidden="true" class="glyphicon glyphicon-new-window"></i>
+      </a>
     </li>
   {{/if}}
 {{/if}}


### PR DESCRIPTION
## Summary

Fixes #4977. 

Tab link now has both a title & target attribute with the appropriate icon and accessible info for the screenreader users. I renamed it to `DOCS` since `USER MANUAL` seemed too big for me visually, although I have considered `HELP`too...

@MCGallaspy 

## Screenshots

![docs-new-window](https://cloud.githubusercontent.com/assets/1457929/13857418/21120812-ec7a-11e5-83cd-b5fe2ffa7df0.png)