### PR TITLE
Make video/thumbnail download more robust

### DIFF
--- a/docs/developer_docs/behave_testing.rst
+++ b/docs/developer_docs/behave_testing.rst
@@ -1,3 +1,5 @@
+.. _bdd:
+
 Behavior-Driven Integration Tests
 =================================
 

--- a/docs/developer_docs/environment.rst
+++ b/docs/developer_docs/environment.rst
@@ -1,7 +1,7 @@
 .. _development-environment:
 
-Setting up your development environment
-=======================================
+Getting started
+===============
 
 .. warning::  These directions may be out of date! This page needs to be consolidated with the `Getting Started page on our wiki <https://github.com/learningequality/ka-lite/wiki/Getting-started>`_.
 
@@ -69,10 +69,10 @@ __________
 You can install KA Lite in its very own separate environment that does not
 interfere with other Python software on your machine like this::
 
-    $> pip install virtualenv virtualenvwrapper
-    $> mkvirtualenv my-kalite-env
-    $> workon my-kalite-env
-    $> pip install ka-lite
+    pip install virtualenv virtualenvwrapper
+    mkvirtualenv my-kalite-env
+    workon my-kalite-env
+    pip install ka-lite
 
 
 Running tests
@@ -83,3 +83,20 @@ On Circle CI, we run Selenium 2.53.6 because it works in their environment. Howe
 for more recent versions of Firefox, you need to upgrade Selenium::
 
     pip install selenium\<3.5 --upgrade
+
+To run all of the tests (this is slow)::
+
+    kalite manage test
+
+To skip BDD tests (because they are slow)::
+
+    kalite manage test --no-bdd
+
+To run a specific test (not a BDD test), add an argument ``<app>.<TestClass>``::
+
+    kalite manage test updates.TestDownload --no-bdd
+
+To run a specific item from :ref:`bdd`, use ``<app>.<feature_module_name>``::
+
+    kalite manage test distributed.content_rating --bdd-only
+

--- a/docs/developer_docs/index.rst
+++ b/docs/developer_docs/index.rst
@@ -4,7 +4,7 @@ Developer Docs
 Useful stuff our devs think that the rest of our devs ought to know about.
 
 .. toctree::
-    Setting up your development environment <environment>
+    Getting started <environment>
     Front-End Code <front_end_code>
     Javascript Unit Tests <javascript_testing>
     Behavior-Driven Integration Tests <behave_testing>

--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -15,12 +15,18 @@ to read the release notes.
 Bug fixes
 ^^^^^^^^^
 
+* Video download retry upon connection timeouts/errors :url-issue:`5528`
 * Simplified login is now working when there are 1,000 or more users registered in a facility. :url-issue:`5523`
 
 Developers
 ^^^^^^^^^^
 
  * Do not use `npm clean`, now requires npm>=5 for building on unclean systems :url-issue:`5519`
+
+Contents
+^^^^^^^^
+
+ * Resized video torrent set for English rebuilt with missing videos
 
 
 0.17.3

--- a/docs/usermanual/userman_admin.rst
+++ b/docs/usermanual/userman_admin.rst
@@ -674,7 +674,7 @@ _________________
   In order to keep local data in the ``UserLog`` model, detailing usage, you can choose the number of ``UserLog`` objects that you wish to retain. These objects are not sync'ed.
 
 
-Online Synchronization
+Online synchronization
 ______________________
 
 * ``USER_LOG_SUMMARY_FREQUENCY = <desired frequency (number, amount of time)>``
@@ -687,6 +687,15 @@ ______________________
   This setting is how many such records we keep on your local server, for display.
   When you log in to our online server, you will see a *full* history of these records.
 
+
+Other settings
+______________
+
+* ``KALITE_DOWNLOAD_RETRIES = <integer>``
+  ``(default = 5)``
+  If you are trying to download videos with a very unstable connection, this
+  setting will increase the number of retries for individual video downloads.
+  The grace period between each attempt automatically increases.
 
 Environment variables
 _____________________

--- a/kalite/packages/bundled/fle_utils/internet/download.py
+++ b/kalite/packages/bundled/fle_utils/internet/download.py
@@ -10,12 +10,6 @@ from requests.packages.urllib3.util.retry import Retry
 socket.setdefaulttimeout(20)
 
 
-class DownloadCancelled(Exception):
-
-    def __str__(self):
-        return "Download has been cancelled"
-
-
 class URLNotFound(Exception):
     pass
 

--- a/kalite/packages/bundled/fle_utils/internet/download.py
+++ b/kalite/packages/bundled/fle_utils/internet/download.py
@@ -1,9 +1,7 @@
-import os
 import requests
 import socket
 import sys
 import tempfile
-from requests.utils import default_user_agent
 
 socket.setdefaulttimeout(20)
 
@@ -28,28 +26,13 @@ def callback_percent_proxy(callback, start_percent=0, end_percent=100):
     return callback_percent_proxy_inner_fn
 
 
-def _reporthook(numblocks, blocksize, filesize, url=None):
-    base = os.path.basename(url)
-    if filesize <= 0:
-        filesize = blocksize
-    try:
-        percent = min((numblocks * blocksize * 100) / filesize, 100)
-    except:
-        percent = 100
-    if numblocks != 0:
-        sys.stdout.write("\b" * 40)
-    sys.stdout.write("%-36s%3d%%" % (base, percent))
-    if percent == 100:
-        sys.stdout.write("\n")
-
-
 def _nullhook(*args, **kwargs):
     pass
 
 
 def download_file(url, dst=None, callback=None):
     if sys.stdout.isatty():
