### PR TITLE
Re-arrange CI test build steps

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,18 +10,17 @@ dependencies:
   override:
     - pip install -r requirements_sphinx.txt
     - pip install -e .
-
-test:
-  pre:
+    - make assets
+    - make docs
     - wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v0.10.0/geckodriver-v0.10.0-linux64.tar.gz
     - gunzip -c geckodriver.tar.gz | tar xopf -
     - chmod +x geckodriver
     - sudo mv geckodriver /home/ubuntu/bin
+
+test:
+  pre:
     - export PATH="$PATH:/home/ubuntu/bin"
   override:
-    - make assets:
-        parallel: true
-    - make docs
     - kalite start --traceback -v2
     - sleep 6s  # Necessary for server to be ready
     - kalite status


### PR DESCRIPTION
Move a bunch of dependency setup that affects all containers to the dependency build so the build fails when any of these steps fail

Before, our builds would continue even though JS asset building had failed. Which created a lot of confusing errors in Selenium tests.