### PR TITLE
Harden download robustness

### DIFF
--- a/kalite/updates/tests/base.py
+++ b/kalite/updates/tests/base.py
@@ -5,7 +5,7 @@ from kalite.topic_tools.content_models import set_database, Item
 
 
 # Some small videos from the content database 2017-11-13
-TEST_YOUTUBE_IDS = ["riXcZT2ICjA", "_7aUxFzTG5w"]
+TEST_YOUTUBE_IDS = ["9P80OLC6wKY", "zaGUlwslGGg"]
 
 
 @set_database

--- a/kalite/updates/videos.py
+++ b/kalite/updates/videos.py
@@ -10,6 +10,7 @@ from . import settings
 from django.conf import settings as django_settings
 from fle_utils.general import ensure_dir
 from fle_utils.internet.download import callback_percent_proxy, download_file
+from requests.exceptions import HTTPError
 
 
 logger = logging.getLogger(__name__)
@@ -79,6 +80,14 @@ def download_video(youtube_id, extension="mp4", callback=None):
     filepath = get_video_local_path(youtube_id, extension)
     thumb_filepath = get_thumbnail_local_path(youtube_id)
 
+    logger.info(
+        "Downloading {id} (video: {video}, thumbnail: {thumbnail})".format(
+            id=youtube_id,
+            video=url,
+            thumbnail=thumb_url,
+        )
+    )
+
     try:
         # Download video
         download_file(
@@ -96,9 +105,20 @@ def download_video(youtube_id, extension="mp4", callback=None):
             max_retries=settings.DOWNLOAD_MAX_RETRIES
         )
 
+    except HTTPError as e:
+        logger.error(
+            "HTTP status {status} for URL: {url}".format(
+                status=e.response.status_code,
+                url=e.response.url,
+            )
+        )
+        raise
+
     except (socket.timeout, IOError) as e:
-        logger.exception(e)
-        logger.info("Timeout -- Network UnReachable")
+        logger.info("Network error for URL: {url}, exception: {exc}".format(
+            url=url,
+            exc=str(e)
+        ))
         delete_downloaded_files(youtube_id)
         raise
 


### PR DESCRIPTION
## Summary

 * Fixes blank video downloads when server is down (part of #5538)
 * Raise exceptions when non-200 download responses
 * Add tests for various failures
 * Improve logging

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Has documentation been written/updated?
- [x] Have you written release notes for the upcoming release?

## Reviewer guidance

...

## Issues addressed

#5538