### PR TITLE
Ensure attempt logs are given exercise_id, and inserted in right order.

### DIFF
--- a/kalite/distributed/static/js/distributed/exercises/views.js
+++ b/kalite/distributed/static/js/distributed/exercises/views.js
@@ -550,10 +550,10 @@ var ExerciseWrapperBaseView = BaseView.extend({
         }
 
         var defaults = {
-            exercise_id: this.options.exercise_id,
+            exercise_id: this.log_model.get("exercise_id"),
             user: window.statusModel.get("user_uri"),
-            context_type: this.options.context_type || "",
-            context_id: this.options.context_id || "",
+            context_type: "exercise",
+            context_id: "",
             language: "", // TODO(jamalex): get the current exercise language
             version: window.statusModel.get("version"),
             seed: seed,
@@ -564,7 +564,7 @@ var ExerciseWrapperBaseView = BaseView.extend({
 
         this.current_attempt_log = new Models.AttemptLogModel(data);
 
-        this.attempt_collection.add(this.current_attempt_log);
+        this.attempt_collection.unshift(this.current_attempt_log);
 
         return this.current_attempt_log;
 


### PR DESCRIPTION
## Summary

Due to some refactoring, we were no longer setting `exercise_id` when saving an `AttemptLog`. This means there was no way of know what exercise it was for, which was messing up coach reports, syncing (it was a required field, and hence caused failed validation), and exercises (refreshing the page would make attempts disappear).

Minimal changes here, but they fix all of these issues.

## Issues addressed

Fixes #5017 and #4989.