### PR TITLE
Preserve content pack assets from collectstatic(clear=True).

### DIFF
--- a/data/version.yml
+++ b/data/version.yml
@@ -6,6 +6,7 @@
     all:
       - Tweaks to our documentation (#5067)
       - Refactor assessment item asking logic in the setup command (#5065)
+      - Properly copy over docs pages while preserving content pack assets (#5074)
     students: []
     coaches: []
     admins: []

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -482,7 +482,15 @@ class Command(BaseCommand):
         # Now deploy the static files
         logging.info("Copying static media...")
         ensure_dir(settings.STATIC_ROOT)
-        call_command("collectstatic", interactive=False, verbosity=0, ignore_patterns=['vtt', 'html', 'srt'],
+
+        # The following file ignores have to be preserved from a
+        # collectstatic(clear=True), due to being bundled with content packs,
+        # and we thus have now way of getting them back.
+        collectstatic_ignores = [
+            "*.vtt", "*.srt",              # subtitle files come with language packs -- don't delete
+            "*/perseus/ke/exercises/*", # exercises come with language packs, and we have no way to replicate
+        ]
+        call_command("collectstatic", interactive=False, verbosity=0, ignore_patterns=collectstatic_ignores,
                      clear=True)
         call_command("collectstatic_js_reverse", interactive=False)
 


### PR DESCRIPTION
## Summary

Fixes #5069. Instead of blanket preserving all HTML files, we now specifically preserve the files found under `perseus/ke/exercises`, as these are the only HTML files that can't be `collectstatic`'ed (they come from content packs).

I ran manually tested the sdist made from this branch using the following procedures on an RPi 3:

1. A fresh install
```
1. create a new virtualenv and ensure there's no .kalite dir
2. pip install ka-lite-static-0.16.1.tar.gz
3. kalite manage setup (downloading the content pack in the process)
4. load the kalite server and check for docs, and do some khan exercises
```

outcomes: docs link loads to 0.16, khan exercises load correctly.


2. An upgrade from 0.15.1 to 0.16.1
```
1. pip install ka-lite-static-0.15.1.tar.gz with a current time of 04/03/2016
2. kalite manage setup

3. revert time to 03/28/1971
4. pip install ka-lite-static-0.16.1.tar.gz
5. kalite manage setup (skipping content pack installation)
```

result: `static/js/distributed/ke/exercises` had a timestamp of 04/03, docs links loaded 0.16.

@rtibbles @indirectlylit @MCGallaspy @jamalex