### PR TITLE
0.17.0b3

### DIFF
--- a/kalite/version.py
+++ b/kalite/version.py
@@ -3,7 +3,7 @@
 # Must also be of the form N.N.N for internal use, where N is a non-negative integer
 MAJOR_VERSION = "0"
 MINOR_VERSION = "17"
-PATCH_VERSION = "0dev0"
+PATCH_VERSION = "0b3"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
 


### PR DESCRIPTION
Supersedes #5326

**WARNING!** Merging this, merges and closes all PRs contained in this PR, and they may have a separate review process and amendments following. **So don't merge this PR!!** :)

New release, manually brewing the distributions:
- [x] [ka-lite on pypi](https://pypi.python.org/pypi/ka-lite)
- [x] [ka-lite-static on pypi](https://pypi.python.org/pypi/ka-lite-static)
- [ ] [ka-lite on Launchpad PPA](https://launchpad.net/~learningequality/+archive/ubuntu/ka-lite)
- [ ] OSX installer
- [ ] Windows installer

## Known issues

See release notes: http://ka-lite.readthedocs.io/en/develop/installguide/release_notes.html

## Included PRs

## Installer links
- Debian/Ubuntu: Not going to happen - waiting for 0.17.0b4 w/ empty content.db stuff merged
- [Windows]() TODO
- [Mac]() TODO
### PyPi

NB! Now only serves .whl files.

```
pip install ka-lite --pre
```

or

```
pip install ka-lite-static --pre  # bundled dependencies
```
