### PR TITLE
Downgrade docutils package to fix sphinx issue.

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ django-debug-toolbar==1.3.2
 django-extensions==1.5.9  # Found in installed apps in kalite.project.settings.dev
 sqlparse<0.2
 pep8
-sphinx
+sphinx>=1.5.1
 #cli2man
 polib # used for our own makemessages
 xlrd # used for management command convert_xls_to_items

--- a/requirements_sphinx.txt
+++ b/requirements_sphinx.txt
@@ -1,6 +1,5 @@
 -r requirements_test.txt
-docutils <0.13.1
-sphinx
+sphinx>=1.5.1
 sphinx_rtd_theme
 sphinx-intl
 # Required by screenshots.py to take screenshots in headless manner

--- a/requirements_sphinx.txt
+++ b/requirements_sphinx.txt
@@ -1,4 +1,5 @@
 -r requirements_test.txt
+docutils <0.13.1
 sphinx
 sphinx_rtd_theme
 sphinx-intl


### PR DESCRIPTION
## Summary

Running `make dist` in KA Lite `develop branch` will have this error:

> Exception occurred:
  File "/Users/user/.virtualenvs/kalite-b1/lib/python2.7/site-packages/docutils/writers/_html_base.py", line 671, in depart_document
    assert not self.context, 'len(context) = %s' % len(self.context)
AssertionError: len(context) = 1

Hi @benjaoming I downgraded the `docutils` package as  a quick fix on [sphinx issue](https://github.com/sphinx-doc/sphinx/issues/3212).


