### PR TITLE
Make wait times a lot shorter for silly BDD tests

### DIFF
--- a/kalite/distributed/features/steps/superuser_create.py
+++ b/kalite/distributed/features/steps/superuser_create.py
@@ -27,7 +27,8 @@ def step_impl(context):
 
 @then("I should see a modal")
 def step_impl(context):
-    assert find_id_with_wait(context, modal_container, wait_time=120), "modal not displayed!"
+    assert id_shown_with_wait(context, modal_container, wait_time=5), "modal not displayed!"
+
 
 @when("the username is empty")
 def step_impl(context):
@@ -49,7 +50,7 @@ def step_impl(context):
 
 @then("the modal won't dismiss")
 def step_impl(context):
-    assert not elem_is_invisible_with_wait(context, context.modal_element), "modal dismissed!"
+    assert not elem_is_invisible_with_wait(context, context.modal_element, wait_time=2), "modal dismissed!"
 
 @when("the password is empty")
 def step_impl(context):
@@ -85,10 +86,10 @@ def step_impl(context):
 
 @then("the modal will dismiss")
 def impl(context):
-    assert elem_is_invisible_with_wait(context, context.modal_element, wait_time=120), "modal not dismissed!"
+    assert elem_is_invisible_with_wait(context, context.modal_element, wait_time=5), "modal not dismissed!"
 
 def fill_field(context, text, field_id):
-    field = find_id_with_wait(context, field_id, wait_time=180)
+    field = find_id_with_wait(context, field_id, wait_time=5)
     field.clear()
     field.click()  # Ensure that we're focused on that field for input.
     for key in text:

--- a/kalite/testing/behave_helpers.py
+++ b/kalite/testing/behave_helpers.py
@@ -160,17 +160,20 @@ def elem_is_invisible_with_wait(context, elem, wait_time=MAX_WAIT_TIME):
     Returns True if the element is invisible or stale, otherwise waits and returns False
     """
     try:
-        if elem.get_attribute("id"):
-            by = (By.ID, elem.get_attribute("id"))
-        elif elem.get_attribute("class"):
-            by = (By.CLASS_NAME, elem.get_attribute("class"))
-        else:
-            assert False, "No way to select element."
+        if not elem.is_displayed():
+            return True
     except StaleElementReferenceException:
         return True
+
+    def displayed_condition(driver):
+        try:
+            return not elem.is_displayed()
+        except StaleElementReferenceException:
+            return True
+
     try:
         WebDriverWait(context.browser, wait_time).until(
-            EC.invisibility_of_element_located(by)
+            displayed_condition
         )
         return True
     except TimeoutException:


### PR DESCRIPTION
## Summary

Enough facepalming. Make a couple of very slow tests faster and more reliable (they still failed randomly).

Cuts off 1:50 from test time on my local system.

Before:

```
1 feature passed, 0 failed, 0 skipped
7 scenarios passed, 0 failed, 0 skipped
42 steps passed, 0 failed, 0 skipped, 0 undefined
Took 2m22.849s
```

Now:

```
1 feature passed, 0 failed, 0 skipped
7 scenarios passed, 0 failed, 0 skipped
42 steps passed, 0 failed, 0 skipped, 0 undefined
Took 0m31.488s
```

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file

## Reviewer guidance

-

## Issues addressed

-
