### PR TITLE
Enable simplified login

### DIFF
--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -345,7 +345,7 @@ var LoginView = BaseView.extend({
         return this.student_usernames.indexOf(this.$("#id_username").val()) > -1;
     },
 
-    set_login_button_state: function() {
+    set_login_button_state: function(event) {
         if (this.admin || this.check_user_in_list()) {
             this.$(".login-btn").removeAttr("disabled");
         } else {

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -278,6 +278,7 @@ var LoginView = BaseView.extend({
             facility: this.facility,
             is_teacher: false
         };
+        var setGetParamDict = require("utils/get_params").setGetParamDict;
         var url = setGetParamDict(window.sessionModel.get("USER_URL"), data);
         api.doRequest(url, null, {
             cache: true,

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -320,7 +320,7 @@ var LoginView = BaseView.extend({
         // has finished loading.
         this.set_login_button_state();
         this.$(".password-btn").removeAttr("disabled");
-        this.$("#id_username").on( "autocompletesearch", this.set_login_button_state);
+        this.$("#id_username").on(this.set_login_button_state);
     },
 
     key_user: function(event) {


### PR DESCRIPTION
## Summary

Hi @aronasorman, @benjaoming and @radinamatic 
When we minify the javascript in the `bundle_common.js` the `setGetParamDict` is not accessible in `set_autocomplete` function. 
I declare `setGetParamDict` inside the  `set_autocomplete` function so it can be accessible.

## Issues addressed

-Fixes #5255

## Screenshots (if appropriate)

![screen shot 2016-08-10 at 12 00 50 am](https://cloud.githubusercontent.com/assets/4099119/17524300/9d8aab96-5e90-11e6-9569-10b310a9a3ad.png)

![screen shot 2016-08-10 at 12 41 15 am](https://cloud.githubusercontent.com/assets/4099119/17524951/3259bd96-5e93-11e6-9e7e-bea743024e8f.png)

