### PR TITLE
Fix channel name

### DIFF
--- a/data/version.yml
+++ b/data/version.yml
@@ -1,3 +1,14 @@
+0.16.3:
+  release_date: "2016/04/25"
+  git_commit: ""
+  new_features: []
+  bugs_fixed:
+    all:
+      - Fix for 'nix based systems with unconventional kernel versioning (#5087)
+    students: []
+    coaches: []
+    admins: []
+
 0.16.2:
   release_date: "2016/04/12"
   git_commit: ""

--- a/data/version.yml
+++ b/data/version.yml
@@ -1,3 +1,15 @@
+0.16.4:
+  release_date: "2016/04/29"
+  git_commit: ""
+  new_features: []
+  bugs_fixed:
+    all:
+      - Update Perseus JS modules resulting in many broken exercises ( #5105 #5036 #5099 )
+      - Fix broken unpacking of legacy assessment items zip ( #5108 )
+    students: []
+    coaches: []
+    admins: []
+
 0.16.3:
   release_date: "2016/04/25"
   git_commit: ""

--- a/kalite/contentload/management/commands/unpack_assessment_zip.py
+++ b/kalite/contentload/management/commands/unpack_assessment_zip.py
@@ -70,7 +70,6 @@ class Command(BaseCommand):
         unpack_thread = threading.Thread(target=unpack)
         unpack_thread.daemon = True
         unpack_thread.start()
-        logging.info("Unpacking...")
         while unpack_thread.is_alive():
             time.sleep(1)
             sys.stdout.write(".")
@@ -105,6 +104,8 @@ def unpack_zipfile_to_content_folder(zf):
         # 0.16 legacy assessment zip no longer comes with a channel.name file
         folder = settings.KHAN_ASSESSMENT_ITEM_ROOT
 
+    logging.info("Unpacking to folder {}...".format(folder))
+
     ensure_dir(folder)
     zf.extractall(folder)
 
@@ -116,16 +117,17 @@ def unpack_zipfile_to_content_folder(zf):
         settings.ASSESSMENT_ITEM_ROOT,
         'assessmentitems.version'
     )
-    if os.path.isfile(version_file_copied_dest):
-        os.unlink(version_file_copied_dest)
-    # Test that file exists because there's a test that mocks unzipping and
-    # then this would fail because a file that should exist doesn't (doh)
-    if os.path.isfile(version_file):
-        # Ensure that special files are in their configured locations
-        shutil.copy(
-            version_file,
-            version_file_copied_dest
-        )
+    if version_file_copied_dest != version_file:
+        if os.path.isfile(version_file_copied_dest):
+            os.unlink(version_file_copied_dest)
+        # Test that file exists because there's a test that mocks unzipping and
+        # then this would fail because a file that should exist doesn't (doh)
+        if os.path.isfile(version_file):
+            # Ensure that special files are in their configured locations
+            shutil.copy(
+                version_file,
+                version_file_copied_dest
+            )
 
 
 def is_valid_url(url):

--- a/kalite/contentload/management/commands/unpack_assessment_zip.py
+++ b/kalite/contentload/management/commands/unpack_assessment_zip.py
@@ -107,10 +107,17 @@ def unpack_zipfile_to_content_folder(zf):
 
     ensure_dir(folder)
     zf.extractall(folder)
+    version_file = os.path.join(folder, 'assessmentitems.version')
+    version_file_copied_dest = os.path.join(
+        settings.ASSESSMENT_ITEM_ROOT,
+        'assessmentitems.version'
+    )
+    if os.path.isfile(version_file_copied_dest):
+        os.unlink(version_file_copied_dest)
     # Ensure that special files are in their configured locations
-    shutil.move(
-        os.path.join(folder, 'assessmentitems.version'),
-        settings.ASSESSMENT_ITEM_ROOT
+    shutil.copy(
+        version_file,
+        version_file_copied_dest
     )
 
 

--- a/kalite/contentload/management/commands/unpack_assessment_zip.py
+++ b/kalite/contentload/management/commands/unpack_assessment_zip.py
@@ -110,7 +110,7 @@ def unpack_zipfile_to_content_folder(zf):
     # Ensure that special files are in their configured locations
     shutil.move(
         os.path.join(folder, 'assessmentitems.version'),
-        folder
+        settings.ASSESSMENT_ITEM_ROOT
     )
 
 

--- a/kalite/contentload/management/commands/unpack_assessment_zip.py
+++ b/kalite/contentload/management/commands/unpack_assessment_zip.py
@@ -107,6 +107,10 @@ def unpack_zipfile_to_content_folder(zf):
 
     ensure_dir(folder)
     zf.extractall(folder)
+
+    # If assessmentitems.version exists, copy it to another location outside
+    # of the channel folder because for some reason a test expects it to be
+    # there.
     version_file = os.path.join(folder, 'assessmentitems.version')
     version_file_copied_dest = os.path.join(
         settings.ASSESSMENT_ITEM_ROOT,
@@ -114,11 +118,14 @@ def unpack_zipfile_to_content_folder(zf):
     )
     if os.path.isfile(version_file_copied_dest):
         os.unlink(version_file_copied_dest)
-    # Ensure that special files are in their configured locations
-    shutil.copy(
-        version_file,
-        version_file_copied_dest
-    )
+    # Test that file exists because there's a test that mocks unzipping and
+    # then this would fail because a file that should exist doesn't (doh)
+    if os.path.isfile(version_file):
+        # Ensure that special files are in their configured locations
+        shutil.copy(
+            version_file,
+            version_file_copied_dest
+        )
 
 
 def is_valid_url(url):

--- a/kalite/contentload/management/commands/unpack_assessment_zip.py
+++ b/kalite/contentload/management/commands/unpack_assessment_zip.py
@@ -100,24 +100,17 @@ def should_upgrade_assessment_items():
 def unpack_zipfile_to_content_folder(zf):
     try:
         channel = zf.read("channel.name")
-    except KeyError:
-        channel = ""
-
-    if channel:
-
         folder = os.path.join(settings.ASSESSMENT_ITEM_ROOT, channel)
-
-    else:
-        folder = settings.ASSESSMENT_ITEM_ROOT
+    except KeyError:
+        # 0.16 legacy assessment zip no longer comes with a channel.name file
+        folder = settings.KHAN_ASSESSMENT_ITEM_ROOT
 
     ensure_dir(folder)
     zf.extractall(folder)
-
-    ensure_dir(settings.KHAN_ASSESSMENT_ITEM_ROOT)
     # Ensure that special files are in their configured locations
     shutil.move(
         os.path.join(folder, 'assessmentitems.version'),
-        settings.KHAN_ASSESSMENT_ITEM_VERSION_PATH
+        folder
     )
 
 

--- a/kalite/contentload/tests/unpack_assessment_zip.py
+++ b/kalite/contentload/tests/unpack_assessment_zip.py
@@ -114,14 +114,10 @@ class UnpackAssessmentZipUtilityFunctionTests(KALiteTestCase):
     def test_unpack_zipfile_to_khan_content_extracts_to_content_dir(self):
         zipfile_instance = zipfile.ZipFile(open(self.zipfile_path, "r"), "r")
 
-        zipfile_instance.extractall = MagicMock(side_effect=zipfile_instance.extractall)
-        
         from kalite.contentload.settings import KHAN_ASSESSMENT_ITEM_ROOT
-        extract_dir = KHAN_ASSESSMENT_ITEM_ROOT
-
         mod.unpack_zipfile_to_content_folder(zipfile_instance)
 
-        zipfile_instance.extractall.assert_called_once_with(extract_dir)
+        self.assertEqual(os.listdir(KHAN_ASSESSMENT_ITEM_ROOT), ["assessmentitems.version"], "No assessment items unpacked")
 
     def test_is_valid_url_returns_false_for_invalid_urls(self):
         invalid_urls = [

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -487,8 +487,8 @@ class Command(BaseCommand):
         # collectstatic(clear=True), due to being bundled with content packs,
         # and we thus have now way of getting them back.
         collectstatic_ignores = [
-            "*.vtt", "*.srt",              # subtitle files come with language packs -- don't delete
-            "*/perseus/ke/exercises/*", # exercises come with language packs, and we have no way to replicate
+            "*.vtt", "*.srt",  # subtitle files come with language packs -- don't delete
+            "*/perseus/ke/exercises/*",  # exercises come with language packs, and we have no way to replicate
         ]
         call_command("collectstatic", interactive=False, verbosity=0, ignore_patterns=collectstatic_ignores,
                      clear=True)

--- a/kalite/topic_tools/base.py
+++ b/kalite/topic_tools/base.py
@@ -34,10 +34,6 @@ from . import settings
 CACHE_VARS = []
 
 
-if not os.path.exists(settings.CHANNEL_DATA_PATH):
-    logging.warning("Channel {channel} does not exist.".format(channel=settings.CHANNEL))
-
-
 def database_exists(channel="khan", language="en", database_path=None):
     path = database_path or settings.CONTENT_DATABASE_PATH.format(channel=channel, language=language)
 

--- a/kalite/version.py
+++ b/kalite/version.py
@@ -7,7 +7,7 @@ from kalite.shared.utils import open_json_or_yml
 # Must also be of the form N.N.N for internal use, where N is a non-negative integer
 MAJOR_VERSION = "0"
 MINOR_VERSION = "16"
-PATCH_VERSION = "2"
+PATCH_VERSION = "3"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
 

--- a/kalite/version.py
+++ b/kalite/version.py
@@ -7,7 +7,7 @@ from kalite.shared.utils import open_json_or_yml
 # Must also be of the form N.N.N for internal use, where N is a non-negative integer
 MAJOR_VERSION = "0"
 MINOR_VERSION = "16"
-PATCH_VERSION = "3"
+PATCH_VERSION = "4"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
 


### PR DESCRIPTION
## Summary

Final changes before 0.16.4

As noted in #5105 :

> Error was that the original assessment_zip used to contain a file channel.name and the legacy version doesn't. Fixing it in the codebase.