### PR TITLE
Fix wrong remote_size when annotating content

### DIFF
--- a/kalite/topic_tools/content_models.py
+++ b/kalite/topic_tools/content_models.py
@@ -692,7 +692,7 @@ def annotate_content_models(channel="khan", language="en", ids=None, iterator_co
                 available = any(child.available for child in children)
                 total_files = sum(child.total_files for child in children)
                 files_complete = sum(child.files_complete for child in children)
-                child_remote = sum(child.remote_size for child in children if (not child.available and child.kind != "Topic") or (child.kind == "Topic"))
+                child_remote = sum(child.remote_size for child in children if (not (child.available and child.kind == "Topic") or (child.kind == "Topic")))
                 child_on_disk = sum(child.size_on_disk for child in children)
 
                 # ensure files_complete doesn't go above total_files; can be removed after fix is in for:


### PR DESCRIPTION
## Summary

Take this for example:

After a successful scan, some of the Topics' `remote_size` becomes `0`

![screen shot 2018-01-30 at 1 24 42 pm](https://user-images.githubusercontent.com/27984604/35549661-84c94174-05c1-11e8-9f76-5e067853e27e.png)

Therefore, when ticking the `Math` topic, it might look something like this:
![image](https://user-images.githubusercontent.com/374612/35065789-951f8cba-fbce-11e7-9e74-441cccacd846.png)

@benjaoming this was the one I found. Could you test this one?

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [ ] Has documentation been written/updated?
- [ ] Have you written release notes for the upcoming release?

## Reviewer guidance

*If you PR has a significant size, give the reviewer some helpful remarks*

## Issues addressed

List the issues solved or partly solved by the PR

