### PR TITLE
 Add logging to setup and initialize_kalite (2)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,8 @@ test:
     - sudo mv geckodriver /home/ubuntu/bin
     - export PATH="$PATH:/home/ubuntu/bin"
   override:
-    - make assets
+    - make assets:
+        parallel: true
     - make docs
     - kalite start --traceback -v2
     - sleep 6s  # Necessary for server to be ready
@@ -25,7 +26,6 @@ test:
     - kalite stop --traceback -v2
     - case $CIRCLE_NODE_INDEX in 0) coverage run --source=kalite --omit="kalite/testing/*,*/tests/*,*/migrations/*,kalite/packages/*" bin/kalite manage test --bdd-only ;; 1) coverage run --source=kalite --omit="kalite/testing/*,kalite/packages/*,*/tests/*,*/migrations/*" bin/kalite manage test --no-bdd;; esac:
         parallel: true
-    # TODO: replace below with "make lint" when we're pep8
     - npm install -g jshint
     - jshint kalite/*/static/js/*/
   post:

--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -19,6 +19,8 @@ Bug fixes
  * Respect selected date range on tabular coach report :url-issue:`5022`
  * Correct summary of total exercise attempts on coach reports :url-issue:`5020`
  * Do not load video into memory to check its size, just use disk stats :url-issue:`2909`
+ * Print server address after ``kalite start`` :url-issue:`5441`
+ * Log everything from automatic initialization in ``kalite start`` and ``kalite manage setup`` :url-issue:`5408`
 
 Known issues
 ^^^^^^^^^^^^

--- a/kalite/cli.py
+++ b/kalite/cli.py
@@ -426,7 +426,7 @@ def manage(command, args=None, as_thread=False):
         return thread
 
 
-def start(debug=False, daemonize=True, args=[], skip_job_scheduler=False, port=None):
+def start(debug=False, daemonize=True, args=[], skip_job_scheduler=False, port=None, auto_initialize=True):
     """
     Start the kalite server as a daemon
 
@@ -503,7 +503,8 @@ def start(debug=False, daemonize=True, args=[], skip_job_scheduler=False, port=N
         with open(PID_FILE, 'w') as f:
             f.write("%d\n%d" % (os.getpid(), port))
 
-    manage('initialize_kalite')
+    if auto_initialize:
+        manage('initialize_kalite')
 
     if not daemonize:
         print_server_address(port)

--- a/kalite/cli.py
+++ b/kalite/cli.py
@@ -353,13 +353,14 @@ def get_pid():
         # Probably a mis-configured KA Lite
         raise NotRunning(STATUS_SERVER_CONFIGURATION_ERROR)
 
+    served_pid = -1
     try:
-        pid = int(response.read())
+        served_pid = int(response.read())
     except ValueError:
         # Not a valid INT was returned, so probably not KA Lite
         raise NotRunning(STATUS_UNKNOWN_INSTANCE)
 
-    if pid == pid:
+    if pid == served_pid:
         return pid, LISTEN_ADDRESS, listen_port  # Correct PID !
     else:
         # Not the correct PID, maybe KA Lite is running from somewhere else!

--- a/kalite/cli.py
+++ b/kalite/cli.py
@@ -293,7 +293,7 @@ def get_pid():
     TODO: This function has for historical reasons maintained to try to get
     the PID of a KA Lite server without a PID file running on the same port.
     The behavior is to make an HTTP request for the PID on a certain port.
-    This behavior is stupid, because a KA lite process may just be part of a
+    This behavior is stupid, because a KA Lite process may just be part of a
     process pool, so it won't be able to tell the correct PID for sure,
     anyways.
     The behavior is also quite redundant given that `kalite start` should always
@@ -436,7 +436,6 @@ def start(debug=False, daemonize=True, args=[], skip_job_scheduler=False, port=N
     :param daemonize: Default True, will run in foreground if False
     :param skip_job_scheduler: Skips running the job scheduler in a separate thread
     """
-    # TODO: Do we want to fail if running as root?
 
     port = int(port or DEFAULT_LISTEN_PORT)
 
@@ -581,7 +580,7 @@ def stop(args=[], sys_exit=True):
                 killed_with_force = True
             except ValueError:
                 sys.stderr.write("Could not find PID in .pid file\n")
-            except OSError:  # TODO: More specific exception handling
+            except OSError:
                 sys.stderr.write("Could not read .pid file\n")
             if not killed_with_force:
                 if sys_exit:

