### PR TITLE
Clean *pyc files before building the sdist to avoid inclusion of .pyc…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,9 @@ release: dist man
 	twine upload -s --sign-with gpg2 dist/*
 
 sdist: clean docs assets
+	# Building assets currently creates pyc files in the source dirs,
+	# so we should delete those...
+	make clean-pyc
 	python setup.py sdist --formats=$(format) --static
 
 dist: clean docs assets


### PR DESCRIPTION
… caused by make assets

Somehow `python setup.py sdist` does not protect against having .pyc in the tar.gz output. I'm not sure if this is some upstream regression in setuptools, it hasn't happened in 0.16.9, even though the build process was the same and `make assets` was also invoked in the process.