-        callback = callback or _reporthook
+        callback = callback or _nullhook
     else:
         callback = callback or _nullhook
     dst = dst or tempfile.mkstemp()[1]

--- a/kalite/packages/bundled/fle_utils/internet/download.py
+++ b/kalite/packages/bundled/fle_utils/internet/download.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import socket
 import sys
@@ -71,4 +72,12 @@ def download_file(url, dst=None, callback=None, max_retries=5):
                     total_size = float(response.headers['content-length'])
                     fraction = min(float(bytes_fetched) / total_size, 1.0)
                 callback(fraction)
+        # Verify file existence
+        if (
+            not os.path.isfile(dst) or
+            "content-length" not in response.headers or
+            not os.path.getsize(dst) == int(response.headers['content-length'])
+        ):
+            raise URLNotFound("URL was not found, tried: {}".format(url))
+
     return response

--- a/kalite/packages/bundled/fle_utils/videos.py
+++ b/kalite/packages/bundled/fle_utils/videos.py
@@ -1,71 +1,7 @@
 """
+Legacy module, do not use
 """
-import glob
-import logging
-import os
-import socket
 
-from general import ensure_dir
-from internet.download import callback_percent_proxy, download_file, URLNotFound, DownloadCancelled
-
+# This is used in the Central Server for redirects. 
 OUTSIDE_DOWNLOAD_BASE_URL = "http://s3.amazonaws.com/KA-youtube-converted/"  # needed for redirects
 OUTSIDE_DOWNLOAD_URL = OUTSIDE_DOWNLOAD_BASE_URL + "%s/%s"  # needed for default behavior, below
-
-logger = logging.getLogger(__name__)
-
-
-def download_video(youtube_id, download_path="../content/", download_url=OUTSIDE_DOWNLOAD_URL, format="mp4", callback=None):
-    """Downloads the video file to disk (note: this does NOT invalidate any of the cached html files in KA Lite)"""
-
-    ensure_dir(download_path)
-
-    video_filename = "%(id)s.%(format)s" % {"id": youtube_id, "format": format}
-    thumb_filename = "%(id)s.png" % {"id": youtube_id}
-
-    url = download_url % (video_filename, video_filename)
-    thumb_url = download_url % (video_filename, thumb_filename)
-
-    filepath = os.path.join(download_path, video_filename)
-    thumb_filepath = os.path.join(download_path, thumb_filename)
-
-    try:
-        response = download_file(url, filepath, callback_percent_proxy(callback, end_percent=95))
-        if (
-                not os.path.isfile(filepath) or
-                "content-length" not in response.headers or
-                not os.path.getsize(filepath) == int(response.headers['content-length'])):
-            raise URLNotFound("Video was not found, tried: {}".format(url))
-
-        response = download_file(thumb_url, thumb_filepath, callback_percent_proxy(callback, start_percent=95, end_percent=100))
-        if (
-                not os.path.isfile(thumb_filepath) or
-                "content-length" not in response.headers or
-                not os.path.getsize(thumb_filepath) == int(response.headers['content-length'])):
-            raise URLNotFound("Thumbnail was not found, tried: {}".format(thumb_url))
-
-    except DownloadCancelled:
-        delete_downloaded_files(youtube_id, download_path)
-        raise
-
-    except (socket.timeout, IOError) as e:
-        logging.exception(e)
-        logging.info("Timeout -- Network UnReachable")
-        delete_downloaded_files(youtube_id, download_path)
-        raise
-
-    except Exception as e:
-        logging.exception(e)
-        delete_downloaded_files(youtube_id, download_path)
-        raise
-
-
-def delete_downloaded_files(youtube_id, download_path):
-    files_deleted = 0
-    for filepath in glob.glob(os.path.join(download_path, youtube_id + ".*")):
-        try:
-            os.remove(filepath)
-            files_deleted += 1
-        except OSError:
-            pass
-    if files_deleted:
-        return True

--- a/kalite/packages/bundled/fle_utils/videos.py
+++ b/kalite/packages/bundled/fle_utils/videos.py
@@ -14,7 +14,10 @@ OUTSIDE_DOWNLOAD_URL = OUTSIDE_DOWNLOAD_BASE_URL + "%s/%s"  # needed for default
 logger = logging.getLogger(__name__)
 
 
-def get_outside_video_urls(youtube_id, download_url=OUTSIDE_DOWNLOAD_URL, format="mp4"):
+def download_video(youtube_id, download_path="../content/", download_url=OUTSIDE_DOWNLOAD_URL, format="mp4", callback=None):
+    """Downloads the video file to disk (note: this does NOT invalidate any of the cached html files in KA Lite)"""
+
+    ensure_dir(download_path)
 
     video_filename = "%(id)s.%(format)s" % {"id": youtube_id, "format": format}
     url = download_url % (video_filename, video_filename)
