### PR TITLE
Bump release branch to dev version

### DIFF
--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -223,7 +223,10 @@ def extract_subtitles(zf, lang):
 
     ensure_dir(SUBTITLE_DEST_DIR)
 
-    subtitles = (s for s in zf.namelist() if SUBTITLE_ZIP_DIR in s)
+    def is_subtitle_file(s):
+        return SUBTITLE_ZIP_DIR in s and len(s) > len(SUBTITLE_ZIP_DIR)
+
+    subtitles = (s for s in zf.namelist() if is_subtitle_file(s))
 
     for subtitle in subtitles:
         # files inside zipfiles may come with leading directories in their

--- a/kalite/version.py
+++ b/kalite/version.py
@@ -3,7 +3,7 @@
 # Must also be of the form N.N.N for internal use, where N is a non-negative integer
 MAJOR_VERSION = "0"
 MINOR_VERSION = "17"
-PATCH_VERSION = "4"
+PATCH_VERSION = "5dev"
 VERSION = "%s.%s.%s" % (MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 SHORTVERSION = "%s.%s" % (MAJOR_VERSION, MINOR_VERSION)
 


### PR DESCRIPTION
@mrpau-eugene @mrpau-richard notice that the 0.17.x branch now tracks the version number that we're currently working on.. this is very much because of the new Buildkite functionality.