### PR TITLE
Optimizations to annotate_content_models for a 10x speedup

### DIFF
--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -666,24 +666,21 @@ def annotate_content_models(channel="khan", language="en", ids=None, iterator_co
     """
 
     db = kwargs.get("db")
+
     if db:
+
         content_models = iterator_content_items(ids=ids, channel=channel, language=language)
+
         with db.atomic() as transaction:
-            def recurse_availability_up_tree(node, available):
-                if not node.parent:
-                    return
-                else:
-                    parent = node.parent
-                Parent = Item.alias()
-                children = Item.select().join(Parent, on=(Item.parent == Parent.pk)).where(Item.parent == parent.pk)
-                if not available:
-                    children_available = children.where(Item.available == True).count() > 0
-                    available = children_available
 
-                files_complete = children.aggregate(fn.SUM(Item.files_complete))
+            def update_parent_annotation(parent):
 
-                child_remote = children.where(((Item.available == False) & (Item.kind != "Topic")) | (Item.kind == "Topic")).aggregate(fn.SUM(Item.remote_size))
-                child_on_disk = children.aggregate(fn.SUM(Item.size_on_disk))
+                children = list(Item.select(Item.available, Item.files_complete, Item.remote_size, Item.size_on_disk).where(Item.parent == parent.pk))
+
+                available = any(child.available for child in children)
+                files_complete = sum(child.files_complete for child in children)
+                child_remote = sum(child.remote_size for child in children if (not child.available and child.kind != "Topic") or (child.kind == "Topic"))
+                child_on_disk = sum(child.size_on_disk for child in children)
 
                 if parent.available != available:
                     parent.available = available
@@ -697,8 +694,11 @@ def annotate_content_models(channel="khan", language="en", ids=None, iterator_co
                     parent.size_on_disk = child_on_disk
                 if parent.is_dirty():
                     parent.save()
-                    recurse_availability_up_tree(parent, available)
+                    return True  # return True to indicate we need to continue up the tree
+                else:
+                    return False  # return False to indicate we don't need to continue up the tree
 
+            parents_to_update = {}
             for path, update in content_models:
                 if update:
                     # We have duplicates in the topic tree, make sure the stamping happens to all of them.
@@ -710,7 +710,16 @@ def annotate_content_models(channel="khan", language="en", ids=None, iterator_co
                         for attr, val in item_data.iteritems():
                             setattr(item, attr, val)
                         item.save()
-                        recurse_availability_up_tree(item, update.get("available", False))
+                        # recurse_availability_up_tree(item)
+                        parents_to_update[item.parent.pk] = item.parent
+
+            while parents_to_update:
+                new_parents_to_update = {}
+                for node in parents_to_update.values():
+                    changed = update_parent_annotation(node)
+                    if changed and node.parent:
+                        new_parents_to_update[node.parent.pk] = node.parent
+                parents_to_update = new_parents_to_update
 
 
 @set_database


### PR DESCRIPTION
This is to ameliorate the slowness identified in https://github.com/learningequality/ka-lite/issues/5200. 

On my laptop, with the full set of videos:

- Old code: 1 hour 8 min
- New code: 6 mins 24 seconds

So, the speedup looks to be around 10x.

The main sources of the speedup:

- `.annotate` was super slow in peewee; now we use list comprehensions
- we recalculated shared ancestors numerous times (non-deduped recursion); now, we queue up and then recurse level-by-level, only ever updating each node at most once