### PR TITLE
Static files from content packs served from CONTENT_ROOT

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -63,6 +63,7 @@ Bug fixes
  * Source distribution and `ka-lite` + `ka-lite-raspberry-pi` debian packages no longer ship with English content.db, means they have reduced ~40% in file size :url-issue:`5318`
  * Installation works with latest ``setuptools >= 30.0`` affecting almost any recent system using ``pip install``. :url-issue:`5352`
  * Installation works with latest ``pip 9``. :url-issue:`5319`
+ * ``kalite manage contentpackchecker all --update`` wrongly retrieved all available content packs. Now only updates *installed* content packs.
  * **Windows**: Logging works again: Writing to ``server.log`` was disabled on Windows :url-issue:`5057`
  * **Dev** Loading subtitles now works in ``bin/kalite manage runserver --settings=kalite.project.settings.dev``
  * **Dev** Test runner is now compatible with Selenium 3 and Firefox 50

--- a/kalite/distributed/management/commands/contentpackchecker.py
+++ b/kalite/distributed/management/commands/contentpackchecker.py
@@ -1,7 +1,6 @@
 import glob
 import json
 import os
-import requests
 
 from optparse import make_option
 
@@ -12,9 +11,7 @@ from django.core.management.base import BaseCommand
 from kalite.topic_tools.content_models import Item, set_database, parse_data, AssessmentItem
 
 from kalite.i18n.base import get_locale_path, get_subtitle_file_path as get_subtitle_path, \
-    get_localized_exercise_dirpath
-
-from kalite.version import SHORTVERSION
+    get_localized_exercise_dirpath, get_installed_language_packs
 
 logging = django_settings.LOG
 
@@ -52,11 +49,7 @@ class Command(BaseCommand):
 
         if languages[0] == "all":
 
-            metadata_url = "https://learningequality.org/downloads/ka-lite/{version}/content/contentpacks/all_metadata.json".format(version=SHORTVERSION)
-
-            metadata = json.loads(requests.get(metadata_url).content)
-
-            languages = [lang["code"] for lang in metadata]
+            languages = get_installed_language_packs(force=True).keys()
 
         if options["update"]:
             for language in languages:

--- a/kalite/distributed/management/commands/contentpackchecker.py
+++ b/kalite/distributed/management/commands/contentpackchecker.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand
 from kalite.topic_tools.content_models import Item, set_database, parse_data, AssessmentItem
 
 from kalite.i18n.base import get_locale_path, get_subtitle_file_path as get_subtitle_path, \
-    get_localized_exercise_dirpath, get_installed_language_packs
+    get_installed_language_packs
 
 logging = django_settings.LOG
 
@@ -80,7 +80,6 @@ class Command(BaseCommand):
             print "\tNumber of unique exercises:", len(set([item["id"] for item in self.get_content_items_by_kind(language=language, kind="Exercise")]))
             print "\tNumber of assessment items:", self.count_assessment_items(language=language)
 
-            print "\tNumber of khan-exercises files:", len(self.get_html_exercises(language=language))
             print "\tNumber of subtitle files:", len(self.get_subtitles(language=language))
 
             print ""
@@ -93,11 +92,6 @@ class Command(BaseCommand):
     @set_database
     def count_assessment_items(self, **kwargs):
         return AssessmentItem.select().count()
-
-    def get_html_exercises(self, language):
-        exercise_dest_path = get_localized_exercise_dirpath(language)
-        return glob.glob(os.path.join(exercise_dest_path, "*.html"))
-
 
     def get_content_pack_metadata(self, language):
         metadata_path = os.path.join(get_locale_path(language), "{language}_metadata.json".format(language=language))

--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -15,7 +15,7 @@ from fle_utils.general import ensure_dir
 from kalite.contentload import settings as content_settings
 from kalite.i18n.base import lcode_to_django_lang, get_po_filepath, get_locale_path, \
     download_content_pack, update_jsi18n_file, get_subtitle_file_path as get_subtitle_path, \
-    extract_content_db, get_localized_exercise_dirpath
+    extract_content_db
 from kalite.topic_tools import settings as topic_settings
 from kalite.updates.management.utils import UpdatesStaticCommand
 from peewee import SqliteDatabase
@@ -167,33 +167,12 @@ class Command(UpdatesStaticCommand):
         extract_subtitles(zf, lang)
         extract_content_pack_metadata(zf, lang)  # always extract to the en lang
         extract_assessment_items(zf, "en")
-        extract_html_exercises(zf, lang)
 
         if not self.is_template:
             self.next_stage(_("Looking for available content items."))
             call_command("annotate_content_items", language=lang)
 
         self.complete(_("Finished processing content pack."))
-
-
-def extract_html_exercises(zf, lang):
-    exercise_dest_path = get_localized_exercise_dirpath(lang)
-    zip_exercise_path = "exercises/"
-
-    items = [s for s in zf.namelist() if zip_exercise_path in s]
-
-    if not items:  # no html exercises to extract
-        return
-
-    extract_path = tempfile.mkdtemp()
-    full_extract_path = os.path.join(extract_path, zip_exercise_path)
-    try:
-        zf.extractall(extract_path, items)
-
-        shutil.rmtree(exercise_dest_path, ignore_errors=True)
-        shutil.move(full_extract_path, exercise_dest_path)
-    finally:                    # no matter what happens, remove the extract path
-        shutil.rmtree(extract_path)
 
 
 def extract_content_pack_metadata(zf, lang):

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -470,15 +470,7 @@ class Command(BaseCommand):
         logging.info("Copying static media...")
         ensure_dir(settings.STATIC_ROOT)
 
