### PR TITLE
Allow the 'clean' command to run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ for req in RAW_REQUIREMENTS:
 STATIC_REQUIREMENTS = []
 
 # Decide if the invoked command is a request to do building
-DIST_BUILDING_COMMAND = any([x in sys.argv for x in ("bdist", "sdist", "bdist_wheel", "bdist_deb", "sdist_dsc")]) and not any([x.startswith("--use-premade-distfile") for x in sys.argv])
+DIST_BUILDING_COMMAND = any([x in sys.argv for x in ("bdist", "sdist", "bdist_wheel", "bdist_deb", "sdist_dsc", "clean")]) and not any([x.startswith("--use-premade-distfile") for x in sys.argv])
 
 # This is where static packages are automatically installed by pip when running
 # setup.py sdist --static or if a distributed version built by the static


### PR DESCRIPTION
## Summary

Getting rid of this error more permanently (although also disabled the `clean` command in debian/rules)

```
make[1]: Entering directory '/ka-lite-installers/debian/build/ka-lite-source-0.17.4'
rm -rf ka_lite_static.egg-info
python setup.py clean -a
Already blocking...
Already blocking...
Traceback (most recent call last):
  File "setup.py", line 289, in <module>
    "Already installed ka-lite so cannot install ka-lite-static. "
RuntimeError: Already installed ka-lite so cannot install ka-lite-static. Remove existing ka-lite-static packages, for instance using 

    pip uninstall ka-lite-static  # Standard
    sudo apt-get remove ka-lite  # Ubuntu/Debian

...or other possible installation mechanisms you may have been using.
debian/rules:8: recipe for target 'override_dh_auto_clean' failed
```

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Has documentation been written/updated?
- [x] Have you written release notes for the upcoming release?

## Reviewer guidance

Non really, 0.17.4 is out, so this is for the next, and not really important

## Issues addressed

n/a