### PR TITLE
Remove .gitmodules file causing RTD to break

### DIFF
--- a/kalite/distributed/static/js/distributed/perseus/ke/.gitmodules
+++ b/kalite/distributed/static/js/distributed/perseus/ke/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/qunit"]
-	path = test/qunit
-	url = https://github.com/jquery/qunit.git


### PR DESCRIPTION
## Summary

I'm very sure this file isn't in use, removing it because it breaks our RTD builds because RTD automatically checks out submodules... and this particular submodule doesn't even exist :)

This change will be ported into all branches.

@rtibbles - just letting you know :)