### PR TITLE
Experiment with universal user-oriented js error handling

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -33,6 +33,7 @@ Bug fixes
  * Redirect to front page if user logs in from the signup page :url-issue:`3926`
  * Progress bar missing when decimals in progress percentage :url-issue:`5321`
  * Missing cache invalidation for JavaScript meant client-side breakage: Upgraded CherryPy HTTP server to 3.3.0 :url-issue:`5317`
+ * Implement friendlier user-facing error messages during unexpected JS failures :url-issue:`5123`
  * **Dev** Loading subtitles now works in ``bin/kalite manage runserver --settings=kalite.project.settings.dev``
 
 

--- a/kalite/distributed/custom_context_processors.py
+++ b/kalite/distributed/custom_context_processors.py
@@ -35,5 +35,6 @@ def custom(request):
         "True": True,
         "False": False,
         "is_config_package_nalanda": "nalanda" in settings.CONFIG_PACKAGE,
-        "HIDE_CONTENT_RATING": settings.HIDE_CONTENT_RATING
+        "HIDE_CONTENT_RATING": settings.HIDE_CONTENT_RATING,
+        "universal_js_user_error": settings.AJAX_ERROR
     }

--- a/kalite/distributed/static/js/distributed/base/baseview.js
+++ b/kalite/distributed/static/js/distributed/base/baseview.js
@@ -5,6 +5,19 @@ module.exports = Backbone.View.extend({
 
 
     /**
+     * Bind error handling
+     */
+    initialize: function(options) {
+        this.bind("error", this.defaultErrorHandler);
+    },
+
+    defaultErrorHandler: function(model, error) {
+         if (error.status == 500) {
+              $("#ajax_user_error").show();
+         }
+    },
+
+    /**
      * Add a subview to the view to allow for easy clean up on remove/close.
      * @param {Object} subview_type - The constructor for the view you want to instantiate.
      * @param {Object} options - The options object for instantiating the subview.
@@ -15,7 +28,7 @@ module.exports = Backbone.View.extend({
         this.subviews.push(subview);
         return subview;
     },
-
+    
     /**
      * Bulk append views to the view to allow for minimal repaint when adding many views.
      * @param {Array} view_list - An array of all the views you want to append.

--- a/kalite/distributed/static/js/distributed/bundle_modules/base.js
+++ b/kalite/distributed/static/js/distributed/bundle_modules/base.js
@@ -18,6 +18,12 @@ global.$ = $;
 global._ = _;
 global.sessionModel = new SessionModel();
 
+$(document).ajaxError(
+  function(e, xhr, options) {
+    $("#ajax_user_error").show();
+  }
+);
+
 var url = require("url");
 
 // An object we can use for checking the state of our models and views.

--- a/kalite/distributed/templates/distributed/base.html
+++ b/kalite/distributed/templates/distributed/base.html
@@ -120,6 +120,9 @@
 
             {# Body #}
             <div id="content-container" class="container" role="main">
+                <div id="ajax_user_error" style="display: none" class="alert alert-danger">
+                  {{ universal_js_user_error|safe }}
+                </div>
                 {% block outer_content %}
                     {% block precontent %}
                         {% include "distributed/partials/_messages.html" %}

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -373,10 +373,10 @@ JS_REVERSE_JS_MINIFY = False
 
 # https://github.com/learningequality/ka-lite/issues/5123
 AJAX_ERROR = ugettext_lazy(
-    """<p>Sorry, this page is having an unexpected problem - but this error """
+    """<p>Sorry, this page is having an unexpected problem - the error """
     """<strong>is not your fault</strong></p>"""
-    """<p>Please don't worry, and select another from 25,000 exercises in here """
-    """to continue learning...</p>"""
+    """<p>Don't let that stop you, try selecting another video or exercise """
+    """from ~30,000 videos and exercises to continue your learning...</p>"""
 )
 
 TASTYPIE_CANNED_ERROR = AJAX_ERROR

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -370,6 +370,18 @@ DEFAULT_ENCODING = 'utf-8'
 # https://github.com/ierror/django-js-reverse/issues/29
 JS_REVERSE_JS_MINIFY = False
 
+
+# https://github.com/learningequality/ka-lite/issues/5123
+AJAX_ERROR = ugettext_lazy(
+    """<p>Sorry, this page is having an unexpected problem - but this error """
+    """<strong>is not your fault</strong></p>"""
+    """<p>Please don't worry, and select another from 25,000 exercises in here """
+    """to continue learning...</p>"""
+)
+
+TASTYPIE_CANNED_ERROR = AJAX_ERROR
+
+
 ########################
 # Storage and caching
 ########################

--- a/kalite/testing/behave_helpers.py
+++ b/kalite/testing/behave_helpers.py
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 def alert_in_page(browser, wait_time=MAX_WAIT_TIME):
     try:
         elem = WebDriverWait(browser, wait_time).until(
-            EC.presence_of_element_located((By.CLASS_NAME, "alert"))
+            EC.presence_of_element_located((By.CSS_SELECTOR, "#message_container .alert"))
         )
         return elem
     except TimeoutException:


### PR DESCRIPTION
## Summary

We have received comments that our user-facing JS error handling may result in some bad learning experiences @j-schwartz

The original screenshot documents a default error message stemming from tasty-pie. It seems to land inside a message display that doesn't concern itself with failures - so this one is hard to fix, yet we can replace the default Tastypie error message as is done in this PR. I didn't manage to recreate the actual issue though.

![tasty pie err](https://cloud.githubusercontent.com/assets/9270388/15523994/6c038a10-21d3-11e6-87d0-bf17f7088ba3.png)

Other than that, the below error message will now be shown in all cases of Backbone errors and errors in Ajax requests. I'm not familiar with any expected failures in our current codebase.
## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)
- [x] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file
## Reviewer guidance

Is this too aggressive?
## Issues addressed
#5123
## Screenshots (if appropriate)

![screenshot from 2016-10-02 18-52-30](https://cloud.githubusercontent.com/assets/374612/19022149/694c1fde-88d1-11e6-83bf-56e6de84b3bd.png)
