### PR TITLE
Remove dependency link and depend on django-tastypie-legacy

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -36,6 +36,7 @@ Bug fixes
  * Implement friendlier user-facing error messages during unexpected JS failures :url-issue:`5123`
  * Source distribution and `ka-lite` + `ka-lite-raspberry-pi` debian packages no longer ship with English content.db, means they have reduced ~40% in file size :url-issue:`5318`
  * Installation works with latest ``setuptools >= 30.0`` affecting almost any recent system using ``pip install``. :url-issue:`5352`
+ * Installation works with latest ``pip 9``. :url-issue:`5319`
  * **Windows**: Logging works again: Writing to ``server.log`` was disabled on Windows :url-issue:`5057`
  * **Dev** Loading subtitles now works in ``bin/kalite manage runserver --settings=kalite.project.settings.dev``
  * **Dev** Test runner is now compatible with Selenium 3 and Firefox 50

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,8 +26,5 @@ pbkdf2==1.3
 rsa==3.1.1
 youtube-dl==2015.11.24
 
-# There is still no release of this
-# fixed issue, i.e. django-tastypie==0.12.2 is broken.
-# This one works though...
-https://github.com/django-tastypie/django-tastypie/archive/e6bc34bea83d53552c7fc9dfa696ed7693fe22ab.tar.gz#egg=django-tastypie-0.12.2dev0
+django-tastypie-legacy
 requests==2.11.1


### PR DESCRIPTION
## Summary

Now releasing the 0.12 django-tastypie-legacy package in order to service our legacy South needs.

Fixes #5319