### PR TITLE
Update MacOS uninstall documentation

### DIFF
--- a/docs/installguide/uninstall.rst
+++ b/docs/installguide/uninstall.rst
@@ -26,7 +26,7 @@ Option 2:
 1. Open Terminal.
 2. Type ``bash /Applications/KA-Lite/KA-Lite_Uninstall.tool`` in your Terminal and press Enter.
 3. It will confirm if you want to keep or delete your KA Lite data folder.
-4. To confirm the uninstallation it will ask for you password, type your password and press enter.
+4. Another dialog will appear asking your ``Password``, type your password then click on ``Ok`` button.
 
 
 Linux: Debian/Ubuntu

--- a/docs/installguide/uninstall.rst
+++ b/docs/installguide/uninstall.rst
@@ -13,7 +13,7 @@ _______
 
 Option 1:
 
-1. Launch ``KA-Lite Monitor`` from your ``Applications`` folder.
+1. Launch ``KA-Lite`` from your ``Applications`` folder.
 2. Click on the app icon at the menu bar.
 3. Click on ``Preferences`` in the menu option.
 4. Click the ``Uninstall KA Lite`` from the ``Preferences`` tab.

--- a/docs/installguide/uninstall.rst
+++ b/docs/installguide/uninstall.rst
@@ -45,7 +45,6 @@ __________________
 You can remove KA Lite (when installed from pip or source distribution) with
 ``pip uninstall ka-lite`` or ``pip uninstall ka-lite-static`` (static version).
 
-333
 Removing user data
 __________________
 

--- a/docs/installguide/uninstall.rst
+++ b/docs/installguide/uninstall.rst
@@ -11,21 +11,22 @@ _______
 Mac OSX
 _______
 
-Option 1:
+Uninstallation from user interface
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Launch ``KA-Lite`` from your ``Applications`` folder.
 2. Click on the app icon at the menu bar.
 3. Click on ``Preferences`` in the menu option.
 4. Click the ``Uninstall KA Lite`` from the ``Preferences`` tab.
-5. if you want to delete your KA Lite data folder checked the ``Delete KA Lite data folder`` checkbox.
-6. You will be prompted that ``Are you sure that you want to uninstall the KA Lite application?``, just click on ``OK`` button.
-7. Another dialog will appear asking your ``Password``, type your password then click on ``Ok`` button.
+5. A confirmation dialogue will appear, followed by a dialogue asking for your local administrator password. After confirming these steps, KA Lite will be uninstalled.
+6. Another dialog will appear asking your ``Password``, type your password then click on ``Ok`` button.
 
-Option 2:
+Uninstallation from command line
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 1. Open Terminal.
 2. Type ``bash /Applications/KA-Lite/KA-Lite_Uninstall.tool`` in your Terminal and press Enter.
-3. It will confirm if you want to keep or delete your KA Lite data folder.
+3. You will be prompted to choose to keep or delete your data folder.
 4. Another dialog will appear asking your ``Password``, type your password then click on ``Ok`` button.
 
 
@@ -45,7 +46,7 @@ __________________
 You can remove KA Lite (when installed from pip or source distribution) with
 ``pip uninstall ka-lite`` or ``pip uninstall ka-lite-static`` (static version).
 
-
+333
 Removing user data
 __________________
 

--- a/docs/installguide/uninstall.rst
+++ b/docs/installguide/uninstall.rst
@@ -19,7 +19,6 @@ Uninstallation from user interface
 3. Click on ``Preferences`` in the menu option.
 4. Click the ``Uninstall KA Lite`` from the ``Preferences`` tab.
 5. A confirmation dialogue will appear, followed by a dialogue asking for your local administrator password. After confirming these steps, KA Lite will be uninstalled.
-6. Another dialog will appear asking your ``Password``, type your password then click on ``Ok`` button.
 
 Uninstallation from command line
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/installguide/uninstall.rst
+++ b/docs/installguide/uninstall.rst
@@ -11,14 +11,22 @@ _______
 Mac OSX
 _______
 
+Option 1:
+
 1. Launch ``KA-Lite Monitor`` from your ``Applications`` folder.
 2. Click on the app icon at the menu bar.
 3. Click on ``Preferences`` in the menu option.
-4. Click the ``Reset App`` from the ``Advanced`` tab.
-5. You will be prompted that "This will reset app. Are you sure?", just click on ``OK`` button.
-6. Another dialog will appear asking your ``Password``, type your password then click on ``Ok`` button.
-7. Quit the ``KA-Lite Monitor`` app (do not click the ``Apply`` button!).
-8. Move the ``KA-Lite Monitor`` app to ``Trash``.
+4. Click the ``Uninstall KA Lite`` from the ``Preferences`` tab.
+5. if you want to delete your KA Lite data folder checked the ``Delete KA Lite data folder`` checkbox.
+6. You will be prompted that ``Are you sure that you want to uninstall the KA Lite application?``, just click on ``OK`` button.
+7. Another dialog will appear asking your ``Password``, type your password then click on ``Ok`` button.
+
+Option 2:
+
+1. Open Terminal.
+2. Type ``bash /Applications/KA-Lite/KA-Lite_Uninstall.tool`` in your Terminal and press Enter.
+3. It will confirm if you want to keep or delete your KA Lite data folder.
+4. To confirm the uninstallation it will ask for you password, type your password and press enter.
 
 
 Linux: Debian/Ubuntu


### PR DESCRIPTION
## Summary

This will update the macOS uninstall documentation. This include two option how to uninstall the KA Lite in your macOS via `KA Lite Preferences`  or `KA-Lite_Uninstall.tool`

## Issues addressed
https://github.com/learningequality/ka-lite-installers/issues/446
#5440

