### PR TITLE
RPi fix: Make running retrievecontentpack download NOT update the DB

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -9,6 +9,15 @@ to read the release notes.
   ``0.15.x`` to ``0.17.x`` is not guaranteed to work.
 
 
+0.17.5b1
+--------
+
+Bug fixes
+^^^^^^^^^
+
+* Slow download using ``retrievecontentpack`` on Raspberry Pi :url-issue:`5575`
+
+
 0.17.4
 ------
 

--- a/kalite/distributed/management/commands/retrievecontentpack.py
+++ b/kalite/distributed/management/commands/retrievecontentpack.py
@@ -23,6 +23,7 @@ from kalite.updates.management.utils import UpdatesStaticCommand
 from peewee import SqliteDatabase
 from kalite.topic_tools.content_models import Item, AssessmentItem
 from requests.exceptions import ConnectionError, HTTPError
+from fle_utils.django_utils.command import LocaleAwareCommand
 
 
 logger = logging.getLogger(__name__)
@@ -41,7 +42,19 @@ class Command(UpdatesStaticCommand):
 
     """
 
-    option_list = UpdatesStaticCommand.option_list + (
+
+    option_list = LocaleAwareCommand.option_list + (
+        make_option(
+            "", "--background",
+            action="store_true",
+            dest="background",
+            default=False,
+            help=(
+                "Run the command with job scheduler and database-backed "
+                "progress. Used when you retrieve a content pack before "
+                "initializing KA Lite's db."
+            )
+        ),
         make_option(
             "", "--template",
             action="store_true",
@@ -147,6 +160,9 @@ class Command(UpdatesStaticCommand):
 
         lang = args[1]
 
+        # This rather hacky callback will add progress to the database-backed
+        # progress monitoriing, which is terrible for performance on for
+        # instance Raspberry Pi devices.
         def download_callback(fraction):
             percent = int(fraction * 100)
             self.update_stage(

--- a/kalite/updates/api_views.py
+++ b/kalite/updates/api_views.py
@@ -205,7 +205,7 @@ def start_languagepack_download(request):
     data = json.loads(request.raw_post_data)  # Django has some weird post processing into request.POST, so use .body
     lang_code = lcode_to_ietf(data['lang'])
 
-    call_command_async('retrievecontentpack', 'download', lang_code)
+    call_command_async('retrievecontentpack', 'download', lang_code, background=True)
 
     return JsonResponseMessageSuccess(_("Successfully started language pack download for %(lang_name)s.") % {"lang_name": get_language_name(lang_code)})
 

--- a/kalite/updates/management/utils.py
+++ b/kalite/updates/management/utils.py
@@ -29,7 +29,11 @@ class UpdatesCommand(LocaleAwareCommand):
     """
     Abstract class for sharing code across Dynamic and Static versions
     """
+    
     option_list = LocaleAwareCommand.option_list + (
+        # WARNING: Because of issues having foreground as a default option, we
+        # are overwriting this with a --background option in
+        # retrievecontentpack
         make_option(
             "", "--foreground",
             action="store_true",
@@ -39,7 +43,8 @@ class UpdatesCommand(LocaleAwareCommand):
                 "Run the command without job scheduler and  database-backed "
                 "progress. Used when you retrieve a content pack before "
                 "initializing KA Lite's db."
-            )),
+            )
+        ),
     )
 
     def __init__(self, process_name=None, *args, **kwargs):
@@ -53,9 +58,10 @@ class UpdatesCommand(LocaleAwareCommand):
         # Should be set by command's handle() method since there's no clear
         # call structure defined. Respected by the methods that update stuff
         # in the database.
-        self.foreground = options["foreground"]
+        self.foreground = options.get("foreground", False)
+        self.background = options.get("background", True)
 
-        if not self.foreground:
+        if not self.foreground and self.background:
             self.progress_log = UpdateProgressLog.get_active_log(process_name=self.process_name)
         else:
             self.progress_log = None


### PR DESCRIPTION
## Summary

Before, we called `update_stage`, which would write progress to the DB. A pretty bad idea.

On RPi, it basically meant it was impossible to run `retrievecontentpack` in some cases.

Thanks @holta for reporting this!

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Has documentation been written/updated?
- [ ] Have you written release notes for the upcoming release?

## Reviewer guidance

I know this isn't necessarily nicely done or follows through with any kind of consequence for other commands, but this fixes the immediate issue for RPi.

## Issues addressed

#5575
#4892