### PR TITLE
String formatting error failing in legacy download of assessment items

### DIFF
--- a/kalite/contentload/management/commands/unpack_assessment_zip.py
+++ b/kalite/contentload/management/commands/unpack_assessment_zip.py
@@ -1,24 +1,25 @@
-import requests
+from distutils.version import StrictVersion
+from optparse import make_option
 import os
-import urlparse
-import zipfile
-import tempfile
-import sys
+import requests
 import shutil
+import sys
+import tempfile
 import threading
 import time
-from distutils.version import StrictVersion
-from fle_utils.general import ensure_dir
-from optparse import make_option
+import urlparse
+import zipfile
+
+from django.core.management import call_command
 
 from django.conf import settings as django_settings
 from django.core.management.base import BaseCommand, CommandError
-from django.core.management import call_command
-
-logging = django_settings.LOG
-
+from fle_utils.general import ensure_dir
 from kalite import version
 from kalite.contentload import settings
+
+
+logging = django_settings.LOG
 
 
 class Command(BaseCommand):
@@ -46,7 +47,11 @@ class Command(BaseCommand):
             # this way we can download stuff larger than the device's RAM
             r = requests.get(ziplocation, prefetch=False)
             content_length = r.headers.get("Content-Length")
-            logging.info("Downloaded size: ", str(int(content_length) // 1024 // 1024) + " MB" if content_length else "Unknown")
+            logging.info(
+                "Downloaded size: {}".format(
+                    str(int(content_length) // 1024 // 1024) + " MB" if content_length else "Unknown"
+                )
+            )
             sys.stdout.write("Downloading file...")
             sys.stdout.flush()
             f = tempfile.TemporaryFile("r+")

--- a/kalite/contentload/tests/unpack_assessment_zip.py
+++ b/kalite/contentload/tests/unpack_assessment_zip.py
@@ -13,6 +13,7 @@ from django.test.utils import override_settings
 from kalite.testing.base import KALiteTestCase
 from kalite.contentload.management.commands import unpack_assessment_zip as mod
 from kalite import version
+from kalite.i18n.base import reset_content_db
 
 TEMP_CONTENT_PATH = tempfile.mkdtemp()
 TEMP_ASSESSMENT_ITEM_VERSION_PATH = os.path.join(TEMP_CONTENT_PATH, 'assessmentitems.version')
@@ -37,7 +38,9 @@ contentload_settings.KHAN_ASSESSMENT_ITEM_JSON_PATH = os.path.join(TEMP_CONTENT_
 class UnpackAssessmentZipCommandTests(KALiteTestCase):
 
     def setUp(self):
-        
+
+        reset_content_db()
+
         # Create a dummy assessment item zip
         _, self.zipfile_path = tempfile.mkstemp()
         with open(self.zipfile_path, "w") as f:

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -33,7 +33,8 @@ from kalite.contentload.settings import KHAN_ASSESSMENT_ITEM_ROOT, OLD_ASSESSMEN
 from fle_utils.config.models import Settings
 from fle_utils.general import get_host_name, ensure_dir
 from fle_utils.platforms import is_windows
-from kalite.i18n.base import CONTENT_PACK_URL_TEMPLATE, outdated_langpacks
+from kalite.i18n.base import CONTENT_PACK_URL_TEMPLATE, outdated_langpacks,\
+    reset_content_db
 from kalite.contentload.management.commands.unpack_assessment_zip import should_upgrade_assessment_items
 from kalite.facility.models import Facility
 from kalite.version import VERSION, SHORTVERSION
@@ -388,16 +389,7 @@ class Command(BaseCommand):
         Settings.set("database_version", VERSION)
 
         # Copy all content item db templates
-        if os.path.exists(settings.DB_CONTENT_ITEM_TEMPLATE_DIR):
-            for file_name in os.listdir(settings.DB_CONTENT_ITEM_TEMPLATE_DIR):
-                if file_name.endswith("sqlite"):
-                    template_path = os.path.join(settings.DB_CONTENT_ITEM_TEMPLATE_DIR, file_name)
-                    dest_database = os.path.join(settings.DEFAULT_DATABASE_DIR, file_name)
-                    if install_clean or not os.path.exists(dest_database):
-                        print("Copying {} to {}".format(template_path, dest_database))
-                        shutil.copy(template_path, dest_database)
-                    else:
-                        print("Skipping {}".format(template_path))
+        reset_content_db(force=install_clean)
 
         # download the english content pack
         # This can take a long time and lead to Travis stalling. None of this

--- a/kalite/i18n/base.py
+++ b/kalite/i18n/base.py
@@ -14,7 +14,7 @@ from django.views.i18n import javascript_catalog
 
 from contextlib import contextmanager
 
-from kalite.version import VERSION, SHORTVERSION
+from kalite.version import SHORTVERSION
 from kalite.topic_tools import settings as topic_settings
 
 from fle_utils.config.models import Settings
@@ -28,7 +28,8 @@ CONTENT_PACK_URL_TEMPLATE = ("http://pantry.learningequality.org/downloads"
 CACHE_VARS = []
 
 
-from django.conf import settings; logging = settings.LOG
+from django.conf import settings
+logging = settings.LOG
 
 
 class LanguageNotFoundError(Exception):
@@ -155,7 +156,7 @@ def convert_language_code_format(lang_code, for_django=True):
 
     lang_code = lang_code.lower()
     code_parts = re.split('-|_', lang_code)
-    if len(code_parts) >  1:
+    if len(code_parts) > 1:
         assert len(code_parts) == 2, "code_parts was: {0}".format(code_parts)
         code_parts[1] = code_parts[1].upper()
         if for_django:
@@ -339,7 +340,7 @@ def select_best_available_language(target_code, available_codes=None):
 
 def delete_language(lang_code):
 
-    langpack_resource_paths = [ get_localized_exercise_dirpath(lang_code), get_subtitle_file_path(lang_code), get_locale_path(lang_code) ]
+    langpack_resource_paths = [get_localized_exercise_dirpath(lang_code), get_subtitle_file_path(lang_code), get_locale_path(lang_code)]
 
     for langpack_resource_path in langpack_resource_paths:
         try:
@@ -421,3 +422,16 @@ def extract_content_db(zf, lang, is_template=False):
         dbfobj = zf.open("content.db")
         shutil.copyfileobj(dbfobj, f)
 
+
+def reset_content_db(force=False):
+    # Copy all content item db templates
+    if os.path.exists(settings.DB_CONTENT_ITEM_TEMPLATE_DIR):
+        for file_name in os.listdir(settings.DB_CONTENT_ITEM_TEMPLATE_DIR):
+            if file_name.endswith("sqlite"):
+                template_path = os.path.join(settings.DB_CONTENT_ITEM_TEMPLATE_DIR, file_name)
+                dest_database = os.path.join(settings.DEFAULT_DATABASE_DIR, file_name)
+                if force or not os.path.exists(dest_database):
+                    print("Copying {} to {}".format(template_path, dest_database))
+                    shutil.copy(template_path, dest_database)
+                else:
+                    print("Skipping {}".format(template_path))


### PR DESCRIPTION
## Summary

This error has caused downloading of assessment items to fail, but no one has noticed, so likely no one uses this functionality. It's gonna be deleted in 0.17.

## Issues addressed

#5209 