### PR TITLE
Upgrade six library version to 1.10.0 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ django-js-reverse==0.5.0
 ply==3.4
 # used by django-js-reverse
 slimit==0.8.1
-six==1.9.0
+six>=1.10.0
 django-appconf==1.0.1
 peewee==2.6.4
 python-dateutil==2.4.2


### PR DESCRIPTION
## Summary

Running `pip install .` to compile ka-lite source will have these errors
```
Processing /Users/user/ka-lite
    Complete output from command python setup.py egg_info:
    Already blocking...
    Already blocking...
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/pf/jwg228js7cg687y7hkgym1040000gn/T/pip-_wsYPx-build/setup.py", line 338, in <module>
        'install_scripts': my_install_scripts  # Windows bat wrapper
      File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/core.py", line 111, in setup
        _setup_distribution = dist = klass(attrs)
      File "/Users/user/.virtualenvs/kalite-build/lib/python2.7/site-packages/setuptools/dist.py", line 320, in __init__
        _Distribution.__init__(self, attrs)
      File "/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py", line 287, in __init__
        self.finalize_options()
      File "/Users/user/.virtualenvs/kalite-build/lib/python2.7/site-packages/setuptools/dist.py", line 386, in finalize_options
        ep.require(installer=self.fetch_build_egg)
      File "/Users/user/.virtualenvs/kalite-build/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2318, in require
        items = working_set.resolve(reqs, env, installer, extras=self.extras)
      File "/Users/user/.virtualenvs/kalite-build/lib/python2.7/site-packages/pkg_resources/__init__.py", line 859, in resolve
        raise VersionConflict(dist, req).with_context(dependent_req)
    pkg_resources.VersionConflict: (six 1.9.0 (/Users/user/.virtualenvs/kalite-build/lib/python2.7/site-packages), Requirement.parse('six>=1.10.0'))
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/pf/jwg228js7cg687y7hkgym1040000gn/T/pip-_wsYPx-build/

```

Upgrading six library to 1.10.0 will fix the issue.

/cc @benjaoming 