### PR TITLE
Since we're clearly not displaying an IP address for the local device..

### DIFF
--- a/kalite/control_panel/templates/control_panel/device_management.html
+++ b/kalite/control_panel/templates/control_panel/device_management.html
@@ -134,7 +134,6 @@
                     <thead>
                         <tr class="header-footer-bg">
                             <th width="250px">{% trans "Sync Date" %}</th>
-                            <th width="250px">{% trans "Device IP Address" %}</th>
                             <th width="200px">{% trans "# Models Uploaded" %}</th>
                             <th width="200px">{% trans "# Models Downloaded" %}</th>
                             <th width="200px">{% trans "# Errors" %}</th>
@@ -144,7 +143,6 @@
                     {% for sync_session in session_pages %}
                         <tr>
                             <td>{{ sync_session.timestamp }}</td>
-                            <td>{{ sync_session.ip }}</td>
                             <td>{{ sync_session.models_uploaded }}</td>
                             <td>{{ sync_session.models_downloaded }}</td>
                             <td>{{ sync_session.errors }}</td>


### PR DESCRIPTION
## Summary

Quick fix for #2003 - since we're clearly not displaying an IP address but a host name, let's write that so it isn't confused with the local device IP

We apparently have issues that can be fixed in 2 seconds :)

## Issues addressed

#2003