### PR TITLE
CSP header should not block development Central Server

### DIFF
--- a/kalite/distributed/middleware.py
+++ b/kalite/distributed/middleware.py
@@ -30,7 +30,16 @@ class CSPMiddleware:
         if getattr(settings, 'CSP_REPORT_ONLY', False):
             header += '-Report-Only'
 
-        response[header] = "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.learningequality.org; img-src data: *; script-src 'self' *.learningequality.org 'unsafe-eval' 'unsafe-inline'"
+        response[header] = "default-src 'self' 'unsafe-eval' 'unsafe-inline' data: *.learningequality.org{append_srcs}; img-src data: *; script-src 'self' *.learningequality.org 'unsafe-eval' 'unsafe-inline'"
+        
+        # Add potentially alternative hosts configured as central server
+        if "learningequality.org" not in settings.CENTRAL_SERVER_HOST:
+            response[header] = response[header].format(
+                append_srcs=" " + settings.CENTRAL_SERVER_HOST
+            )
+        else:
+            response[header] = response[header].format(append_srcs="")
+
         return response
 
 


### PR DESCRIPTION
## Summary

This fixes the last artifact of #5348 that I've seen. Which was really annoying for simple development scenarios (developing the Central Server)

## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [x] Has documentation been written/updated?
- [x] Have you written release notes for the upcoming release?

## Reviewer guidance

n/a

## Issues addressed

Fixes #5348