### PR TITLE
Fixes #5030: Disable logging on Windows, to avoid errors.

### DIFF
--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -109,6 +109,12 @@ LOGGING = {
     }
 }
 
+# Disable the logging output on Windows, as it's broken, and was causing problems.
+# See: https://github.com/learningequality/ka-lite/issues/5030
+# TODO(jamalex): if we can get logging working properly on Windows, this can be removed
+if os.name == "nt":
+    LOGGING["handlers"]["console"]["class"] = "django.utils.log.NullHandler"
+
 
 ###################################################
 # RUNNING FROM STATIC SOURCE DIR?


### PR DESCRIPTION
## Summary

As seen in #5030, `logging.StreamHandler` is causing problems on Windows, and isn't logging correctly. As this causes problems for other parts of the application, this PR disables the logging output, specifically on Windows.

## Issues addressed

Fixes #5030.