### PR TITLE
Allow logins during LOCKDOWN #5117

### DIFF
--- a/kalite/distributed/middleware.py
+++ b/kalite/distributed/middleware.py
@@ -6,16 +6,21 @@ from django.core.urlresolvers import reverse
 
 
 class LockdownCheck:
+
     def process_request(self, request):
         """
         Whitelist only a few URLs, otherwise fail.
         """
-        if (settings.LOCKDOWN
-            and not request.is_logged_in
-            and request.path not in [reverse("facility_user_signup"), reverse("dynamic_js"), reverse("dynamic_css")]
-            and not request.path.startswith("/api/")
-            and not request.path.startswith(settings.CONTENT_DATA_URL)
-            and not request.path.startswith(settings.STATIC_URL)):
+        if (
+                settings.LOCKDOWN and
+                not request.is_logged_in and
+                request.path not in [reverse("facility_user_signup"), reverse("dynamic_js"), reverse("dynamic_css")] and
+                not request.path.startswith("/api/") and
+                not request.path.startswith("/securesync/api/user/status") and
+                not request.path.startswith(settings.CONTENT_DATA_URL) and
+                not request.path.startswith(settings.STATIC_URL) and
+                not request.GET.get('login', '') == 'True'
+        ):
 
             raise PermissionDenied()
 


### PR DESCRIPTION
## Summary

We hardcode-specify which pages are allowed during lockdown :/

Tested that this enables both first-run admin creation and subsequent logins, after which the user can view content etc.

This is critical to fix because reporter has said so, and I believe @Aypak :)

## Fixes

#5117