### PR TITLE
Revert "Do one-pass finds in Makefile"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,14 @@ clean-build:
 	rm -fr dist-packages/
 	rm -fr dist-packages-temp/
 	rm -fr kalite/database/templates
-	find . -regextype posix-extended -regex '.*\.(egg-info|egg)' -exec rm -fr {} +
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
 
 clean-pyc:
-	find . -regextype posix-extended -regex '.*\.(pyc|pyo|~|__pycache__)' -exec rm -fr {} +
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
 
 clean-test:
 	rm -fr .tox/


### PR DESCRIPTION
Reverts learningequality/ka-lite#4978

Seems to have been the cause of some error: https://github.com/learningequality/ka-lite/commit/f4ac347a001f4d2f275e564fe80f627e5ce74287#commitcomment-16816534

Goodbye concise `find`s...