### PR TITLE
Pragma support

### DIFF
--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -530,6 +530,9 @@ LOGOUT_URL = "/securesync/api/user/logout/"
 # 18 threads seems a sweet spot
 CHERRYPY_THREAD_COUNT = getattr(local_settings, "CHERRYPY_THREAD_COUNT", 18)
 
+# PRAGMAs to pass to SQLite when we first open the content DBs for reading. Used mostly for optimizations.
+CONTENT_DB_SQLITE_PRAGMAS = []
+
 ########################
 # After all settings, but before config packages,
 #   import settings from other apps.

--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -113,7 +113,7 @@ def set_database(function):
                 language=language
             )
 
-        db = SqliteDatabase(path)
+        db = SqliteDatabase(path, pragmas=settings.CONTENT_DB_SQLITE_PRAGMAS)
 
         kwargs["db"] = db
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ply==3.4
 slimit==0.8.1
 six==1.9.0
 django-appconf==1.0.1
-peewee==2.6.3
+peewee==2.6.4
 python-dateutil==2.4.2
 django-dbbackup==2.3.2
 ifcfg==0.9.3


### PR DESCRIPTION
Adds SQLite pragma support for content databases.

- Upgrades our peewee version to add pragma support for `SQLiteDatabase` calls.
- Adds a new setting in `base.py`, called `CONTENT_DB_SQLITE_PRAGMAS`, which should be a list of two-tuples. By default it's an empty list, but you can override it like so:

```python
CONTENT_DB_SQLITE_PRAGMAS = [("journal_mode", "MEMORY"),
                             ("temp_store", "2")]
```

depending on your situation. See [this link](https://www.sqlite.org/pragma.html) for a list of pragmas you can put here.