--- a/kalite/distributed/management/commands/initialize_kalite.py
+++ b/kalite/distributed/management/commands/initialize_kalite.py
@@ -1,7 +1,7 @@
 """
 This is a command-line tool to execute functions helpful to testing.
 """
-from django.conf import settings
+import logging
 
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
@@ -9,7 +9,7 @@ from django.db import DatabaseError
 
 from fle_utils.config.models import Settings
 
-logging = settings.LOG
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -32,7 +32,7 @@ class Command(BaseCommand):
         except (DatabaseError, AssertionError):
             from django import db
             db.close_connection()  # So that the database file is free.
-            logging.info("Setting up KA Lite; this may take a few minutes; please wait!\n")
+            logger.info("Setting up KA Lite; this may take a few minutes; please wait!\n")
             call_command("setup", interactive=False)
             # Double check the setup process worked ok.
             assert Settings.get("database_version") == VERSION, "There was an error configuring the server. Please report the output of this command to Learning Equality."

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -17,7 +17,6 @@ import shutil
 import sys
 import tempfile
 import subprocess
-import warnings
 
 from distutils import spawn
 from annoying.functions import get_object_or_None
@@ -72,25 +71,6 @@ def raw_input_password():
             continue
         break
     return password
-
-
-def clean_pyc(path):
-    """Delete all *pyc files recursively in a path"""
-    if not os.access(path, os.W_OK):
-        warnings.warn(
-            "{0} is not writable so cannot delete stale *pyc files".format(path))
-        return
-    print("Cleaning *pyc files (if writable) from: {0}".format(path))
-    for root, __dirs, files in os.walk(path):
-        pyc_files = filter(
-            lambda filename: filename.endswith(".pyc"), files)
-        py_files = set(
-            filter(lambda filename: filename.endswith(".py"), files))
-        excess_pyc_files = filter(
-            lambda pyc_filename: pyc_filename[:-1] not in py_files, pyc_files)
-        for excess_pyc_file in excess_pyc_files:
-            full_path = os.path.join(root, excess_pyc_file)
-            os.remove(full_path)
 
 
 def validate_username(username):

--- a/kalite/distributed/management/commands/setup.py
+++ b/kalite/distributed/management/commands/setup.py
@@ -49,13 +49,16 @@ PRESEED_DIR = os.path.join(kalite.ROOT_DATA_PATH, "preseed")
 PRESEED_CONTENT_PACK_MASK = re.compile(r"contentpack.*\.(?P<lang>[a-z]{2,}).zip")
 
 
+logger = logging.getLogger(__name__)
+
+
 def raw_input_yn(prompt):
     ans = ""
     while True:
         ans = raw_input("%s (yes or no) " % prompt.strip()).lower()
         if ans in ["yes", "no"]:
             break
-        logging.warning("Please answer yes or no.\n")
+        logger.warning("Please answer yes or no.\n")
     return ans == "yes"
 
 
@@ -63,11 +66,11 @@ def raw_input_password():
     while True:
         password = getpass.getpass("Password: ")
         if not password:
-            logging.error("\tError: password must not be blank.\n")
+            logger.error("\tError: password must not be blank.\n")
             continue
 
         elif password != getpass.getpass("Password (again): "):
-            logging.error("\tError: passwords did not match.\n")
+            logger.error("\tError: passwords did not match.\n")
             continue
         break
     return password
@@ -91,7 +94,7 @@ def get_username(username):
         username = raw_input("Username (leave blank to use '%s'): " %
                              get_clean_default_username()) or get_clean_default_username()
         if not validate_username(username):
-            logging.error(
+            logger.error(
                 "\tError: Username must contain only letters, digits, and underscores, and start with a letter.\n")
 
     return username
@@ -108,7 +111,7 @@ def get_hostname_and_description(hostname=None, description=None):
             "" if not default_hostname else (" (or, press Enter to use '%s')" % get_host_name()))
         hostname = raw_input(prompt) or default_hostname
         if not hostname:
-            logging.error("\tError: hostname must not be empty.\n")
+            logger.error("\tError: hostname must not be empty.\n")
         else:
             break
 
@@ -146,7 +149,7 @@ def get_assessment_items_filename():
     if not filename:
         filename = recommended_filename
     while not validate_filename(filename):
