### PR TITLE
Update requests version to 2.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ peewee==2.6.4
 python-dateutil==2.4.2
 django-dbbackup==2.3.2
 ifcfg==0.9.3
-requests==1.1.0
+requests==2.10.0


### PR DESCRIPTION
## Summary

Since our major user is windows we need to fix this #5277 issue. Updating the **requests** will solve this issue. 

Note: 
After upgrading the requests some issue will respawn on the KA Lite for OS X. Such as [Unclean shutdown in OS X installer](https://github.com/learningequality/ka-lite/issues/5211).
PEX will be implemented soon after **0.17.x** release then the OS X issue is solve.

/cc: @benjaoming 

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [ ] Test the upgrade process in the previous release.

## Issues addressed

- [ ]  [Server not starting in KA-Lite 0.16.9](https://github.com/learningequality/ka-lite/issues/5277)
- [ ] [Downgrading requests causes issues with old versions of pip](https://github.com/learningequality/ka-lite/issues/5264)