### PR TITLE
Ignore SSL timeouts when SauceConnect is down

### DIFF
--- a/kalite/testing/base_environment.py
+++ b/kalite/testing/base_environment.py
@@ -10,6 +10,7 @@ import shutil
 import sauceclient as sc
 import socket
 
+from ssl import SSLError
 from httplib import CannotSendRequest
 from selenium import webdriver
 from selenium.common.exceptions import WebDriverException
@@ -207,6 +208,8 @@ def after_scenario(context, scenario):
                 context.sauce.jobs.update_job(context.browser.session_id, passed=False)
             else:
                 context.sauce.jobs.update_job(context.browser.session_id, passed=True)
+    except SSLError as e:
+        print("SSL error: Couldn't log the job... Error message:\n" + e.message)
     except Exception as e:
         if "404" in e.message:
             print("Couldn't log the job... Error message:\n" + e.message)


### PR DESCRIPTION
## Summary

As I merged #5245, the tests on Circle failed again. This time because Sauce was down. So let's just ignore that.

https://circleci.com/gh/learningequality/ka-lite/2499

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file

## Reviewer guidance

Nah I guess we can all do without if Sauce is down.. there'll be a message in the log, and one can just build again if Sauce output is wanted.

## Issues addressed

None