### PR TITLE
Try adding a wait for element to be visible before clicking it

### DIFF
--- a/kalite/distributed/features/steps/content_rating.py
+++ b/kalite/distributed/features/steps/content_rating.py
@@ -183,6 +183,11 @@ def rate_id(context, id_, val=3):
     def rate_element(driver):
         try:
             inner_wrapper = find_id_with_wait(context, id_, wait_time=2)
+            # Adding this because sidebar may block the view or have made the
+            # screen scroll out of place
+            # WebDriverException: Message: Element is not clickable at point (519, 419.7166748046875). Other element would receive the click: <ul style="overflow: hidden; width: auto; height: 697px;" class="sidebar"></ul>
+            if not elem_is_visible_with_wait(context, inner_wrapper, wait_time=1):
+                raise KALiteTimeout("Expected rating element to show up but it didn't")
             els = inner_wrapper.find_elements_by_class_name(STAR_RATING_OPTION_CLASS)
             rating_el = [el for el in filter(lambda x: int(x.get_attribute("data-val")) == val, els)][0]
             rating_el.click()


### PR DESCRIPTION
## Summary

BDD tests are failing again, and failure doesn't occur locally as usual.

## Reviewer guidance

None

## Issues addressed

Related #5215 - however, this is a new error

## Screenshots (if appropriate)

https://saucelabs.com/jobs/fa013f75e77b407b8e18cd34109f9701

When complaining about not being able to click feedback element, this is the screen shot shown:

![0006screenshot](https://cloud.githubusercontent.com/assets/374612/17209207/30c03158-54bc-11e6-8d04-51ad312ceaad.png)


