### PR TITLE
Simplify am_i_online which broke because of a 301 on kalite.learninequality.org

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -76,6 +76,7 @@ Bug fixes
  * Installation works with latest ``pip 9``. :url-issue:`5319`
  * ``kalite manage contentpackchecker all --update`` wrongly retrieved all available content packs. Now only updates *installed* content packs.
  * No content pack files are placed in ``STATIC_ROOT``, ensuring that ``kalite manage collectstatic`` will not remove any files from content packs (subtitles!). :url-issue:`5386` :url-issue:`5073`
+ * Online availability incorrectly detected, bypassing registration progress on Video and Language downloads :url-issue:`5401`
  * **Windows**: Logging works again: Writing to ``server.log`` was disabled on Windows :url-issue:`5057`
  * **Dev** Loading subtitles now works in ``bin/kalite manage runserver --settings=kalite.project.settings.dev``
  * **Dev** Auto-discovery of content-packs in well-known location ``/usr/share/kalite/preseed/contentpack-<version>.<lang>.zip``, example: ``/usr/share/kalite/preseed/contentpack-0.17.en.zip``. Happens during ``kalite.distributed.management.commands.setup``.

--- a/kalite/packages/bundled/fle_utils/internet/functions.py
+++ b/kalite/packages/bundled/fle_utils/internet/functions.py
@@ -9,6 +9,8 @@ import re
 import requests
 
 
+from django.conf import settings
+from django.core.urlresolvers import reverse
 from urlparse import parse_qs, urlsplit, urlunsplit
 from urllib import urlencode
 
@@ -16,18 +18,21 @@ from urllib import urlencode
 logger = logging.getLogger(__name__)
 
 
-def am_i_online(url):
+def am_i_online():
     """Test whether we are online or not.
     returns True or False.
     Eats all exceptions!   <- great :( /benjaoming
     """
     from kalite.version import user_agent
 
+    url = "%s://%s%s" % (settings.SECURESYNC_PROTOCOL, settings.CENTRAL_SERVER_HOST, reverse("get_server_info"))
+
     try:
-        response = requests.get(url, timeout=5, allow_redirects=True, headers={"user-agent": user_agent()})
+        response = requests.get(url, timeout=5, allow_redirects=False, headers={"user-agent": user_agent()})
 
         # Validate that response came from the requested url
         if response.status_code != 200:
+            
             logger.warning("Unexpected response detecting online status: {}".format(response))
             return False
 

--- a/kalite/packages/bundled/fle_utils/internet/functions.py
+++ b/kalite/packages/bundled/fle_utils/internet/functions.py
@@ -11,7 +11,7 @@ import requests
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from urlparse import parse_qs, urlsplit, urlunsplit
+from urlparse import parse_qs, urlsplit, urlunsplit, urljoin
 from urllib import urlencode
 
 
@@ -25,7 +25,7 @@ def am_i_online():
     """
     from kalite.version import user_agent
 
-    url = "%s://%s%s" % (settings.SECURESYNC_PROTOCOL, settings.CENTRAL_SERVER_HOST, reverse("get_server_info"))
+    url = urljoin(settings.CENTRAL_SERVER_URL, reverse("get_server_info"))
 
     try:
         response = requests.get(url, timeout=5, allow_redirects=False, headers={"user-agent": user_agent()})

--- a/kalite/packages/bundled/fle_utils/internet/functions.py
+++ b/kalite/packages/bundled/fle_utils/internet/functions.py
@@ -2,46 +2,39 @@
 For functions mucking with internet access
 """
 import ifcfg
+import logging
 import os
 import platform
 import re
 import requests
-import socket
+
 
 from urlparse import parse_qs, urlsplit, urlunsplit
 from urllib import urlencode
 
 
-def am_i_online(url, expected_val=None, search_string=None, timeout=5, allow_redirects=True):
+logger = logging.getLogger(__name__)
+
+
+def am_i_online(url):
     """Test whether we are online or not.
     returns True or False.
-    Eats all exceptions!
+    Eats all exceptions!   <- great :( /benjaoming
     """
-    assert not (search_string and expected_val is not None), "Search string and expected value cannot both be set"
-
     from kalite.version import user_agent
 
     try:
