### PR TITLE
More filename patterns for contentpack preseeding

### DIFF
--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -43,7 +43,11 @@ CONTENTPACK_URL = CONTENT_PACK_URL_TEMPLATE.format(
     version=SHORTVERSION, langcode="en", suffix="")
 
 PRESEED_DIR = os.path.join(ROOT_DATA_PATH, "preseed")
-PRESEED_CONTENT_PACK_MASK = re.compile(r"contentpack\.(?P<lang>[a-z]{2,}).zip")
+
+# Examples:
+# contentpack.en.zip
+# contentpack-0.16.en.zip
+PRESEED_CONTENT_PACK_MASK = re.compile(r"contentpack.*\.(?P<lang>[a-z]{2,}).zip")
 
 
 def raw_input_yn(prompt):


### PR DESCRIPTION
## Summary

Add possibility to use patterns of own choice to content packs to allow installers to version them

E.g. the debian installer will use `/usr/share/kalite/preseed/contentpack-0.17.en.zip` for the English content pack, thus avoiding installing 0.17 content packs when upgrading to 0.18 in some distant future.