### PR TITLE
Allow logins during lockdown

### DIFF
--- a/kalite/distributed/middleware.py
+++ b/kalite/distributed/middleware.py
@@ -17,6 +17,7 @@ class LockdownCheck:
                 request.path not in [reverse("facility_user_signup"), reverse("dynamic_js"), reverse("dynamic_css")] and
                 not request.path.startswith("/api/") and
                 not request.path.startswith("/securesync/api/user/status") and
+                not request.path.startswith("/securesync/api/user/login") and
                 not request.path.startswith(settings.CONTENT_DATA_URL) and
                 not request.path.startswith(settings.STATIC_URL) and
                 not request.GET.get('login', '') == 'True'


### PR DESCRIPTION
## Summary

The Lockdown feature was still not working as expected. Students were still not able to login when lockdown activated. @benjaoming made a fix that got rid of page redirect error that was previously present when lockdown was activated

## Issues addressed
#5150 

Students were not able to login when lockdown was activated because /securesync/api/user/login was not whitelisted. Tested and working after this change.