### PR TITLE
Fixes #4974: Remove broken assessment DB display from diagnose command.

### DIFF
--- a/kalitectl.py
+++ b/kalitectl.py
@@ -770,7 +770,6 @@ def diagnose():
         diag("content root", settings.CONTENT_ROOT)
         diag("content size", filesizeformat(get_size(settings.CONTENT_ROOT)))
         diag("user database", settings.DATABASES['default']['NAME'])
-        diag("assessment database", settings.DATABASES['assessment_items']['NAME'])
         try:
             from securesync.models import Device
             device = Device.get_own_device()


### PR DESCRIPTION
## Summary

Quick fix to get the `kalite diagnose` command working again. This command is useful for getting more details in bug reports from users.

## Issues addressed

#4974