### PR TITLE
Special little hotfix for signup page redirect - fixes #3926

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -21,6 +21,7 @@ Bug fixes
  * ``favicon.ico`` missing in distributed set of files, little KA green leaf now appears in browser window decorations and shortcuts :url-issue:`5306`
  * Use current year in footer text :url-issue:`5055`
  * New setting ``HIDE_CONTENT_RATING`` for hiding content rating box :url-issue:`5104`
+ * Redirect to front page if user logs in from the signup page :url-issue:`3926`
 
 Known issues
 ^^^^^^^^^^^^

--- a/kalite/distributed/static/js/distributed/user/views.js
+++ b/kalite/distributed/static/js/distributed/user/views.js
@@ -232,6 +232,9 @@ var LoginView = BaseView.extend({
     handle_login: function(response) {
         if (response.status == 200) {
             this.trigger("login_success");
+            if (location.href.indexOf("signup") > -1) {
+                window.location = "/";
+            }
             if (this.next) {
                 window.location = this.next;
             } else if (response.redirect) {


### PR DESCRIPTION
## Summary

Forces a javascript redirect if the word "signup" appears in the URL. The page itself is already protected server-side and users can't actually signup after logging in.