### PR TITLE
Do not load video into memory to check its size, just use disk stats

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -18,6 +18,7 @@ Bug fixes
  * Touch devices: Scroll events drop through to underlying page rather than scrolling long sidebar lists :url-issue:`5407` :url-issue:`5410`
  * Respect selected date range on tabular coach report :url-issue:`5022`
  * Correct summary of total exercise attempts on coach reports :url-issue:`5020`
+ * Do not load video into memory to check its size, just use disk stats :url-issue:`2909`
 
 Known issues
 ^^^^^^^^^^^^

--- a/kalite/packages/bundled/fle_utils/videos.py
+++ b/kalite/packages/bundled/fle_utils/videos.py
@@ -42,14 +42,14 @@ def download_video(youtube_id, download_path="../content/", download_url=OUTSIDE
         if (
                 not os.path.isfile(filepath) or
                 "content-length" not in response.headers or
-                not len(open(filepath, "rb").read()) == int(response.headers['content-length'])):
+                not os.path.getsize(filepath) == int(response.headers['content-length'])):
             raise URLNotFound("Video was not found, tried: {}".format(url))
 
         response = download_file(thumb_url, thumb_filepath, callback_percent_proxy(callback, start_percent=95, end_percent=100))
         if (
                 not os.path.isfile(thumb_filepath) or
                 "content-length" not in response.headers or
-                not len(open(thumb_filepath, "rb").read()) == int(response.headers['content-length'])):
+                not os.path.getsize(thumb_filepath) == int(response.headers['content-length'])):
             raise URLNotFound("Thumbnail was not found, tried: {}".format(thumb_url))
 
     except DownloadCancelled:


### PR DESCRIPTION
`os.path.getsize` returns bytes, should be safe since file object is closed after returning from `download_file`

## Summary

This is a potential problem for small devices downloading huge videos.

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Has documentation been written/updated?
- [x] Have you written release notes for the upcoming release?

## Reviewer guidance

I've checked this by fetching a video.

## Issues addressed

#2909 

