### PR TITLE
Force clear out collectstatic on setup

### DIFF
--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -477,7 +477,8 @@ class Command(BaseCommand):
 
         # Now deploy the static files
         logging.info("Copying static media...")
-        call_command("collectstatic", interactive=False, verbosity=0)
+        call_command("collectstatic", interactive=False, verbosity=0, ignore_patterns=['vtt', 'html', 'srt'],
+                     clear=True)
         call_command("collectstatic_js_reverse", interactive=False)
 
         # This is not possible in a distributed env


### PR DESCRIPTION
## Summary

In some upgrade scenarios (like on the RPi) the system's
built js files might have a timestamp *earlier* than the
static files appearing in the user's static files location.
The effect is that `collectstatic` called during an upgrade
will not replace the old static files with the new ones, since
the timestamp is reverse.

So force them to be cleared. But preserve the "extra" files we
add in, e.g. for subtitles (vtt, srt) and exercise templates (html).
Those must not be removed, since they're downloadable content!