### PR TITLE
Remove inaccurate release note

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -37,11 +37,6 @@ Developers
 
 * Do not use `npm clean`, now requires npm>=5 for building on unclean systems :url-issue:`5519`
 
-Contents
-^^^^^^^^
-
-* Resized video torrent set for English rebuilt with missing videos
-
 
 Known issues
 ^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Had anticipated to fix missing videos in torrent sets, but there weren't any (I think it must have been pre- the July content pack that I observed it)

@jamalex This! Sorry about having expressed otherwise -- I'm still confident that I've downloaded torrent sets before that didn't have all videos... but now it's tested and with the latest content pack, the videos from the torrent match 100%.
