### PR TITLE
Revert "Downgrade docutils package to fix sphinx issue."

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ django-debug-toolbar==1.3.2
 django-extensions==1.5.9  # Found in installed apps in kalite.project.settings.dev
 sqlparse<0.2
 pep8
-sphinx>=1.5.1
+sphinx
 #cli2man
 polib # used for our own makemessages
 xlrd # used for management command convert_xls_to_items

--- a/requirements_sphinx.txt
+++ b/requirements_sphinx.txt
@@ -1,5 +1,5 @@
 -r requirements_test.txt
-sphinx>=1.5.1
+sphinx
 sphinx_rtd_theme
 sphinx-intl
 # Required by screenshots.py to take screenshots in headless manner


### PR DESCRIPTION
Reverts learningequality/ka-lite#5362

Not able to accommodate because RTD complained:

https://readthedocs.org/projects/ka-lite/builds/4796414/