### PR TITLE
Summarize all exercises' individual streak progress

### DIFF
--- a/kalite/control_panel/templates/control_panel/partials/_groups_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_groups_table.html
@@ -87,8 +87,8 @@
                                     <td>{{ group.total_logins }}</td>
                                     <td>{{ group.total_hours|floatformat }} {% trans "hour(s)" %}</td>
                                     <td>{{ group.total_videos }}</td>
-                                    <td>{{ group.total_exercises }}</td>
-                                    <td>{{ group.pct_mastery|percent:1 }}</td> 
+                                    <td>{{ group.total_exercises_completed }}</td>
+                                    <td>{{ group.pct_mastery|floatformat:1 }}%</td> 
                                 </tr>
                                 {% endif %}
                             {% endfor %}

--- a/kalite/control_panel/templates/control_panel/partials/_students_table.html
+++ b/kalite/control_panel/templates/control_panel/partials/_students_table.html
@@ -97,8 +97,8 @@
                                 <td>{{ student.total_logins }}</td>
                                 <td>{{ student.total_hours|floatformat }} {% trans "hour(s)" %}</td>
                                 <td>{{ student.total_videos }}</td>
-                                <td>{{ student.total_exercises }}</td>
-                                <td>{{ student.pct_mastery|percent:1  }}</td>
+                                <td>{{ student.exercises_completed }}</td>
+                                <td>{{ student.pct_mastery|floatformat:1  }}%</td>
                             </tr>
                         {% endfor %}
                         {# 10x td for table formatting #}


### PR DESCRIPTION
## Summary

 - Fixes display error in which we multiplied 100 on a summary that was already stored as a percentage in the database.
 - Furthermore, it only counted exercises solved, which seems wrong, because in that case it would only count "100%" for each exercise that was solved, and thus an average "100%" mastery would always be displayed even though other exercises were incomplete.

## TODO

- [x] N/A: Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
- [x] N/A: Has documentation been written/updated?
- [x] N/A: New dependencies (if any) added to requirements file

## Reviewer guidance

This is a matter of something that was super-broken before and hardly explained. I won't be able to address any comments due to absence, so someone else would have to take over the PR.

## Issues addressed

#5181

## Screenshots (if appropriate)

![screenshot from 2016-06-28 22 55 29](https://cloud.githubusercontent.com/assets/374612/16432000/75f53da4-3d83-11e6-8f62-dc5a2761ef5e.png)
