### PR TITLE
[WIP] Build .pex files to speed up testing

### DIFF
--- a/.buildkite/build_whl.sh
+++ b/.buildkite/build_whl.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+make dockerenvdist
+buildkite-agent artifact upload 'dist/*.whl'
+buildkite-agent artifact upload 'dist/*.tar.gz'
+buildkite-agent artifact upload 'dist/*.pex'

--- a/.buildkite/build_windows_installer.sh
+++ b/.buildkite/build_windows_installer.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PARENT_PATH=$(pwd)
+KALITE_DOCKER_PATH="$PARENT_PATH/windows_installer_docker_build"
+KALITE_WINDOWS_PATH="$KALITE_DOCKER_PATH/ka-lite-installers/windows"
+
+# Download artifacts to dist/
+mkdir -p dist
+buildkite-agent artifact download 'dist/*.whl' dist/
+make dockerwriteversion
+
+# Clone KA-Lite windows installer and download content pack
+cd $KALITE_DOCKER_PATH
+git clone https://github.com/learningequality/ka-lite-installers.git && cd ka-lite-installers && git checkout 0.17.x
+cd $KALITE_WINDOWS_PATH && wget http://pantry.learningequality.org/downloads/ka-lite/0.17/content/contentpacks/en.zip
+
+# Copy kalite whl files to kalite windows installer path
+COPY_CMD="cp $PARENT_PATH/dist/*.whl $KALITE_WINDOWS_PATH"
+$COPY_CMD
+
+if [ $? -ne 0 ]; then
+    echo "... Abort! Error running $COPY_CMD"
+    exit 1
+fi
+
+# Build KA-Lite windows installer docker image
+KALITE_BUILD_VERSION=$(cat $PARENT_PATH/kalite/VERSION)
+cd $KALITE_DOCKER_PATH
+DOCKER_BUILD_CMD="docker image build -t $KALITE_BUILD_VERSION-build ."
+$DOCKER_BUILD_CMD
+
+if [ $? -ne 0 ]; then
+    echo "... Abort! Error running $DOCKER_BUILD_CMD."
+    exit 1
+fi
+
+INSTALLER_PATH="$KALITE_DOCKER_PATH/installer"
+mkdir -p $INSTALLER_PATH
+
+# Run KA-Lite windows installer docker image.
+DOCKER_RUN_CMD="docker run -v $INSTALLER_PATH:/installer/ $KALITE_BUILD_VERSION-build"
+$DOCKER_RUN_CMD
+
+if [ $? -ne 0 ]; then
+    echo "... Abort! Error running $DOCKER_RUN_CMD."
+    exit 1
+fi
+cd $KALITE_DOCKER_PATH
+buildkite-agent artifact upload './installer/*.exe'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,5 +4,10 @@ steps:
 
   - wait
 
-  - label: Build the python packages and windows installer
-    command: mkdir -p dist && .buildkite/build_and_upload_artifact.sh && docker container prune -f
+  - label: Build python packages
+    command: mkdir -p dist && .buildkite/build_whl.sh && docker container prune -f
+  
+  - wait
+
+  - label: Build windows installer
+    command: .buildkite/build_windows_installer.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,37 +5,25 @@ RUN apt-get -y update
 RUN apt-get install -y software-properties-common curl
 RUN add-apt-repository ppa:voronov84/andreyv
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get -y update && apt-get install -y python2.7 python-pip git nodejs gettext python-sphinx wget
-
-# Install wine and related packages
-RUN dpkg --add-architecture i386 
-RUN apt-get update && apt-get install -y --no-install-recommends git ca-certificates sudo software-properties-common
-RUN add-apt-repository -y ppa:ubuntu-wine/ppa && apt-get -y update && apt-get install --no-install-recommends --assume-yes wine
-
+RUN apt-get -y update && apt-get install -y python2.7 python-pip git nodejs gettext wget
 
 COPY . /kalite
 VOLUME /kalitedist/
 