-        logging.error(
+        logger.error(
             "Error: couldn't open the specified file: \"%s\"\n" % filename)
         filename = raw_input(prompt)
 
@@ -156,7 +159,7 @@ def get_assessment_items_filename():
 def detect_content_packs(options):
 
     if settings.RUNNING_IN_CI:  # skip if we're running on Travis
-        logging.warning("Running in CI; skipping content pack download.")
+        logger.warning("Running in CI; skipping content pack download.")
         return
 
     preseeded_content_packs = False
@@ -175,18 +178,25 @@ def detect_content_packs(options):
 
     # skip if we're not running in interactive mode (and it wasn't forced)
     if not options['interactive']:
-        logging.warning(
+        logger.warning(
             "Not running in interactive mode; skipping content pack download.")
         return
 
-    print(
-        "\nIn order to access many of the available exercises, you need to load a content pack for the latest version.")
-    print(
-        "If you have an Internet connection, you can download the needed package. Warning: this may take a long time!")
-    print(
-        "If you have already downloaded the content pack, you can specify the location of the file in the next step.")
-    print("Otherwise, we will download it from {url}.".format(
-        url=CONTENTPACK_URL))
+    logger.info(
+        "\nIn order to access many of the available exercises, you need to "
+        "load a content pack for the latest version."
+        "\n"
+        "If you have an Internet connection, you can download the needed "
+        "file. Warning: this may take a long time!"
+    )
+    logger.info(
+        "\n"
+        "If you have already downloaded the content pack, you can specify the "
+        "location of the file in the next step."
+    )
+    logger.info(
+        "Otherwise, we will download it from {url}.".format(url=CONTENTPACK_URL)
+    )
 
     if raw_input_yn("Do you wish to download and install the content pack now?"):
         ass_item_filename = CONTENTPACK_URL
@@ -199,7 +209,7 @@ def detect_content_packs(options):
         retrieval_method = "local"
 
     if not ass_item_filename:
-        logging.warning(
+        logger.warning(
             "No content pack given. You will need to download and install it later.")
     else:
         call_command("retrievecontentpack", retrieval_method,
@@ -259,18 +269,22 @@ class Command(BaseCommand):
             options["hostname"] = options["hostname"] or get_host_name()
 
         # blank allows ansible scripts to dump errors cleanly.
-        print("                                     ")
-        print("   _   __  ___    _     _ _          ")
-        print("  | | / / / _ \  | |   (_) |         ")
-        print("  | |/ / / /_\ \ | |    _| |_ ___    ")
-        print("  |    \ |  _  | | |   | | __/ _ \   ")
-        print("  | |\  \| | | | | |___| | ||  __/   ")
-        print("  \_| \_/\_| |_/ \_____/_|\__\___|   ")
-        print("                                     ")
-        print("https://learningequality.org/ka-lite/")
-        print("                                     ")
-        print("         version %s" % VERSION)
-        print("                                     ")
+        logger.info(
+            "                                     \n"
+            "   _   __  ___    _     _ _          \n"
+            "  | | / / / _ \  | |   (_) |         \n"
+            "  | |/ / / /_\ \ | |    _| |_ ___    \n"
+            "  |    \ |  _  | | |   | | __/ _ \   \n"
+            "  | |\  \| | | | | |___| | ||  __/   \n"
+            "  \_| \_/\_| |_/ \_____/_|\__\___|   \n"
+            "                                     \n"
+            "https://learningequality.org/ka-lite/\n"
+            "                                     \n"
+            "         version {version:s}\n"
+            "                                     ".format(
+                version=VERSION
+            )
+        )
 
         if sys.version_info < (2, 7):
             raise CommandError(
@@ -279,28 +293,26 @@ class Command(BaseCommand):
             raise CommandError(
                 "Your Python version is: %d.%d.%d -- which is not supported. Please use the Python 2.7 series or wait for Learning Equality to release Kolibri.\n" % sys.version_info[:3])
         elif sys.version_info < (2, 7, 6):
-            logging.warning(
+            logger.warning(
                 "It's recommended that you install Python version 2.7.6. Your version is: %d.%d.%d\n" % sys.version_info[:3])
 
         if options["interactive"]:
-            print(
-                "--------------------------------------------------------------------------------")
-            print(
-                "This script will configure the database and prepare it for use.")
-            print(
-                "--------------------------------------------------------------------------------")
+            logger.info(
+                "--------------------------------------------------------------------------------\n"
+                "This script will configure the database and prepare it for use.\n"
+                "--------------------------------------------------------------------------------\n"
+            )
             raw_input("Press [enter] to continue...")
 
         # Assuming uid '0' is always root
         if not is_windows() and hasattr(os, "getuid") and os.getuid() == 0:
-            print(
-                "-------------------------------------------------------------------")
-            print("WARNING: You are installing KA-Lite as root user!")
-            print(
-                "\tInstalling as root may cause some permission problems while running")
-            print("\tas a normal user in the future.")
-            print(
-                "-------------------------------------------------------------------")
+            logger.info(
+                "-------------------------------------------------------------------\n"
+                "WARNING: You are installing KA-Lite as root user!\n"
+                "    Installing as root may cause some permission problems while running\n"
+                "    as a normal user in the future.\n"
+                "-------------------------------------------------------------------\n"
+            )
             if options["interactive"]:
                 if not raw_input_yn("Do you wish to continue and install it as root?"):
                     raise CommandError("Aborting script.\n")
@@ -327,23 +339,25 @@ class Command(BaseCommand):
                 # We found an existing database file.  By default,
                 #   we will upgrade it; users really need to work hard
                 #   to delete the file (but it's possible, which is nice).
-                print(
-                    "-------------------------------------------------------------------")
-                print("WARNING: Database file already exists!")
-                print(
-                    "-------------------------------------------------------------------")
+                logger.info(
+                    "-------------------------------------------------------------------\n"
+                    "WARNING: Database file already exists!\n"
+                    "-------------------------------------------------------------------"
+                )
                 if not options["interactive"] \
                    or raw_input_yn("Keep database file and upgrade to KA Lite version %s? " % VERSION) \
                    or not raw_input_yn("Remove database file '%s' now? " % database_file) \
                    or not raw_input_yn("WARNING: all data will be lost!  Are you sure? "):
                     install_clean = False
-                    print("Upgrading database to KA Lite version %s" % VERSION)
+                    logger.info("Upgrading database to KA Lite version %s" % VERSION)
                 else:
                     install_clean = True
-                    print("OK.  We will run a clean install; ")
+                    logger.info("OK.  We will run a clean install; ")
                     # After all, don't delete--just move.
-                    print(
-                        "the database file will be moved to a deletable location.")
+                    logger.info(
+                        "the database file will be moved to a deletable "
+                        "location."
+                    )
 
         if not install_clean and not database_file:
             # Make sure that, for non-sqlite installs, the database exists.
@@ -353,12 +367,11 @@ class Command(BaseCommand):
         # Do all input at once, at the beginning
         if install_clean and options["interactive"]:
             if not options["username"] or not options["password"]:
-                print(
-                    "Please choose a username and password for the admin account on this device.")
-                print(
-                    "\tYou must remember this login information, as you will need")
-                print(
-                    "\tto enter it to administer this installation of KA Lite.")
+                logger.info(
+                    "Please choose a username and password for the admin account on this device.\n"
+                    "    You must remember this login information, as you will need\n"
+                    "    to enter it to administer this installation of KA Lite."
+                )
             (username, password) = get_username_password(
                 options["username"], options["password"])
             email = options["email"]
@@ -389,18 +402,28 @@ class Command(BaseCommand):
             if not settings.DB_TEMPLATE_DEFAULT or database_file != settings.DB_TEMPLATE_DEFAULT:
                 # This is an overwrite install; destroy the old db
                 dest_file = tempfile.mkstemp()[1]
-                print(
-                    "(Re)moving database file to temp location, starting clean install. Recovery location: %s" % dest_file)
+                logger.info(
+                    "(Re)moving database file to temp location, starting "
+                    "clean install. Recovery location: {recovery:s}".format(
+                        recovery=dest_file
+                    )
+                )
                 shutil.move(database_file, dest_file)
 
         if settings.DB_TEMPLATE_DEFAULT and not database_exists and os.path.exists(settings.DB_TEMPLATE_DEFAULT):
-            print("Copying database file from {0} to {1}".format(
-                settings.DB_TEMPLATE_DEFAULT, settings.DEFAULT_DATABASE_PATH))
+            logger.info(
+                "Copying database file from {0} to {1}".format(
+                    settings.DB_TEMPLATE_DEFAULT,
+                    settings.DEFAULT_DATABASE_PATH
+                )
+            )
             shutil.copy(
                 settings.DB_TEMPLATE_DEFAULT, settings.DEFAULT_DATABASE_PATH)
         else:
-            print(
-                "Baking a fresh database from scratch or upgrading existing database.")
+            logger.info(
+                "Baking a fresh database from scratch or upgrading existing "
+                "database."
+            )
             call_command(
                 "syncdb", interactive=False, verbosity=options.get("verbosity"))
             call_command(
@@ -415,7 +438,7 @@ class Command(BaseCommand):
         # is required for tests, and does not apply to the central server.
         if options.get("no-assessment-items", False):
 
-            logging.warning(
+            logger.warning(
                 "Skipping content pack downloading and configuration.")
 
         else:
@@ -447,7 +470,7 @@ class Command(BaseCommand):
             admin.save()
 
         # Now deploy the static files
-        logging.info("Copying static media...")
+        logger.info("Copying static media...")
         ensure_dir(settings.STATIC_ROOT)
 
         call_command("collectstatic", interactive=False, verbosity=0, clear=True)
@@ -463,22 +486,34 @@ class Command(BaseCommand):
                 start_script_path = None
 
             # Run annotate_content_items, on the distributed server.
-            print("Annotating availability of all content, checking for content in this directory: (%s)" %
-                  settings.CONTENT_ROOT)
+            logger.info(
+                "Annotating availability of all content, checking for content "
+                "in this directory: {content_root:s}".format(
+                    content_root=settings.CONTENT_ROOT
+                )
+            )
             try:
                 call_command("annotate_content_items")
             except OperationalError:
                 pass
 
             # done; notify the user.
-            print(
-                "\nCONGRATULATIONS! You've finished setting up the KA Lite server software.")
-            print(
-                "You can now start KA Lite with the following command:\n\n\t%s start\n\n" % start_script_path)
+            logger.info(
+                "\nCONGRATULATIONS! You've finished setting up the KA Lite "
+                "server software."
+            )
+            logger.info(
+                "You can now start KA Lite with the following command:"
+                "\n\n"
+                "    {kalite_cmd} start"
+                "\n\n".format(
+                    kalite_cmd=start_script_path
+                )
+            )
 
             if options['interactive'] and start_script_path:
                 if raw_input_yn("Do you wish to start the server now?"):
-                    print("Running {0} start".format(start_script_path))
+                    logger.info("Running {0} start".format(start_script_path))
                     p = subprocess.Popen(
                         [start_script_path, "start"], env=os.environ)
                     p.wait()

--- a/kalite/distributed/tests/__init__.py
+++ b/kalite/distributed/tests/__init__.py
@@ -1,2 +1,3 @@
+from cli_tests import *
 from url_tests import *
 from browser_tests import *

--- a/kalite/distributed/tests/cli_tests.py
+++ b/kalite/distributed/tests/cli_tests.py
@@ -1,0 +1,45 @@
+from cherrypy import engine
+from django.test import TestCase
+
+from kalite.testing.base import KALiteTestCase
+from kalite import cli
+import time
+from thread import start_new_thread
+
+
+class CLITestCase(KALiteTestCase):
+    """
+    Quick and dirty tests to ensure that we have a functional CLI
+    """
+    
+    def test_manage(self):
+        """
+        Run the `manage videoscan` command synchronously
+        """
+        cli.manage("videoscan")
+
+    def test_thread_manage(self):
+        """
+        Run the `manage help` command as thread
+        """
+        cli.manage("help", as_thread=True)
+
+    def test_start(self):
+        def cherry_py_stop_thread():
+            time.sleep(4)
+            engine.exit()
+
+        # Because threads use the database with transactions, we can't run
+        # the server in its own thread. Instead, we run `cli.start` from the
+        # main thread and ask cherrypy to stop from a separate countdown
+        # thread.
+        start_new_thread(cherry_py_stop_thread, ())
+        cli.start(
+            debug=False,
+            daemonize=False,
+            args=[],
+            skip_job_scheduler=True,
+            port=8009,
+            auto_initialize=True
+        )
+        time.sleep(2)

--- a/kalite/distributed/tests/cli_tests.py
+++ b/kalite/distributed/tests/cli_tests.py
@@ -1,13 +1,15 @@
-from cherrypy import engine
-from django.test import TestCase
-
-from kalite.testing.base import KALiteTestCase
-from kalite import cli
 import time
+
+
+from django.test import TestCase
 from thread import start_new_thread
 
+from cherrypy import engine
 
-class CLITestCase(KALiteTestCase):
+from kalite import cli
+
+
+class CLITestCase(TestCase):
     """
     Quick and dirty tests to ensure that we have a functional CLI
     """
@@ -40,6 +42,5 @@ class CLITestCase(KALiteTestCase):
             args=[],
             skip_job_scheduler=True,
             port=8009,
-            auto_initialize=True
         )
         time.sleep(2)

--- a/kalite/distributed/tests/cli_tests.py
+++ b/kalite/distributed/tests/cli_tests.py
@@ -28,7 +28,7 @@ class CLITestCase(TestCase):
 
     def test_start(self):
         def cherry_py_stop_thread():
-            time.sleep(4)
+            time.sleep(10)
             engine.exit()
 
         # Because threads use the database with transactions, we can't run

--- a/kalite/packages/bundled/README.django.md
+++ b/kalite/packages/bundled/README.django.md
@@ -1,3 +1,9 @@
+Removed closing of pipes in daemon mode because of Windows log file issues:
+
+https://github.com/learningequality/ka-lite/pull/5364/files
+
+
+
 ## BEGIN(djallado): Changes in makemessages.py and trans_real.py to generate handlebars templates in djangojs.pot file.
 diff --git a/python-packages/django/core/management/commands/makemessages.py b/python-packages/django/core/management/commands/makemessages.py
 index 2fd5bda..526026b 100644

--- a/kalite/settings/base.py
+++ b/kalite/settings/base.py
@@ -19,6 +19,20 @@ DEBUG = False
 TEMPLATE_DEBUG = DEBUG
 
 
+###################################################
+# USER DATA
+###################################################
+
+USER_DATA_ROOT = os.environ.get(
+    "KALITE_HOME",
+    os.path.join(os.path.expanduser("~"), ".kalite")
+)
+
+# Ensure that path exists
+if not os.path.exists(USER_DATA_ROOT):
+    os.mkdir(USER_DATA_ROOT)
+
+
 ##############################
 # Basic setup of logging
 ##############################
@@ -29,6 +43,8 @@ LOGGING_LEVEL = logging.INFO
 
 # We should use local module level logging.getLogger
 LOG = logging.getLogger("kalite")
+
+SERVER_LOG = os.path.join(USER_DATA_ROOT, "server.log")
 
 LOGGING = {
     'version': 1,
@@ -43,6 +59,9 @@ LOGGING = {
         'standard': {
             'format': '[%(levelname)s] [%(asctime)s] %(name)s: %(message)s'
         },
+        'no_format': {
+            'format': '%(message)s'
+        },
     },
     'handlers': {
         'null': {
@@ -53,6 +72,12 @@ LOGGING = {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'standard',
+            'stream': sys.stdout,
+        },
+        'console_no_format': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'no_format',
             'stream': sys.stdout,
         },
     },
@@ -69,6 +94,11 @@ LOGGING = {
         },
         'kalite': {
             'handlers': ['console'],
+            'level': LOGGING_LEVEL,
+            'propagate': False,
+        },
+        'kalite.distributed.management.commands': {
+            'handlers': ['console_no_format'],
             'level': LOGGING_LEVEL,
             'propagate': False,
         },
@@ -136,21 +166,12 @@ _data_path = ROOT_DATA_PATH
 
 
 ###################################################
-# USER DATA
+# USER DATA SUB-DIRECTORIES
 ###################################################
 #
 # This is related to data that can be modified by
 # the user running kalite and should be in a user-data
 # storage place.
-
-USER_DATA_ROOT = os.environ.get(
-    "KALITE_HOME",
-    os.path.join(os.path.expanduser("~"), ".kalite")
-)
-
-# Ensure that path exists
-if not os.path.exists(USER_DATA_ROOT):
-    os.mkdir(USER_DATA_ROOT)
 
 USER_WRITABLE_LOCALE_DIR = os.path.join(USER_DATA_ROOT, 'locale')
 KALITE_APP_LOCALE_DIR = os.path.join(USER_DATA_ROOT, 'locale')


### PR DESCRIPTION
Taking over from #5438

## Summary

This also (once again) prints the server address at command line ( a regression from #5364 )

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Has documentation been written/updated?
- [x] Have you written release notes for the upcoming release?

## Reviewer guidance

Let me know if there are problems in this approach. I don't see much of a difference, except I forced ALL of the loggers in `kalite.distributed.management.commands` to user a logger WITHOUT formatting, expecting their outputs to be generally targeted for command line displaying.

However, they are also subject to be printed in the server log.

## Issues addressed

#5408