-        if not search_string and expected_val is None:
-            response = requests.head(url, headers={"user-agent": user_agent()})
-        else:
-            response = requests.get(url, timeout=timeout, allow_redirects=allow_redirects, headers={"user-agent": user_agent()})
+        response = requests.get(url, timeout=5, allow_redirects=True, headers={"user-agent": user_agent()})
 
         # Validate that response came from the requested url
         if response.status_code != 200:
+            logger.warning("Unexpected response detecting online status: {}".format(response))
             return False
-        elif not allow_redirects and response.url != url:
-            return False
-
-        # Check the output, if expected values are specified
-        if expected_val is not None:
-            return expected_val == response.text
-        elif search_string:
-            return search_string in response.text
 
         return True
 
     except Exception as e:
+        logger.warning("Unhandled exception when detecting if online: {}".format(e))
         return False
 
 

--- a/kalite/packages/bundled/securesync/devices/api_views.py
+++ b/kalite/packages/bundled/securesync/devices/api_views.py
@@ -209,7 +209,7 @@ def get_server_info(request):
             if settings.CENTRAL_SERVER:
                 device_info[field] =  True
             else:
-                device_info[field] = am_i_online(url="%s://%s%s" % (settings.SECURESYNC_PROTOCOL, settings.CENTRAL_SERVER_HOST, reverse("get_server_info")))
+                device_info[field] = am_i_online()
 
         elif field:
             # the field isn't one we know about, so add it to the list of invalid fields

--- a/kalite/packages/bundled/securesync/devices/decorators.py
+++ b/kalite/packages/bundled/securesync/devices/decorators.py
@@ -14,7 +14,7 @@ def require_registration(resource_name):
     """
     def real_decorator_wrapper(handler):
         def real_decorator_wrapper_fn(request, *args, **kwargs):
-            if Device.get_own_device().is_registered() or not am_i_online(settings.CENTRAL_SERVER_URL):
+            if Device.get_own_device().is_registered() or not am_i_online():
                 return handler(request, *args, **kwargs)
             else:
                 messages.warning(

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -72,6 +72,11 @@ LOGGING = {
             'level': LOGGING_LEVEL,
             'propagate': False,
         },
+        'fle_utils': {
+            'handlers': ['console'],
+            'level': LOGGING_LEVEL,
+            'propagate': False,
+        },
         'cherrypy.console': {
             'handlers': ['console'],
             'level': LOGGING_LEVEL,

--- a/kalite/updates/tests/regression_tests.py
+++ b/kalite/updates/tests/regression_tests.py
@@ -24,7 +24,7 @@ class RegistrationRedirectTestCase(CreateAdminMixin, KALiteClientTestCase):
     @override_settings(CENTRAL_SERVER_URL="http://127.0.0.1:8997")  # We hope this is unreachable
     def test_not_redirected_when_offline(self):
         self.assertFalse(Device.get_own_device().is_registered(), "The device should be unregistered!")
-        self.assertFalse(am_i_online(url=settings.CENTRAL_SERVER_URL), "Central server should be unreachable!")
+        self.assertFalse(am_i_online(), "Central server should be unreachable!")
         updated_videos_url = self.reverse("update_videos")
         response = self.client.get(updated_videos_url, follow=True)
         redirect_chain = response.redirect_chain  # Will be the empty list if there are no redirects


### PR DESCRIPTION
## Summary

It's fine that kalite.learningequality.org redirects. However, with the mess that `am_i_online` was, it wasn't actually doing the test right.

So I simplified it to a function that doesn't accept arguments.

Also, it doesn't check the root URL since this one redirects, but looks for a well-known API endpoint... which hopefully, we won't remove :)

 * Outputs logging from `fle_utils`
 * Increases reliability of `am_i_online`
 * Add release note

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Have **tests** been written for the new code? If you're fixing a bug, write a regression test (or have a really good reason for not writing one... and I mean **really** good!)
- [x] Has documentation been written/updated?
- [x] New dependencies (if any) added to requirements file

## Reviewer guidance

Not expecting anyone to jump in on this, but feel free, @jamalex and @aronasorman - since this is a last-minute release blocker that will ship shortly.

## Issues addressed

#5401