+# Use virtualenv's pip
+ENV PIP=/kalite/kalite_env/bin/pip
+
 # for mounting the whl files into other docker containers
 RUN pip install virtualenv && virtualenv /kalite/kalite_env  --python=python2.7
-RUN /kalite/kalite_env/bin/pip install -r /kalite/requirements_dev.txt \
-	&& /kalite/kalite_env/bin/pip install -r /kalite/requirements_sphinx.txt \
-	&& /kalite/kalite_env/bin/pip install -e /kalite/.
+
+RUN $PIP install -r /kalite/requirements_dev.txt \
+	&& $PIP install -r /kalite/requirements_sphinx.txt \
+	&& $PIP install -e /kalite/. \
+	&& $PIP install pex
 
 # Override the PATH to add the path of our virtualenv python binaries first so it's python executes instead of
 # the system python.
 ENV PATH=/kalite/kalite_env/bin:$PATH
 ENV KALITE_PYTHON=/kalite/kalite_env/bin/python
 
-# Installer dependencies
-RUN cd /kalite/ && git clone https://github.com/learningequality/ka-lite-installers.git && cd /kalite/ka-lite-installers && git checkout 0.17.x
-RUN cd /kalite/ka-lite-installers/windows && wget http://pantry.learningequality.org/downloads/ka-lite/0.17/content/contentpacks/en.zip
-
-# Build the python packages and the ka-lite windows installer
-CMD cd /kalite && make dist \
-	&& cd /kalite/ka-lite-installers/windows \
-	&& cp -R /kalite/dist/ka_lite_static-*-py2-none-any.whl /kalite/ka-lite-installers/windows \
-	&& export KALITE_BUILD_VERSION=$(/kalite/kalite_env/bin/kalite --version) \
-	&& wine inno-compiler/ISCC.exe installer-source/KaliteSetupScript.iss \
-	&& cp /kalite/dist/* /kalitedist/ \
-	&& cp /kalite/ka-lite-installers/windows/KALiteSetup-$(/kalite/kalite_env/bin/kalite --version).exe /kalitedist/
+CMD cd /kalite && make dist pex && cp /kalite/dist/* /kalitedist/

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,10 @@ dist: clean docs assets
 	python setup.py bdist_wheel --static  --no-clean
 	ls -l dist
 
+pex:
+	pex -m kalite dist/ka_lite_static*.whl --disable-cache -o dist/ka-lit-static$$(git describe).pex
+	ls -l dist
+
 install: clean
 	python setup.py install
 

--- a/windows_installer_docker_build/Dockerfile
+++ b/windows_installer_docker_build/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:xenial
+
+RUN apt-get -y update
+
+RUN dpkg --add-architecture i386
+RUN apt-get update && apt-get install -y --no-install-recommends git wget ca-certificates sudo software-properties-common
+
+RUN add-apt-repository -y ppa:ubuntu-wine/ppa && apt-get -y update && apt-get install --no-install-recommends --assume-yes wine
+
+COPY . /kalite
+
+RUN mkdir /installer/
+
+# Build KA-Lite windows installer.
+CMD cd /kalite/ka-lite-installers/windows \
+    && WHL_FILE=$(basename $(find . -name ka_lite-*.whl)) \
+    && export KALITE_BUILD_VERSION=$(echo $WHL_FILE | cut -d'-' -f 2) \
+    && wine inno-compiler/ISCC.exe installer-source/KaliteSetupScript.iss \
+    && cp /kalite/ka-lite-installers/windows/KALiteSetup-$KALITE_BUILD_VERSION.exe /installer/


### PR DESCRIPTION
## Summary

@benjaoming quite off from the instructions but I made it similar to how kolibri generates the pex and installers. I can make it as instructed (.buildkite/pex.sh) if this approach is not appropriate

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

 * [x] Generate pex file `dist/ka-lite-static<version-info>.pex`
 * [ ] Activate script on Buildkite
 * [ ] Get PR status feedback through bot

Should we also upload the files to google cloud storage?

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR
#5544