### PR TITLE
Treat socket.error as if no server is running

### DIFF
--- a/kalitectl.py
+++ b/kalitectl.py
@@ -343,7 +343,7 @@ def get_pid():
     try:
         conn.request("GET", PING_URL)
         response = conn.getresponse()
-    except timeout:
+    except (timeout, socket.error):
         raise NotRunning(STATUS_NOT_RESPONDING)
     except (httplib.HTTPException, URLError):
         if os.path.isfile(STARTUP_LOCK):


### PR DESCRIPTION
## Summary

As reported by  @harishbalachandran, trying to connect to a server defined in kalite.pid may cause a socket.error

Here, we catch it and thus assume that a `socket.error` indicates a running instance that's dead somehow or another network error that we don't need to worry about.

## Issues addressed

#5132
