### PR TITLE
Cautiously upgrade CherryPy to 3.3.0 - fixes #5317

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -17,6 +17,7 @@ New features
    :url-issue:`5342` -
    (Thanks: Jonathan Field)
 
+
 Bug fixes
 ^^^^^^^^^
 
@@ -31,6 +32,7 @@ Bug fixes
  * New setting ``HIDE_CONTENT_RATING`` for hiding content rating box :url-issue:`5104`
  * Redirect to front page if user logs in from the signup page :url-issue:`3926`
  * Progress bar missing when decimals in progress percentage :url-issue:`5321`
+ * Missing cache invalidation for JavaScript meant client-side breakage: Upgraded CherryPy HTTP server to 3.3.0 :url-issue:`5317`
 
 
 Known issues

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-appconf==1.0.1
 peewee==2.6.4
 python-dateutil==2.4.2
 django-annoying==0.8.4
-cherrypy==3.2.2
+cherrypy==3.3.0
 ifcfg==0.9.3
 importlib==1.0.3
 pbkdf2==1.3


### PR DESCRIPTION
## Summary

CherryPy doesn't document all changes, but this upgrade immediately meant I could see cache invalidation go back to normal, fixing #5317

Since it's an upstream bug, we don't write tests, we expect dependencies to work :)

Tested:

1. Changes in files => HTTP 200
1. Unchanged files => HTTP 304

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file

## Issues addressed

#5317 
