### PR TITLE
Only display error messages when status code matches 500

### DIFF
--- a/kalite/distributed/static/js/distributed/bundle_modules/base.js
+++ b/kalite/distributed/static/js/distributed/bundle_modules/base.js
@@ -19,8 +19,10 @@ global._ = _;
 global.sessionModel = new SessionModel();
 
 $(document).ajaxError(
-  function(e, xhr, options) {
-    $("#ajax_user_error").show();
+  function(e, xhr, options, error) {
+    if (xhr.status == 500) {
+      $("#ajax_user_error").show();
+    }
   }
 );
 


### PR DESCRIPTION
## Summary

Apparrently `ajaxError` is called with a status code `0`. Not sure why, but this fix will conservatively stick to displaying error messages when codes match `500`. Let's expand it once we discover which codes are appropriate.

## Issues addressed

#5365
