### PR TITLE
Add a note that the --foreground flag is gone.

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -18,6 +18,11 @@ Bug fixes
 * Slow download using ``retrievecontentpack`` on Raspberry Pi :url-issue:`5575`
 * Customized content packs may fail depending on the Zip program used :url-issue:`5476`
 
+Removed
+^^^^^^^
+
+* Removed ``--foreground`` flag from ``retrievecontentpack`` command, the default behaviour is foreground :url-issue:`5575`
+
 
 0.17.4
 ------

--- a/kalite/updates/tests/download_tests.py
+++ b/kalite/updates/tests/download_tests.py
@@ -139,8 +139,8 @@ class TestDownload(UpdatesTestCase):
     @mock.patch("kalite.updates.videos.get_thumbnail_url")
     @mock.patch("kalite.updates.videos.get_video_url")
     def test_500_download(self, get_thumbnail_url, get_video_url):
-        get_thumbnail_url.return_value = "https://httpstat.us/500"
-        get_video_url.return_value = "https://httpstat.us/500"
+        get_thumbnail_url.return_value = "http://httpstat.us/500"
+        get_video_url.return_value = "http://httpstat.us/500"
         
         with self.assertRaises(HTTPError):
             download_video(self.real_video.youtube_id)


### PR DESCRIPTION
Apologies @mrpau-richard - of course when changing CLI, there should be a release note about it.