### PR TITLE
Add a known issue for Windows upgrades from 0.15 due to #5263

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -1,6 +1,8 @@
 Release Notes
 =============
 
+.. warning::
+
 0.16.9
 ------
 
@@ -17,6 +19,11 @@ Known issues
  * Windows installer tray application option "Run on start" does not work see `learningequality/installers#106 <https://github.com/learningequality/installers/issues/106>`__
  * Writing to ``server.log`` is disabled on Windows :url-issue:`5057`
  * Installing on Windows 8, 32bit is reported to take ~1 hour before eventually finishing.
+ * If you are upgrading from 0.15 on a Windows system, you have to manually locate
+   ``python-packages\ka-lite``, typically in
+   ``C:\Python27\share\kalite\python-packages\requests`` and delete it. Otherwise
+   video download breaks. :url-issue:`5263`
+
 
 **Paper cuts**
 


### PR DESCRIPTION
## Summary

This is important to know: If someone upgrades from 0.15 to 0.16, they *will* experience problems with video downloads. The rest is stated in the commit...

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file

## Reviewer guidance

None really, just a little addition to the docs before releasing!

## Issues addressed

#5263