### PR TITLE
Languagepack upgrade alert

### DIFF
--- a/kalite/distributed/views.py
+++ b/kalite/distributed/views.py
@@ -24,6 +24,7 @@ from django.utils.translation import ugettext as _
 
 from fle_utils.internet.classes import JsonResponseMessageError
 from fle_utils.internet.functions import get_ip_addresses, set_query_params
+from kalite.i18n.base import outdated_langpacks
 from kalite.shared.decorators.auth import require_admin
 from kalite.topic_tools.content_models import search_topic_nodes
 from securesync.api_client import BaseClient
@@ -88,6 +89,13 @@ def homepage(request):
     """
     Homepage.
     """
+    def _alert_outdated_languages(langpacks):
+        pretty_lang_names = " --- ".join(lang.get("name", "") for lang in langpacks)
+        messages.warning(request, _("Dear Admin, please log in and upgrade the following languages as soon as possible: {}").format(pretty_lang_names))
+
+    outdated_langpack_list = list(outdated_langpacks())
+    if outdated_langpack_list:
+        _alert_outdated_languages(outdated_langpack_list)
     return {}
 
 

--- a/kalite/i18n/base.py
+++ b/kalite/i18n/base.py
@@ -5,6 +5,7 @@ import shutil
 import urllib
 import zipfile
 from collections_local_copy import OrderedDict
+from distutils.version import LooseVersion
 from fle_utils.internet.webcache import invalidate_web_cache
 
 from django.http import HttpRequest
@@ -164,6 +165,23 @@ def convert_language_code_format(lang_code, for_django=True):
             lang_code = "-".join(code_parts)
 
     return lang_code
+
+
+def outdated_langpacks():
+    """
+    Function that returns a list of languages (full metadata) that needs to be
+    upgraded to the latest version. Returns an empty list if all languages are
+    upgraded to this release's version.
+    """
+
+    langpacks = get_installed_language_packs(force=True)
+
+    for langpack in langpacks.itervalues():
+        langpackversion = LooseVersion(langpack.get("software_version") or SHORTVERSION)
+        current_software_version = LooseVersion(SHORTVERSION)
+
+        if current_software_version > langpackversion:
+            yield langpack
 
 
 INSTALLED_LANGUAGES_CACHE = None

--- a/kalite/i18n/base.py
+++ b/kalite/i18n/base.py
@@ -200,7 +200,7 @@ def _get_installed_language_packs():
     # There's always English...
     installed_language_packs = [{
         'code': 'en',
-        'software_version': VERSION,
+        'software_version': SHORTVERSION,
         'language_pack_version': 0,
         'percent_translated': 100,
         'subtitle_count': 0,

--- a/kalite/testing/mixins/browser_mixins.py
+++ b/kalite/testing/mixins/browser_mixins.py
@@ -114,6 +114,9 @@ class BrowserActionMixins(object):
         else:
             messages = []
 
+        if isinstance(contains, str):  # make sure we only look at messages we're looking for.
+            messages = [message for message in messages if contains in message.text]
+
         # Check that we got as many as expected
         if num_messages is not None:
             msg = "Make sure there are %d message(s), type='%s'." % \


### PR DESCRIPTION
## Summary

Fixes #5005. We now show this alert on the homepage if there are language packs that need to be upgraded:

![screen shot 2016-03-24 at 14 55 59](https://cloud.githubusercontent.com/assets/191955/14032510/997900fc-f1d0-11e5-81f6-013436d67aad.png)

Note: is shown for everyone, even if you're not logged in. Since this can potentially prevent the said languages from functioning properly, having everyone see it will hopefully convince the admin to upgrade sooner than later.
