### PR TITLE
Fixes control panel errors occurring in certain cases on Central Server

### DIFF
--- a/kalite/control_panel/views.py
+++ b/kalite/control_panel/views.py
@@ -30,7 +30,8 @@ from kalite.facility.decorators import facility_required
 from kalite.facility.forms import FacilityForm
 from kalite.facility.models import Facility, FacilityUser, FacilityGroup
 from kalite.main.models import ExerciseLog, VideoLog, UserLog, UserLogSummary
-from kalite.shared.decorators.auth import require_authorized_admin, require_authorized_access_to_student_data
+from kalite.shared.decorators.auth import require_authorized_admin, require_authorized_access_to_student_data,\
+    skip_central
 from kalite.version import VERSION
 from kalite import PACKAGE_PATH
 from kalite.distributed.views import check_setup_status
@@ -76,7 +77,7 @@ def process_zone_form(request, zone_id):
 
 
 @require_authorized_admin
-@check_setup_status
+@skip_central(check_setup_status)
 @render_to("control_panel/zone_management.html")
 def zone_management(request, zone_id="None"):
     context = control_panel_context(request, zone_id=zone_id)

--- a/kalite/distributed/views.py
+++ b/kalite/distributed/views.py
@@ -49,7 +49,7 @@ def check_setup_status(handler):
             if not request.session.get("registered", True) and BaseClient().test_connection() == "success":
                 # Being able to register is more rare, so prioritize.
                 messages.warning(request, mark_safe(_("Please <a href='%s'>follow the directions to register your device</a>, so that it can synchronize with the central server.") % reverse("register_public_key")))
-            elif not request.session["facility_exists"]:
+            elif not request.session.get("facility_exists", None):
                 zone_id = (Zone.objects.all() and Zone.objects.all()[0].id) or "None"
                 messages.warning(request, mark_safe(_("Please <a href='%s'>create a facility</a> now. Users will not be able to sign up for accounts until you have made a facility.") % reverse("add_facility", kwargs={"zone_id": zone_id})))
 
@@ -57,7 +57,7 @@ def check_setup_status(handler):
             if not request.session.get("registered", True) and BaseClient().test_connection() == "success":
                 # Being able to register is more rare, so prioritize.
                 redirect_url = reverse("register_public_key")
-            elif not request.session["facility_exists"]:
+            elif not request.session.get("facility_exists", None):
                 zone = Device.get_own_device().get_zone()
                 zone_id = "None" if not zone else zone.id
                 redirect_url = reverse("add_facility", kwargs={"zone_id": zone_id})

--- a/kalite/shared/decorators/auth.py
+++ b/kalite/shared/decorators/auth.py
@@ -12,6 +12,17 @@ from kalite.facility.models import FacilityUser
 from securesync.models import Device, Zone
 
 
+def skip_central(decorator):
+    
+    def blank_wrapper(fn):
+        return fn
+    
+    if settings.CENTRAL_SERVER:
+        return blank_wrapper
+    
+    return lambda *a,**kw: decorator(*a **kw)
+
+
 def get_user_from_request(handler=None, request=None, *args, **kwargs):
     """
     Gets ID of requested user (not necessarily the user logged in)


### PR DESCRIPTION
## Summary

Fixes both KeyError issues and skips calling a completely wrong decorator on the central server, breaking zone management in various cases.

## TODO

- [x] Has documentation been written/updated?
- [x] Have you written release notes for the upcoming release?

## Reviewer guidance

n/a

## Issues addressed

n/a

