### PR TITLE
Only download videos not already downloaded

### DIFF
--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -128,7 +128,7 @@ def start_video_download(request):
 
     lang = json.loads(request.body or "{}").get("lang", "en")
 
-    youtube_ids = get_download_youtube_ids(paths, language=lang)
+    youtube_ids = get_download_youtube_ids(paths, language=lang, downloaded=False)
 
     queue = VideoQueue()
 
@@ -150,7 +150,7 @@ def delete_videos(request):
 
     lang = json.loads(request.body or "{}").get("lang", "en")
 
-    youtube_ids = get_download_youtube_ids(paths, language=lang)
+    youtube_ids = get_download_youtube_ids(paths, language=lang, downloaded=True)
 
     num_deleted = 0
 


### PR DESCRIPTION
## Summary

Filters the requested ids to download. I think this could potentially increase the runtime of this endpoint significantly, since each youtube_id hits the database -- but maybe it could be improved by a big constant factor if all the content items are fetched at once? Alternatively, if the requests are batched on the front-end. Thoughts?

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [ ] ~~Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)~~

## Issues addressed

Fixes #4990.