### PR TITLE
Always raise an error when importing from django.contrib.gis

### DIFF
--- a/docs/installguide/release_notes.rst
+++ b/docs/installguide/release_notes.rst
@@ -8,6 +8,13 @@ to read the release notes.
   upgrading from ``0.16.x`` to ``0.17.x`` is fine - but upgrading from
   ``0.15.x`` to ``0.17.x`` is not guaranteed to work.
 
+0.17.6.dev
+----------
+
+Bug fixes
+^^^^^^^^^
+
+* Fix rare ``GEOSException`` on systems with libgeos :url-issue:`5592`
 
 0.17.5
 ------

--- a/kalite/packages/bundled/django/contrib/gis/__init__.py
+++ b/kalite/packages/bundled/django/contrib/gis/__init__.py
@@ -4,3 +4,9 @@ if six.PY3:
     memoryview = memoryview
 else:
     memoryview = buffer
+
+
+# Disable all this stuff because we do not want unnecessary imports of system
+# libraries that may break needlessly
+# Ref: https://github.com/iiab/iiab/issues/1382
+raise ImportError("Harmless: We do not support gis")


### PR DESCRIPTION
## Summary

This is an attempt to address the issue in https://github.com/iiab/iiab/issues/1382

There are version strings of libgeos system libraries that seem to make the loading crash.

## TODO

- [ ] Has documentation been written/updated?
- [ ] Have you written release notes for the upcoming release?

## Reviewer guidance

Let's assume that our tests would break, since this is about load-time issues.. not request/response related.

## Issues addressed

https://github.com/iiab/iiab/issues/1382