### PR TITLE
Fix Unclean shutdown in OS X installer.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ peewee==2.6.3
 python-dateutil==2.4.2
 django-dbbackup==2.3.2
 ifcfg==0.9.3
-requests==2.10.0
+requests==1.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ peewee==2.6.3
 python-dateutil==2.4.2
 django-dbbackup==2.3.2
 ifcfg==0.9.3
-requests==1.2.3
+requests==1.1.0


### PR DESCRIPTION
## Summary

Hi @aronasorman and @benjaoming .
I try to upgrade the `requests` base on the suggestion of @cpauya .
I base my upgrade to a higher version of this [requests v0.14.2] (https://github.com/learningequality/ka-lite/blob/v0.16.5/python-packages/requests/__init__.py#L45) since the `requests==2.10.0` has an issue on our `pyrun`. 

## Issues addressed

This fixes #5211 .

## Screenshots (if appropriate)

![screen shot 2016-07-27 at 3 04 41 am](https://cloud.githubusercontent.com/assets/4099119/17155263/ed8eadc0-53b6-11e6-836a-25dcef24b2f6.png)

## Test Checklist
**Web page:**
- [x] Homepage
- [x] Teach page
- [x] Manage page
- [x] Learn page
- [x] Docs page
- [x] Admin page
- [x] Facility page
- [x] Video download page
- [x] Language Download page

**Functionality:**
- [x] Video download
- [x] Language download
- [x] Register device
- [x] Play Video
- [x] i18n