### PR TITLE
Set max_limit to 0 in order to fetch all users.

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -12,6 +12,11 @@ to read the release notes.
 0.17.4 (unreleased)
 -------------------
 
+Bug fixes
+^^^^^^^^^
+
+* Simplified login is now working when there are 1,000 or more users registered in a facility. :url-issue:`5523`
+
 Developers
 ^^^^^^^^^^
 

--- a/kalite/facility/api_resources.py
+++ b/kalite/facility/api_resources.py
@@ -72,6 +72,7 @@ class FacilityUserResource(ModelResource):
             'facility': ALL_WITH_RELATIONS,
             'is_teacher': ['exact']
         }
+        max_limit = 0
         exclude = ["password"]
 
     def prepend_urls(self):


### PR DESCRIPTION
## Summary

Reference: https://stackoverflow.com/a/18477897

FYI @benjaoming @Aypak 

It seems that tastypie automatically limits the API request to `1000` and I have no idea why do they do that.

I was not able to replicate the issue when there are 1,000 users registered in a facility. But I think this fixes the issue since it is already returning the number of expected users

`{"meta": {"limit": 0, "offset": 0, "total_count": 1011}`

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [ ] Has documentation been written/updated?
- [ ] Have you written release notes for the upcoming release?

## Issues addressed
#5523 