### PR TITLE
CodeCov security blooper

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ dependencies:
     - "node_modules"
   override:
     - pip install -r requirements_sphinx.txt
+    - pip install codecov
     - pip install -e .
     - make assets
     - make docs
@@ -30,5 +31,5 @@ test:
     - npm install -g jshint
     - jshint kalite/*/static/js/*/
   post:
-    - bash <(curl -s https://codecov.io/bash):
+    - codecov:
         parallel: true


### PR DESCRIPTION
## Summary

We should always use package managers. I suppose I might have written this code. Moreover, this Circle CI integration might not even work anymore, I think they have thrown out their 1.0 API.

But just to be sure :)

See:
https://about.codecov.io/security-update


## TODO

If not all TODOs are marked, this PR is considered WIP (work in progress)

- [ ] Has documentation been written/updated?
- [ ] Have you written release notes for the upcoming release?

## Reviewer guidance

This is mainly just to get rid of a mal-practice so it doesn't spread, nothing more. It doesn't even matter if the CI still works. Just remove this horrible line of code and we're good.

This repo isn't affected since the attack was on Jan 31 and no one has been doing builds since.

## Issues addressed

n/a

CC: @aronasorman @rtibbles please note the attack and if you are using this in other repos
