### PR TITLE
Allow admin/coach login when both SIMPLIFIED_LOGIN and LOCKDOWN activated

### DIFF
--- a/kalite/distributed/middleware.py
+++ b/kalite/distributed/middleware.py
@@ -16,6 +16,7 @@ class LockdownCheck:
                 not request.is_logged_in and
                 request.path not in [reverse("facility_user_signup"), reverse("dynamic_js"), reverse("dynamic_css")] and
                 not request.path.startswith("/api/") and
+                not request.path.startswith("/securesync/api/user/") and
                 not request.path.startswith("/securesync/api/user/status") and
                 not request.path.startswith("/securesync/api/user/login") and
                 not request.path.startswith(settings.CONTENT_DATA_URL) and


### PR DESCRIPTION
## Summary

When both settings are activated, urls begining with /securesync/api/user/ were not whitelisted, this was preventing admins and coaches from logging in.

## Issues addressed
#5255 


## Screenshots (if appropriate)
![screenshot at 2016-09-28 14-33-34](https://cloud.githubusercontent.com/assets/7353802/18914146/25275870-858c-11e6-8bf8-244ed7f1e05d.png)
![screenshot at 2016-09-28 14-59-56](https://cloud.githubusercontent.com/assets/7353802/18914228/7c686a8e-858c-11e6-82b8-f60010566a29.png)




