### PR TITLE
Increase wait time in content-rating behave tests, to avoid errors.

### DIFF
--- a/kalite/distributed/features/steps/content_rating.py
+++ b/kalite/distributed/features/steps/content_rating.py
@@ -182,7 +182,7 @@ def rate_id(context, id_, val=3):
 
     def rate_element(driver):
         try:
-            inner_wrapper = find_id_with_wait(context, id_, wait_time=2)
+            inner_wrapper = find_id_with_wait(context, id_, wait_time=5)
             els = inner_wrapper.find_elements_by_class_name(STAR_RATING_OPTION_CLASS)
             rating_el = [el for el in filter(lambda x: int(x.get_attribute("data-val")) == val, els)][0]
             rating_el.click()


### PR DESCRIPTION
## Summary

Hopefully fixes a content-rating test that's failing in CircleCI but passing locally, likely to do a timeout not being long enough.

```
    Given I have filled out a feedback form # kalite/distributed/features/steps/content_rating.py:121 34.200s
      Assertion Failed: FAILED SUB-STEP: When I fill out the form
      Substep info: Traceback (most recent call last):
        File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/behave/model.py", line 1173, in run
          match.run(runner.context)
        File "/home/ubuntu/virtualenvs/venv-2.7.9/lib/python2.7/site-packages/behave/model.py", line 1589, in run
          self.func(context, *args, **kwargs)
        File "/home/ubuntu/ka-lite/kalite/distributed/features/steps/content_rating.py", line 116, in impl
          enter_star_ratings(context)
        File "/home/ubuntu/ka-lite/kalite/distributed/features/steps/content_rating.py", line 173, in enter_star_ratings
          rate_id(context, id_, val=val)
        File "/home/ubuntu/ka-lite/kalite/distributed/features/steps/content_rating.py", line 196, in rate_id
          raise Exception("Unable to enter rating for container with id '{id:s}'".format(id=id_))
      Exception: Unable to enter rating for container with id 'star-container-difficulty'
```