### PR TITLE
Add woff2 files to MANIFEST and sdist

### DIFF
--- a/MANIFEST.in.dist
+++ b/MANIFEST.in.dist
@@ -7,7 +7,7 @@ include README.rst
 include setup.cfg
 include requirements.txt
 
-recursive-include kalite *.html *.txt *.png *.js *.css *.gif *.less *.otf *.svg *.woff *.eot *.ttf *.zip *.json *.handlebars
+recursive-include kalite *.html *.txt *.png *.js *.css *.gif *.less *.otf *.svg *.woff *.eot *.ttf *.zip *.json *.handlebars *.woff2
 
 # Get the empty DBs -- make sure they are properly generated!
 recursive-exclude kalite/database *


### PR DESCRIPTION
## Summary

As mentioned by @rifatbd in #5099, we are missing woff2 files. They need to be in our MANIFEST in order to end up in the sdist.