### PR TITLE
Do not save unconditionally when video ends; only if learner logged in.

### DIFF
--- a/kalite/distributed/static/js/distributed/video/views.js
+++ b/kalite/distributed/static/js/distributed/video/views.js
@@ -224,8 +224,8 @@ var VideoPlayerView = ContentBaseView.extend({
         this.data_model.set({ player_state: state });
 
         if (state === VideoPlayerState.ENDED) {
-            // save the points if the video has completed
-            this.log_model.saveNow();
+            // be sure to save the progress if the video has completed
+            this.update_progress();
         }
 
     },


### PR DESCRIPTION
Addresses the error message issue in #4875.

Tested with admin and no user: now, no error message.
With logged-in learner, still saves the log at the end of the video.