### PR TITLE
Add known issue about content packs in 0.17 series

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -9,25 +9,6 @@ to read the release notes.
   ``0.15.x`` to ``0.17.x`` is not guaranteed to work.
 
 
-0.17.5 (unreleased)
--------------------
-
-Added
-^^^^^
-
-* ...
-
-Bug fixes
-^^^^^^^^^
-
-* Retrievecontentpack might fail :url-issue:`5476`
-
-Developers
-^^^^^^^^^^
-
-* ...
-
-
 0.17.4
 ------
 
@@ -57,6 +38,13 @@ Developers
 Known issues
 ^^^^^^^^^^^^
 
+* The English **Math** topic (top-level) contains a number of misplaced
+  subtopics in the 0.17 series. The problem has propagated from upstream data.
+  The misplacement clutters/obstructs the navigation for students, and it has
+  been a priority to fix this in 0.18, released shortly after 0.17.4.
+  But it's recommended to upgrade to 0.18 and download new video contents
+  following from the new content pack (~450 videos). See below for tips on how
+  to install a content pack from a different KA Lite release. :url-issue:`5561`
 * It isn't possible to cancel video downloads if a video is downloading while
   the connection is switched off.
 * **Chrome 55-56** has issues scrolling the menus on touch devices. Upgrading to Chrome 57 fixes this. :url-issue:`5407`
@@ -65,6 +53,17 @@ Known issues
 * **Windows + IE9** One-Click device registration is broken. Work-around: Use a different browser or use manual device registration. :url-issue:`5409`
 * **Firefox 47**: Subtitles are misaligned in the video player. This is fixed by upgrading Firefox.
 * A limited number of exercises with radio buttons have problems displaying :url-issue:`5172`
+
+
+.. tip::
+  It is possible to install a 0.16 content pack in a 0.17 release as a
+  work-around. Download a specific content pack and then install it from
+  command-line. Example::
+    
+    # Download content pack to "en_0.16.zip"
+    $ wget -r -O en_0.16.zip http://pantry.learningequality.org/downloads/ka-lite/0.16/content/contentpacks/en.zip
+    # Install "en_0.16.zip"
+    $ kalite manage retrievecontentpack local en en_0.16.zip
 
 
 0.17.3


### PR DESCRIPTION
## Summary

This addresses #5561 so that people are finally informed that this is a flaw of 0.17.

We will prioritize getting 0.18 out ASAP, just for the sake of this content pack update!

This is a docs upgrade so it mainly just needs to be merged to master and `0.17.x` to get exposure on RTD.

Additional note: I'm removing the 0.17.5 milestone.

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Has documentation been written/updated?
- [x] Have you written release notes for the upcoming release?

## Reviewer guidance

n/a

## Issues addressed

#5561