### PR TITLE
Make ROOT_DATA_PATH consider the KALITE_DIR environment variable

### DIFF
--- a/kalite/__init__.py
+++ b/kalite/__init__.py
@@ -7,4 +7,7 @@ from version import *
 __version__ = VERSION
 
 # ROOT_DATA_PATH is *not* where the source files live. It's a place where non-user-writable data files may be written.
-ROOT_DATA_PATH = os.path.join(sys.prefix, 'share', 'kalite')
+if 'KALITE_DIR' in os.environ:
+    ROOT_DATA_PATH = os.environ['KALITE_DIR']
+else:
+    ROOT_DATA_PATH = os.path.join(sys.prefix, 'share', 'kalite')


### PR DESCRIPTION
## Summary

Make ROOT_DATA_PATH consider the KALITE_DIR environment variable

Otherwise, kalite start will fail to find the static media files that it will try to copy on the first run, causing assets to be unresolvable when loading the web UI.

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [ ] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
  * I'm unsure how to write a test for this, but I checked it manually. Any advice?
- [X] Has documentation been written/updated?
  * Not needed: it's all about using KALITE_DIR in a missing place, which is already documented
- [X] New dependencies (if any) added to requirements file
  * Not needed

## Issues addressed

https://github.com/learningequality/ka-lite/issues/5143