### PR TITLE
ability to change language via url redirect, added docstring

### DIFF
--- a/kalite/i18n/api_views.py
+++ b/kalite/i18n/api_views.py
@@ -3,34 +3,67 @@ import json
 from django.conf import settings; logging = settings.LOG
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_exempt
+from django.shortcuts import redirect
 
 from .base import get_default_language, set_default_language, set_request_language
 from fle_utils.internet.classes import JsonResponse, JsonResponseMessageError
 from fle_utils.internet.decorators import api_handle_error_with_json
 
-
 @csrf_exempt
 @api_handle_error_with_json
 def set_server_or_user_default_language(request):
-    if request.method == 'GET':
-        return JsonResponseMessageError(_("Can only handle default language changes through POST requests"), status=405)
+    """This function sets the default language for either the server or user.
+    It is accessed via HTTP POST or GET.
 
+    Required Args (POST or GET):
+        lang (str): any supported ISO 639-1 language code
+
+    Optional Args (GET):
+        returnUrl (str): the URL to redirect the client to after setting the language
+        allUsers (bool): when true, set the the default language for all users,
+                         when false or missing, set the language for current user
+
+    Returns:
+        JSON status, unless a returnUrl is provided, in which case it returns
+        a redirect when successful
+
+    Example:
+        To set the current user's language to Spanish and send them to
+        the Math section, you could use the following link:
+
+            /api/i18n/set_default_language/?lang=es&returnUrl=/learn/khan/math
+    """
+
+    returnUrl = ''
+    allUsers = ''
+
+    if request.method == 'GET':
+        data = request.GET
+        if 'returnUrl' in data:
+            returnUrl = data['returnUrl']
+        if 'allUsers' in data:
+            allUsers = data['allUsers']
     elif request.method == 'POST':
         data = json.loads(request.raw_post_data) # POST is getting interpreted wrong again by Django
-        lang_code = data['lang']
 
-        if request.is_django_user and lang_code != get_default_language():
-            logging.debug("setting server default language to %s" % lang_code)
-            set_default_language(lang_code)
-        elif not request.is_django_user and request.is_logged_in and lang_code != request.session["facility_user"].default_language:
-            logging.debug("setting user default language to %s" % lang_code)
-            request.session["facility_user"].default_language = lang_code
-            request.session["facility_user"].save()
+    lang_code = data['lang']
 
-        if lang_code != request.session.get("default_language"):
-            logging.debug("setting session language to %s" % lang_code)
-            request.session["default_language"] = lang_code
+    if allUsers or (request.is_django_user and lang_code != get_default_language()):
+        logging.debug("setting server default language to %s" % lang_code)
+        set_default_language(lang_code)
+    elif not request.is_django_user and request.is_logged_in and lang_code != request.session["facility_user"].default_language:
+        logging.debug("setting user default language to %s" % lang_code)
+        request.session["facility_user"].default_language = lang_code
+        request.session["facility_user"].save()
 
-        set_request_language(request, lang_code)
+    if lang_code != request.session.get("default_language"):
+        logging.debug("setting session language to %s" % lang_code)
+        request.session["default_language"] = lang_code
 
+    set_request_language(request, lang_code)
+
+    if not returnUrl:
         return JsonResponse({"status": "OK"})
+    else:
+        return redirect(returnUrl)
+

--- a/kalite/i18n/api_views.py
+++ b/kalite/i18n/api_views.py
@@ -39,6 +39,8 @@ def set_server_or_user_default_language(request):
 
     if request.method == 'GET':
         data = request.GET
+        if not 'lang' in data:
+            return redirect('/')
         if 'returnUrl' in data:
             returnUrl = data['returnUrl']
         if 'allUsers' in data:


### PR DESCRIPTION
## Summary

(resubmitting against develop branch per [request](https://github.com/learningequality/ka-lite/pull/5340#issuecomment-262745332))

In multi-lingual environments, it is not user friendly for each user to change the default language manually with the drop-down box on the bottom of the page. This patch allows setting the language through a link, which then redirects the user to the requested content. We use this patch in RACHEL for our multi-lingual installations. You can see it in action here, where we link to English, French, and Spanish versions on the same server:

  http://rachelfriends.org/previews/rachelplus-en/
  http://rachelfriends.org/previews/rachelplus-es/
  http://rachelfriends.org/previews/rachelplus-fr/

It would be nice if this functionality were included in the official release.

## TODO

- No tests existed for this module - I don't know how to write tests for python/django
- I have added documentation (there was none before)
- New dependencies in this file: from django.shortcuts import redirect