-        # The following file ignores have to be preserved from a
-        # collectstatic(clear=True), due to being bundled with content packs,
-        # and we thus have now way of getting them back.
-        collectstatic_ignores = [
-            # subtitle files come with language packs -- don't delete
-            "*.vtt", "*.srt",
-        ]
-        call_command("collectstatic", interactive=False, verbosity=0, ignore_patterns=collectstatic_ignores,
-                     clear=True)
+        call_command("collectstatic", interactive=False, verbosity=0, clear=True)
         call_command("collectstatic_js_reverse", interactive=False)
 
         # This is not possible in a distributed env

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -476,9 +476,6 @@ class Command(BaseCommand):
         collectstatic_ignores = [
             # subtitle files come with language packs -- don't delete
             "*.vtt", "*.srt",
-            # exercises come with language packs, and we have no way to
-            # replicate
-            "*/perseus/ke/exercises/*",
         ]
         call_command("collectstatic", interactive=False, verbosity=0, ignore_patterns=collectstatic_ignores,
                      clear=True)

--- a/kalite/i18n/base.py
+++ b/kalite/i18n/base.py
@@ -70,7 +70,7 @@ def get_langcode_map(lang_name=None, force=False):
 
 
 def get_subtitle_url(youtube_id, code):
-    return settings.STATIC_URL + "srt/%s/subtitles/%s.vtt" % (code, youtube_id)
+    return settings.CONTENT_URL + "srt/%s/subtitles/%s.vtt" % (code, youtube_id)
 
 
 def get_subtitle_file_path(lang_code=None, youtube_id=None):
@@ -82,7 +82,7 @@ def get_subtitle_file_path(lang_code=None, youtube_id=None):
 
     Note also that it must use the django-version language code.
     """
-    srt_path = os.path.join(settings.STATIC_ROOT, "srt")
+    srt_path = os.path.join(settings.CONTENT_ROOT, "srt")
     if lang_code:
         srt_path = os.path.join(srt_path, lcode_to_django_dir(lang_code), "subtitles")
     if youtube_id:

--- a/kalite/i18n/base.py
+++ b/kalite/i18n/base.py
@@ -36,10 +36,6 @@ class LanguageNotFoundError(Exception):
     pass
 
 
-def get_localized_exercise_dirpath(lang_code):
-    return os.path.join(settings.STATIC_ROOT, "js", "distributed", "perseus", "ke", "exercises", lang_code)  # Translations live in user data space
-
-
 def get_locale_path(lang_code=None):
     """returns the location of the given language code, or the default locale root
     if none is provided."""
@@ -344,7 +340,7 @@ def select_best_available_language(target_code, available_codes=None):
 
 def delete_language(lang_code):
 
-    langpack_resource_paths = [get_localized_exercise_dirpath(lang_code), get_subtitle_file_path(lang_code), get_locale_path(lang_code)]
+    langpack_resource_paths = [get_subtitle_file_path(lang_code), get_locale_path(lang_code)]
 
     for langpack_resource_path in langpack_resource_paths:
         try:

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -63,7 +63,7 @@ LOGGING = {
             'level': 'INFO',
         },
         'django.request': {
-            'handlers': ['console'],
+            'handlers': ['null'],
             'level': 'DEBUG',
             'propagate': False,
         },

--- a/kalite/topic_tools/annotate.py
+++ b/kalite/topic_tools/annotate.py
@@ -118,7 +118,7 @@ def update_content_availability(content_list, language="en", channel="khan"):
                 # Generate subtitle URLs for any subtitles that do exist for this content item
                 subtitle_urls = [{
                     "code": lc,
-                    "url": django_settings.STATIC_URL + "srt/{code}/subtitles/{id}.vtt".format(code=lc, id=content.get("id")),
+                    "url": django_settings.CONTENT_URL + "srt/{code}/subtitles/{id}.vtt".format(code=lc, id=content.get("id")),
                     "name": get_language_name(lc)
                     } for lc in subtitle_lang_codes]
 


### PR DESCRIPTION
## Summary

 * Reduces HTTP logging on dev server to something readable
 * Fixes `kalite manage contentpackchecker all --update` so it only updates installed content packs
 * Unpacks subtitle files `*.vtt` to `CONTENT_ROOT/srt`: Annotates with updated url and no longer needs to ignore any file or folder patterns during `collectstatic`

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file
- [x] Update `get_subtitle_file_path`
- [x] Remove old code unpacking/updating `/perseus/ke/exercises/*`
- [x] In `kalite.management.commands.setup`, remove `collectstatic_ignores`
- [x] Update content annotation to discover from different dir and update `url` column
- [x] Update ka-lite-raspberry-pi Nginx Conf
- [x] Update dev server `runserver`
- [x] Update cherrypy staticdirs

## Reviewer guidance

Let me know if you find anything unacceptable here. New static files handing will be described in release notes.

## Issues addressed

#5073 