@@ -22,15 +25,6 @@ def get_outside_video_urls(youtube_id, download_url=OUTSIDE_DOWNLOAD_URL, format
     thumb_filename = "%(id)s.png" % {"id": youtube_id}
     thumb_url = download_url % (video_filename, thumb_filename)
 
-    return (url, thumb_url)
-
-
-def download_video(youtube_id, download_path="../content/", download_url=OUTSIDE_DOWNLOAD_URL, format="mp4", callback=None):
-    """Downloads the video file to disk (note: this does NOT invalidate any of the cached html files in KA Lite)"""
-
-    ensure_dir(download_path)
-
-    url, thumb_url = get_outside_video_urls(youtube_id, download_url=download_url, format=format)
     video_filename = "%(id)s.%(format)s" % {"id": youtube_id, "format": format}
     filepath = os.path.join(download_path, video_filename)
 

--- a/kalite/packages/bundled/fle_utils/videos.py
+++ b/kalite/packages/bundled/fle_utils/videos.py
@@ -20,15 +20,12 @@ def download_video(youtube_id, download_path="../content/", download_url=OUTSIDE
     ensure_dir(download_path)
 
     video_filename = "%(id)s.%(format)s" % {"id": youtube_id, "format": format}
-    url = download_url % (video_filename, video_filename)
-
     thumb_filename = "%(id)s.png" % {"id": youtube_id}
+
+    url = download_url % (video_filename, video_filename)
     thumb_url = download_url % (video_filename, thumb_filename)
 
-    video_filename = "%(id)s.%(format)s" % {"id": youtube_id, "format": format}
     filepath = os.path.join(download_path, video_filename)
-
-    thumb_filename = "%(id)s.png" % {"id": youtube_id}
     thumb_filepath = os.path.join(download_path, thumb_filename)
 
     try:

--- a/kalite/testing/base.py
+++ b/kalite/testing/base.py
@@ -183,6 +183,7 @@ def setup_content_db(instance, db):
             available=False,
             kind="Video",
             id="unavail123",
+            youtube_id="unavail123",
             slug="unavail",
             path=instance.content_unavailable_content_path,
             parent=random.choice(instance.content_subsubtopics).pk,

--- a/kalite/testing/base.py
+++ b/kalite/testing/base.py
@@ -66,128 +66,126 @@ def teardown_content_db(instance, db):
 def setup_content_db(instance, db):
 
     # Setup the content.db (defaults to the en version)
-    with Using(db, [Item], with_transaction=False):
-        # Root node
-        instance.content_root = Item.create(
-            title="Khan Academy",
-            description="",
-            available=True,
-            files_complete=0,
-            total_files="1",
-            kind="Topic",
-            parent=None,
-            id="khan",
-            slug="khan",
-            path="khan/",
-            extra_fields="{}",
-            youtube_id=None,
-            remote_size=315846064333,
-            sort_order=0
+    # Root node
+    instance.content_root = Item.create(
+        title="Khan Academy",
+        description="",
+        available=True,
+        files_complete=0,
+        total_files="1",
+        kind="Topic",
+        parent=None,
+        id="khan",
+        slug="khan",
+        path="khan/",
+        extra_fields="{}",
+        youtube_id=None,
+        remote_size=315846064333,
+        sort_order=0
+    )
+    for _i in range(4):
+        slug = "topic{}".format(_i)
+        instance.content_subtopics.append(
+            Item.create(
+                title="Subtopic {}".format(_i),
+                description="A subtopic",
+                available=True,
+                files_complete=0,
+                total_files="4",
+                kind="Topic",
+                parent=instance.content_root,
+                id=slug,
+                slug=slug,
+                path="khan/{}/".format(slug),
+                extra_fields="{}",
+                remote_size=1,
+                sort_order=_i,
+            )
         )
+    
+    # Parts of the content recommendation system currently is hard-coded
+    # to look for 3rd level recommendations only and so will fail if we
+    # don't have this level of lookup
+    for subtopic in instance.content_subtopics:
         for _i in range(4):
-            slug = "topic{}".format(_i)
-            instance.content_subtopics.append(
+            slug = "{}-{}".format(subtopic.id, _i)
+            instance.content_subsubtopics.append(
                 Item.create(
-                    title="Subtopic {}".format(_i),
-                    description="A subtopic",
+                    title="{} Subsubtopic {}".format(subtopic.title, _i),
+                    description="A subsubtopic",
                     available=True,
-                    files_complete=0,
+                    files_complete=4,
                     total_files="4",
                     kind="Topic",
-                    parent=instance.content_root,
+                    parent=subtopic,
                     id=slug,
                     slug=slug,
-                    path="khan/{}/".format(slug),
+                    path="{}{}/".format(subtopic.path, slug),
+                    youtube_id=None,
                     extra_fields="{}",
                     remote_size=1,
                     sort_order=_i,
                 )
             )
-        
-        # Parts of the content recommendation system currently is hard-coded
-        # to look for 3rd level recommendations only and so will fail if we
-        # don't have this level of lookup
-        for subtopic in instance.content_subtopics:
-            for _i in range(4):
-                slug = "{}-{}".format(subtopic.id, _i)
-                instance.content_subsubtopics.append(
-                    Item.create(
-                        title="{} Subsubtopic {}".format(subtopic.title, _i),
-                        description="A subsubtopic",
-                        available=True,
-                        files_complete=4,
-                        total_files="4",
-                        kind="Topic",
-                        parent=subtopic,
-                        id=slug,
-                        slug=slug,
-                        path="{}{}/".format(subtopic.path, slug),
-                        youtube_id=None,
-                        extra_fields="{}",
-                        remote_size=1,
-                        sort_order=_i,
-                    )
-                )
 
-        # We need at least 10 exercises in some of the tests to generate enough
-        # data etc.
-        # ...and we need at least some exercises in each sub-subtopic
-        for parent in instance.content_subsubtopics:
-            # Make former created exercise the prerequisite of the next one
-            prerequisite = None
-            for _i in range(4):
-                slug = "{}-exercise-{}".format(parent.id, _i)
-                extra_fields = {}
-                if prerequisite:
-                    extra_fields['prerequisites'] = [prerequisite.id]
-                new_exercise = Item.create(
-                    title="Exercise {} in {}".format(_i, parent.title),
-                    parent=parent,
-                    description="Solve this",
+    # We need at least 10 exercises in some of the tests to generate enough
+    # data etc.
+    # ...and we need at least some exercises in each sub-subtopic
+    for parent in instance.content_subsubtopics:
+        # Make former created exercise the prerequisite of the next one
+        prerequisite = None
+        for _i in range(4):
+            slug = "{}-exercise-{}".format(parent.id, _i)
+            extra_fields = {}
+            if prerequisite:
+                extra_fields['prerequisites'] = [prerequisite.id]
+            new_exercise = Item.create(
+                title="Exercise {} in {}".format(_i, parent.title),
+                parent=parent,
+                description="Solve this",
+                available=True,
+                kind="Exercise",
+                id=slug,
+                slug=slug,
+                path="{}{}/".format(parent.path, slug),
+                sort_order=_i,
+                **extra_fields
+            )
+            instance.content_exercises.append(new_exercise)
+            prerequisite = new_exercise
+    # Add some videos, too, even though files don't exist
+    for parent in instance.content_subsubtopics:
+        for _i in range(4):
+            slug = "{}-video-{}".format(parent.pk, _i)
+            instance.content_videos.append(
+                Item.create(
+                    title="Video {} in {}".format(_i, parent.title),
+                    parent=random.choice(instance.content_subsubtopics),
+                    description="Watch this",
                     available=True,
-                    kind="Exercise",
+                    kind="Video",
                     id=slug,
                     slug=slug,
                     path="{}{}/".format(parent.path, slug),
-                    sort_order=_i,
-                    **extra_fields
+                    extra_fields={
+                        "subtitle_urls": [],
+                        "content_urls": {"stream": "/foo", "stream_type": "video/mp4"},
+                    },
+                    sort_order=_i
                 )
-                instance.content_exercises.append(new_exercise)
-                prerequisite = new_exercise
-        # Add some videos, too, even though files don't exist
-        for parent in instance.content_subsubtopics:
-            for _i in range(4):
-                slug = "{}-video-{}".format(parent.pk, _i)
-                instance.content_videos.append(
-                    Item.create(
-                        title="Video {} in {}".format(_i, parent.title),
-                        parent=random.choice(instance.content_subsubtopics),
-                        description="Watch this",
-                        available=True,
-                        kind="Video",
-                        id=slug,
-                        slug=slug,
-                        path="{}{}/".format(parent.path, slug),
-                        extra_fields={
-                            "subtitle_urls": [],
-                            "content_urls": {"stream": "/foo", "stream_type": "video/mp4"},
-                        },
-                        sort_order=_i
-                    )
-                )
+            )
 
-    with Using(db, [Item], with_transaction=False):
-        instance.content_unavailable_item = Item.create(
-            title="Unavailable item",
-            description="baz",
-            available=False,
-            kind="Video",
-            id="unavail123",
-            youtube_id="unavail123",
-            slug="unavail",
-            path=instance.content_unavailable_content_path,
-            parent=random.choice(instance.content_subsubtopics).pk,
-        )
+    instance.content_unavailable_item = Item.create(
+        title="Unavailable item",
+        description="baz",
+        available=False,
+        kind="Video",
+        id="unavail123",
+        youtube_id="unavail123",
+        slug="unavail",
+        path=instance.content_unavailable_content_path,
+        parent=random.choice(instance.content_subsubtopics).pk,
+    )
     
     instance.content_available_content_path = random.choice(instance.content_exercises).path
 

--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -59,6 +59,9 @@ class Item(Model):
         kwargs = parse_model_data(kwargs)
         super(Item, self).__init__(*args, **kwargs)
 
+    def __repr__(self):
+        return "{}: {} (id: {})".format(self.kind, self.title, self.id)
+
 
 class AssessmentItem(Model):
     id = CharField(max_length=50)

--- a/kalite/updates/download_track.py
+++ b/kalite/updates/download_track.py
@@ -19,7 +19,7 @@ class VideoQueue(object):
 
     def add_files(self, files, language=None):
         """
-        Add files to the queue - this should be a list of youtube_ids
+        Add files to the queue - this should be a dict {youtube_id: title}
         and optionally, the language of the video.
         """
         files = [{"youtube_id": key, "title": value, "language": language} for key, value in files.items()]

--- a/kalite/updates/management/commands/videodownload.py
+++ b/kalite/updates/management/commands/videodownload.py
@@ -14,9 +14,16 @@ from kalite.updates.management.utils import UpdatesDynamicCommand
 from ...videos import download_video
 from ...download_track import VideoQueue
 from fle_utils import set_process_priority
-from fle_utils.videos import DownloadCancelled, URLNotFound
+from fle_utils.internet.download import URLNotFound
 from fle_utils.chronograph.management.croncommand import CronCommand
 from kalite.topic_tools.content_models import get_video_from_youtube_id, annotate_content_models_by_youtube_id
+
+
+class DownloadCancelled(Exception):
+
+    def __str__(self):
+        return "Download has been cancelled"
+
 
 def scrape_video(youtube_id, format="mp4", force=False, quiet=False, callback=None):
     """
@@ -91,7 +98,7 @@ class Command(UpdatesDynamicCommand, CronCommand):
                 if percent == 100:
                     self.video = {}
 
-        except DownloadCancelled as de:
+        except DownloadCancelled:
             if self.video:
                 self.stdout.write(_("Download cancelled!") + "\n")
 

--- a/kalite/updates/settings.py
+++ b/kalite/updates/settings.py
@@ -1,15 +1,15 @@
 """
-
 New settings pattern
 
 See:
 https://github.com/learningequality/ka-lite/issues/4054
 https://github.com/learningequality/ka-lite/issues/3757
 
-All settings for the updates app should be defined here, they can
-only on django.conf.settings
+All settings for the updates app should be defined here
 """
 import os
 from django.conf import settings
 
 VIDEO_DOWNLOAD_QUEUE_FILE = os.path.join(settings.USER_DATA_ROOT, "videos_to_download.json")
+
+DOWNLOAD_MAX_RETRIES = getattr(settings, "KALITE_DOWNLOAD_RETRIES", 5)

--- a/kalite/updates/tests/__init__.py
+++ b/kalite/updates/tests/__init__.py
@@ -3,3 +3,4 @@ from availability_tests import *
 from base import *
 from class_tests import *
 from regression_tests import *
+from download_tests import *

--- a/kalite/updates/tests/base.py
+++ b/kalite/updates/tests/base.py
@@ -1,4 +1,33 @@
+import random
+
 from kalite.testing.base import KALiteTestCase
+from kalite.topic_tools.content_models import set_database, Item
+from peewee import Using
+
+
+# Some small videos from the content database 2017-11-13
+TEST_YOUTUBE_IDS = ["riXcZT2ICjA", "_7aUxFzTG5w"]
+
+
+@set_database
+def add_test_content_videos(instance, db):
+    
+    youtube_id = random.choice(TEST_YOUTUBE_IDS)
+    
+    with Using(db, [Item], with_transaction=False):
+        real_video = Item.create(
+            title="A real video from KA/Youtube",
+            description="This video exists",
+            available=False,
+            kind="Video",
+            id=youtube_id,
+            youtube_id=youtube_id,
+            slug="youtube-vid",
+            path=instance.content_unavailable_content_path,
+            parent=random.choice(instance.content_subsubtopics).pk,
+        )
+        instance.real_video = real_video
+        instance.content_videos.append(real_video)
 
 
 class UpdatesTestCase(KALiteTestCase):
@@ -7,4 +36,4 @@ class UpdatesTestCase(KALiteTestCase):
     """
     def setUp(self):
         super(UpdatesTestCase, self).setUp()
-
+        add_test_content_videos(self)

--- a/kalite/updates/tests/base.py
+++ b/kalite/updates/tests/base.py
@@ -2,7 +2,6 @@ import random
 
 from kalite.testing.base import KALiteTestCase
 from kalite.topic_tools.content_models import set_database, Item
-from peewee import Using
 
 
 # Some small videos from the content database 2017-11-13
@@ -14,20 +13,20 @@ def add_test_content_videos(instance, db):
     
     youtube_id = random.choice(TEST_YOUTUBE_IDS)
     
-    with Using(db, [Item], with_transaction=False):
-        real_video = Item.create(
-            title="A real video from KA/Youtube",
-            description="This video exists",
-            available=False,
-            kind="Video",
-            id=youtube_id,
-            youtube_id=youtube_id,
-            slug="youtube-vid",
-            path=instance.content_unavailable_content_path,
-            parent=random.choice(instance.content_subsubtopics).pk,
-        )
-        instance.real_video = real_video
-        instance.content_videos.append(real_video)
+    real_video = Item.create(
+        title="A real video from KA/Youtube",
+        description="This video exists",
+        available=False,
+        kind="Video",
+        format="mp4",
+        id=youtube_id,
+        youtube_id=youtube_id,
+        slug="youtube-vid",
+        path="real/video",
+        parent=random.choice(instance.content_subsubtopics).pk,
+    )
+    instance.real_video = real_video
+    instance.content_videos.append(real_video)
 
 
 class UpdatesTestCase(KALiteTestCase):

--- a/kalite/updates/tests/download_tests.py
+++ b/kalite/updates/tests/download_tests.py
@@ -1,8 +1,10 @@
 from .base import UpdatesTestCase
-from kalite.updates.videos import download_video
+from kalite.updates.videos import download_video, delete_downloaded_files
 from fle_utils.internet.download import URLNotFound
 from kalite.topic_tools.content_models import get_content_item,\
     annotate_content_models_by_youtube_id
+from kalite.updates.download_track import VideoQueue
+from django.core.management import call_command
 
 
 class TestDownload(UpdatesTestCase):
@@ -22,3 +24,17 @@ class TestDownload(UpdatesTestCase):
     def test_download_unavailable(self):
         with self.assertRaises(URLNotFound):
             download_video(self.content_unavailable_item.youtube_id)
+
+    def test_download_command(self):
+        delete_downloaded_files(self.real_video.youtube_id)
+        # Check that it's been marked unavailable
+        updated = get_content_item(content_id=self.real_video.id)
+        annotate_content_models_by_youtube_id(youtube_ids=[self.real_video])
+        self.assertFalse(updated['available'])
+        queue = VideoQueue()
+        queue.add_files({self.real_video.youtube_id: self.real_video.title}, language="en")
+        call_command("videodownload")
+        annotate_content_models_by_youtube_id(youtube_ids=[self.real_video.youtube_id])
+        # Check that it's been marked available
+        updated = get_content_item(content_id=self.real_video.id)
+        self.assertTrue(updated['available'])

--- a/kalite/updates/tests/download_tests.py
+++ b/kalite/updates/tests/download_tests.py
@@ -1,6 +1,8 @@
 from .base import UpdatesTestCase
 from kalite.updates.videos import download_video
 from fle_utils.internet.download import URLNotFound
+from kalite.topic_tools.content_models import get_content_item,\
+    annotate_content_models_by_youtube_id
 
 
 class TestDownload(UpdatesTestCase):
@@ -9,7 +11,13 @@ class TestDownload(UpdatesTestCase):
     """
 
     def test_simple_download(self):
+        # Download a video that exists for real!
         download_video(self.real_video.youtube_id)
+        # After downloading the video, annotate the database
+        annotate_content_models_by_youtube_id(youtube_ids=[self.real_video.youtube_id])
+        # Check that it's been marked available
+        updated = get_content_item(content_id=self.real_video.id)
+        self.assertTrue(updated['available'])
 
     def test_download_unavailable(self):
         with self.assertRaises(URLNotFound):

--- a/kalite/updates/tests/download_tests.py
+++ b/kalite/updates/tests/download_tests.py
@@ -1,0 +1,16 @@
+from .base import UpdatesTestCase
+from kalite.updates.videos import download_video
+from fle_utils.internet.download import URLNotFound
+
+
+class TestDownload(UpdatesTestCase):
+    """
+    Test that topics with exercises are available, others are not.
+    """
+
+    def test_simple_download(self):
+        download_video(self.real_video.youtube_id)
+
+    def test_download_unavailable(self):
+        with self.assertRaises(URLNotFound):
+            download_video(self.content_unavailable_item.youtube_id)

--- a/kalite/updates/videos.py
+++ b/kalite/updates/videos.py
@@ -58,7 +58,7 @@ def get_video_local_path(youtube_id, extension="mp4"):
     return os.path.join(download_path, filename)
 
 
-def get_thumbnail_local_path(youtube_id, extension="mp4"):
+def get_thumbnail_local_path(youtube_id):
     download_path=settings.CONTENT_ROOT
     filename = get_thumbnail_filename(youtube_id)
     return os.path.join(download_path, filename)
@@ -73,17 +73,27 @@ def download_video(youtube_id, extension="mp4", callback=None):
     thumb_url = get_thumbnail_url(youtube_id, extension)
 
     filepath = get_video_local_path(youtube_id, extension)
-    thumb_filepath = get_thumbnail_local_path(youtube_id, extension)
+    thumb_filepath = get_thumbnail_local_path(youtube_id)
 
     try:
-        response = download_file(url, dst=filepath, callback=callback_percent_proxy(callback, end_percent=95))
+        response = download_file(
+            url,
+            dst=filepath,
+            callback=callback_percent_proxy(callback, end_percent=95),
+            max_retries=settings.DOWNLOAD_MAX_RETRIES
+        )
         if (
                 not os.path.isfile(filepath) or
                 "content-length" not in response.headers or
                 not os.path.getsize(filepath) == int(response.headers['content-length'])):
             raise URLNotFound("Video was not found, tried: {}".format(url))
 
-        response = download_file(thumb_url, dst=thumb_filepath, callback=callback_percent_proxy(callback, start_percent=95, end_percent=100))
+        response = download_file(
+            thumb_url,
+            dst=thumb_filepath,
+            callback=callback_percent_proxy(callback, start_percent=95, end_percent=100),
+            max_retries=settings.DOWNLOAD_MAX_RETRIES
+        )
         if (
                 not os.path.isfile(thumb_filepath) or
                 "content-length" not in response.headers or

--- a/kalite/updates/videos.py
+++ b/kalite/updates/videos.py
@@ -76,30 +76,21 @@ def download_video(youtube_id, extension="mp4", callback=None):
     thumb_filepath = get_thumbnail_local_path(youtube_id)
 
     try:
-        response = download_file(
+        # Download video
+        download_file(
             url,
             dst=filepath,
             callback=callback_percent_proxy(callback, end_percent=95),
             max_retries=settings.DOWNLOAD_MAX_RETRIES
         )
-        if (
-                not os.path.isfile(filepath) or
-                "content-length" not in response.headers or
-                not os.path.getsize(filepath) == int(response.headers['content-length'])):
-            raise URLNotFound("Video was not found, tried: {}".format(url))
 
-        response = download_file(
+        # Download thumbnail
+        download_file(
             thumb_url,
             dst=thumb_filepath,
             callback=callback_percent_proxy(callback, start_percent=95, end_percent=100),
             max_retries=settings.DOWNLOAD_MAX_RETRIES
         )
-        if (
-                not os.path.isfile(thumb_filepath) or
-                "content-length" not in response.headers or
-                not os.path.getsize(thumb_filepath) == int(response.headers['content-length'])):
-            logger.critical("Thumbnail was not found, tried: {}".format(thumb_url))
-            raise URLNotFound("Thumbnail was not found, tried: {}".format(url))
 
     except (socket.timeout, IOError) as e:
         logger.exception(e)

--- a/kalite/updates/videos.py
+++ b/kalite/updates/videos.py
@@ -21,7 +21,7 @@ def get_local_video_size(youtube_id, default=None):
         return default
 
 
-def download_video(youtube_id, format="mp4", callback=None):
+def download_video(youtube_id, extension="mp4", callback=None):
     """Downloads the video file to disk (note: this does NOT invalidate any of the cached html files in KA Lite)"""
 
     download_url = ("http://%s/download/videos/" % (settings.CENTRAL_SERVER_HOST)) + "%s/%s"
@@ -30,7 +30,7 @@ def download_video(youtube_id, format="mp4", callback=None):
     
     ensure_dir(download_path)
 
-    video_filename = "%(id)s.%(format)s" % {"id": youtube_id, "format": format}
+    video_filename = "%(id)s.%(format)s" % {"id": youtube_id, "format": extension}
     thumb_filename = "%(id)s.png" % {"id": youtube_id}
 
     url = download_url % (video_filename, video_filename)

--- a/kalite/updates/videos.py
+++ b/kalite/updates/videos.py
@@ -1,18 +1,23 @@
 """
 """
+import glob
+import logging
 import os
+import socket
 
 from django.conf import settings
-logging = settings.LOG
+from fle_utils.general import ensure_dir
+from fle_utils.internet.download import callback_percent_proxy, download_file, URLNotFound, DownloadCancelled
 
-from fle_utils import videos  # keep access to all functions
+
+logger = logging.getLogger(__name__)
 
 
 def get_local_video_size(youtube_id, default=None):
     try:
         return os.path.getsize(os.path.join(settings.CONTENT_ROOT, "%s.mp4" % youtube_id))
     except Exception as e:
-        logging.debug(str(e))
+        logger.debug(str(e))
         return default
 
 
@@ -20,8 +25,59 @@ def download_video(youtube_id, format="mp4", callback=None):
     """Downloads the video file to disk (note: this does NOT invalidate any of the cached html files in KA Lite)"""
 
     download_url = ("http://%s/download/videos/" % (settings.CENTRAL_SERVER_HOST)) + "%s/%s"
-    return videos.download_video(youtube_id, settings.CONTENT_ROOT, download_url, format, callback)
+
+    download_path=settings.CONTENT_ROOT
+    
+    ensure_dir(download_path)
+
+    video_filename = "%(id)s.%(format)s" % {"id": youtube_id, "format": format}
+    thumb_filename = "%(id)s.png" % {"id": youtube_id}
+
+    url = download_url % (video_filename, video_filename)
+    thumb_url = download_url % (video_filename, thumb_filename)
+
+    filepath = os.path.join(download_path, video_filename)
+    thumb_filepath = os.path.join(download_path, thumb_filename)
+
+    try:
+        response = download_file(url, filepath, callback_percent_proxy(callback, end_percent=95))
+        if (
+                not os.path.isfile(filepath) or
+                "content-length" not in response.headers or
+                not os.path.getsize(filepath) == int(response.headers['content-length'])):
+            raise URLNotFound("Video was not found, tried: {}".format(url))
+
+        response = download_file(thumb_url, thumb_filepath, callback_percent_proxy(callback, start_percent=95, end_percent=100))
+        if (
+                not os.path.isfile(thumb_filepath) or
+                "content-length" not in response.headers or
+                not os.path.getsize(thumb_filepath) == int(response.headers['content-length'])):
+            raise URLNotFound("Thumbnail was not found, tried: {}".format(thumb_url))
+
+    except DownloadCancelled:
+        delete_downloaded_files(youtube_id, download_path)
+        raise
+
+    except (socket.timeout, IOError) as e:
+        logger.exception(e)
+        logger.info("Timeout -- Network UnReachable")
+        delete_downloaded_files(youtube_id, download_path)
+        raise
+
+    except Exception as e:
+        logger.exception(e)
+        delete_downloaded_files(youtube_id, download_path)
+        raise
 
 
 def delete_downloaded_files(youtube_id):
-    return videos.delete_downloaded_files(youtube_id, settings.CONTENT_ROOT)
+    download_path = settings.CONTENT_ROOT
+    files_deleted = 0
+    for filepath in glob.glob(os.path.join(download_path, youtube_id + ".*")):
+        try:
+            os.remove(filepath)
+            files_deleted += 1
+        except OSError:
+            pass
+    if files_deleted:
+        return True

--- a/kalite/updates/videos.py
+++ b/kalite/updates/videos.py
@@ -5,9 +5,11 @@ import logging
 import os
 import socket
 
-from django.conf import settings
+from . import settings
+
+from django.conf import settings as django_settings
 from fle_utils.general import ensure_dir
-from fle_utils.internet.download import callback_percent_proxy, download_file, URLNotFound
+from fle_utils.internet.download import callback_percent_proxy, download_file
 
 
 logger = logging.getLogger(__name__)
@@ -15,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def get_local_video_size(youtube_id, default=None):
     try:
-        return os.path.getsize(os.path.join(settings.CONTENT_ROOT, "%s.mp4" % youtube_id))
+        return os.path.getsize(os.path.join(django_settings.CONTENT_ROOT, "%s.mp4" % youtube_id))
     except Exception as e:
         logger.debug(str(e))
         return default
@@ -25,7 +27,7 @@ def get_url_pattern():
     """
     Returns a pattern for generating URLs of videos and thumbnails
     """
-    base = "http://{}/download/videos/".format(settings.CENTRAL_SERVER_HOST)
+    base = "http://{}/download/videos/".format(django_settings.CENTRAL_SERVER_HOST)
     return base + "{dir}/{filename}"
 
 
@@ -53,21 +55,23 @@ def get_thumbnail_url(youtube_id, video_extension="mp4"):
 
 
 def get_video_local_path(youtube_id, extension="mp4"):
-    download_path=settings.CONTENT_ROOT
+    download_path=django_settings.CONTENT_ROOT
     filename = get_video_filename(youtube_id, extension)
     return os.path.join(download_path, filename)
 
 
 def get_thumbnail_local_path(youtube_id):
-    download_path=settings.CONTENT_ROOT
+    download_path=django_settings.CONTENT_ROOT
     filename = get_thumbnail_filename(youtube_id)
     return os.path.join(download_path, filename)
 
 
 def download_video(youtube_id, extension="mp4", callback=None):
-    """Downloads the video file to disk (note: this does NOT invalidate any of the cached html files in KA Lite)"""
+    """
+    Downloads video file to disk
+    """
 
-    ensure_dir(settings.CONTENT_ROOT)
+    ensure_dir(django_settings.CONTENT_ROOT)
 
     url = get_video_url(youtube_id, extension)
     thumb_url = get_thumbnail_url(youtube_id, extension)
@@ -105,7 +109,7 @@ def download_video(youtube_id, extension="mp4", callback=None):
 
 
 def delete_downloaded_files(youtube_id):
-    download_path = settings.CONTENT_ROOT
+    download_path = django_settings.CONTENT_ROOT
     files_deleted = 0
     for filepath in glob.glob(os.path.join(download_path, youtube_id + ".*")):
         try:

--- a/kalite/updates/videos.py
+++ b/kalite/updates/videos.py
@@ -40,33 +40,34 @@ def download_video(youtube_id, extension="mp4", callback=None):
     thumb_filepath = os.path.join(download_path, thumb_filename)
 
     try:
-        response = download_file(url, filepath, callback_percent_proxy(callback, end_percent=95))
+        response = download_file(url, dst=filepath, callback=callback_percent_proxy(callback, end_percent=95))
         if (
                 not os.path.isfile(filepath) or
                 "content-length" not in response.headers or
                 not os.path.getsize(filepath) == int(response.headers['content-length'])):
             raise URLNotFound("Video was not found, tried: {}".format(url))
 
-        response = download_file(thumb_url, thumb_filepath, callback_percent_proxy(callback, start_percent=95, end_percent=100))
+        response = download_file(thumb_url, dst=thumb_filepath, callback=callback_percent_proxy(callback, start_percent=95, end_percent=100))
         if (
                 not os.path.isfile(thumb_filepath) or
                 "content-length" not in response.headers or
                 not os.path.getsize(thumb_filepath) == int(response.headers['content-length'])):
-            raise URLNotFound("Thumbnail was not found, tried: {}".format(thumb_url))
+            logger.critical("Thumbnail was not found, tried: {}".format(thumb_url))
+            raise URLNotFound("Thumbnail was not found, tried: {}".format(url))
 
     except DownloadCancelled:
-        delete_downloaded_files(youtube_id, download_path)
+        delete_downloaded_files(youtube_id)
         raise
 
     except (socket.timeout, IOError) as e:
         logger.exception(e)
         logger.info("Timeout -- Network UnReachable")
-        delete_downloaded_files(youtube_id, download_path)
+        delete_downloaded_files(youtube_id)
         raise
 
     except Exception as e:
         logger.exception(e)
-        delete_downloaded_files(youtube_id, download_path)
+        delete_downloaded_files(youtube_id)
         raise
 
 

--- a/kalite/updates/videos.py
+++ b/kalite/updates/videos.py
@@ -7,7 +7,7 @@ import socket
 
 from django.conf import settings
 from fle_utils.general import ensure_dir
-from fle_utils.internet.download import callback_percent_proxy, download_file, URLNotFound, DownloadCancelled
+from fle_utils.internet.download import callback_percent_proxy, download_file, URLNotFound
 
 
 logger = logging.getLogger(__name__)
@@ -100,10 +100,6 @@ def download_video(youtube_id, extension="mp4", callback=None):
                 not os.path.getsize(thumb_filepath) == int(response.headers['content-length'])):
             logger.critical("Thumbnail was not found, tried: {}".format(thumb_url))
             raise URLNotFound("Thumbnail was not found, tried: {}".format(url))
-
-    except DownloadCancelled:
-        delete_downloaded_files(youtube_id)
-        raise
 
     except (socket.timeout, IOError) as e:
         logger.exception(e)


### PR DESCRIPTION
## Summary

Debugging #5528, I found that the issue seems to be the lack of retries when connections are broken or temporarily unresolved.

Any error in downloading a video or thumbnail results in an item being skipped in the queue. This could also explain why the resized videos torrent set has consistently been missing a couple of items.. downloading 30+k files would usually result in a couple of errors. From my own connection, I had 197 errors out of 15k thumbnail downloads. FYI: @jamalex 

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [ ] Has documentation been written/updated?
- [x] Have you written release notes for the upcoming release?

## Reviewer guidance

Assuming no external use of `download_file` and other refactored components. Central server will not be upgraded immediately.

## Issues addressed

#5528